### PR TITLE
package: add koreader 2020.08.01

### DIFF
--- a/package/koreader/koreader
+++ b/package/koreader/koreader
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+bash /opt/koreader/koreader.sh

--- a/package/koreader/koreader.draft
+++ b/package/koreader/koreader.draft
@@ -1,3 +1,4 @@
 name=KOReader
 desc=ebook reader
 call=/opt/bin/koreader
+term=killall -9 luajit

--- a/package/koreader/koreader.draft
+++ b/package/koreader/koreader.draft
@@ -1,4 +1,6 @@
 name=KOReader
 desc=ebook reader
+imgFile=koreader
 call=/opt/bin/koreader
+term=killall -9 luajit
 term=killall -9 luajit

--- a/package/koreader/koreader.draft
+++ b/package/koreader/koreader.draft
@@ -1,0 +1,3 @@
+name=KOReader
+desc=ebook reader
+call=/opt/bin/koreader

--- a/package/koreader/koreader.draft
+++ b/package/koreader/koreader.draft
@@ -3,4 +3,3 @@ desc=ebook reader
 imgFile=koreader
 call=/opt/bin/koreader
 term=killall -9 luajit
-term=killall -9 luajit

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -22,6 +22,6 @@ package() {
   cp -R "$srcdir"/* "$pkgdir"/opt/koreader/
 
   install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
-  install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png"
+  install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png
   install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
 }

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -1,0 +1,26 @@
+# vim: set ft=sh:
+pkgname=koreader
+pkgdesc="KOReader"
+url=https://github.com/koreader/koreader
+pkgver=2020.08.01-1
+timestamp=2020-09-19T03:30Z
+section=utils
+maintainer="raisjn <of.raisjn@gmail.com>"
+license=AGPL3
+
+image=base
+source=(https://github.com/koreader/koreader/releases/download/v2020.08.1/koreader-remarkable-v2020.08.1.zip)
+sha256sums=(447c151e11bf56d71145cecc731dfa2a39eb026fcce4c4d0571cc8e431d5c491)
+
+build() {
+  # Using prebuilt binaries for koreader
+  return
+}
+
+package() {
+  install -d "$pkgdir"/opt/koreader
+  cp -R "$srcdir"/* "$pkgdir"/opt/koreader/
+
+  install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
+  install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
+}

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -22,5 +22,6 @@ package() {
   cp -R "$srcdir"/* "$pkgdir"/opt/koreader/
 
   install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
+  install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png"
   install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
 }


### PR DESCRIPTION
> what do you think of binary releases?

> i also started going down source release path, but koreader build process actually needs a git repo because it uses submodules to manage dependencies.

