### PR TITLE
Update retris to 0.5.4-1

### DIFF
--- a/package/retris/package
+++ b/package/retris/package
@@ -1,13 +1,13 @@
 # vim: set ft=sh:
 pkgname=retris
-pkgver=0.5.4
+pkgver=0.5.4-1
 pkgdesc="Implementation of rust tetris_core on the reMarkable using libremarkable"
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 origin=https://github.com/LinusCDE/retris.git
-revision=03f22b0bd9ab2aae4beb0dfe30b88bd1f2237e1d
+revision=469c9525603ef86d676f79eb008fa4067526d0c2
 
 build() {
     cargo build --release

--- a/package/retris/package
+++ b/package/retris/package
@@ -1,13 +1,13 @@
 # vim: set ft=sh:
 pkgname=retris
-pkgver=0.5.3-1
+pkgver=0.5.4
 pkgdesc="Implementation of rust tetris_core on the reMarkable using libremarkable"
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 origin=https://github.com/LinusCDE/retris.git
-revision=206f43c4b0f146622641cab22313cb8b27109cff
+revision=03f22b0bd9ab2aae4beb0dfe30b88bd1f2237e1d
 
 build() {
     cargo build --release


### PR DESCRIPTION
Hi,
I added some cli integration to the software.

The most interesting change is probably that retris will no more clash with remux by recognizing xochitl, failing to kill it but then only offer to exit by starting xochitl.service (which will mean to xochitl instances).