### PR TITLE
Allow disabling the build() step

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -8,20 +8,14 @@ section=utils
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL3
 
-image=base
 source=(https://github.com/koreader/koreader/releases/download/v2020.08.1/koreader-remarkable-v2020.08.1.zip)
 sha256sums=(447c151e11bf56d71145cecc731dfa2a39eb026fcce4c4d0571cc8e431d5c491)
 
-build() {
-  # Using prebuilt binaries for koreader
-  return
-}
-
 package() {
-  install -d "$pkgdir"/opt/koreader
-  cp -R "$srcdir"/* "$pkgdir"/opt/koreader/
+    install -d "$pkgdir"/opt/koreader
+    cp -R "$srcdir"/* "$pkgdir"/opt/koreader/
 
-  install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
-  install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png
-  install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png
+    install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
 }

--- a/package/xochitl/package
+++ b/package/xochitl/package
@@ -8,7 +8,6 @@ section=readers
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=Apache-2.0
 
-image=base:v1.1
 source=(
     xochitl.png
     xochitl.draft
@@ -17,10 +16,6 @@ sha256sums=(
     SKIP
     SKIP
 )
-
-build() {
-    return
-}
 
 package() {
     install -d "$pkgdir"/opt/etc/draft "$pkgdir"/opt/etc/draft/icons

--- a/scripts/lib
+++ b/scripts/lib
@@ -131,7 +131,6 @@ load-recipe() {
     [[ -z $license ]] && error "Missing or empty 'license' variable"
     [[ -z $arch ]] && arch=armv7-3.2
 
-    [[ -z $image ]] && error "Missing or empty 'image' variable"
     [[ -z $source ]] && error "Missing or empty 'source' variable"
     [[ -z $sha256sums ]] && error "Missing or empty 'sha256sums' variable"
 

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -101,17 +101,19 @@ done
 find "$srcdir" -exec touch --no-dereference --date="@${SOURCE_DATE_EPOCH}" {} +
 
 # Run build script inside a Docker container
-section "Building binaries"
-docker container run --interactive --rm \
-    --mount type=bind,src="$(realpath "$recipedir")",dst=/recipe \
-    --mount type=bind,src="$(realpath "$srcdir")",dst=/src \
-    "$(image-name "$image")" /bin/bash \
-<<CMDS
-    source /recipe/package
-    cd /src
-    build
-    chown -R $(id -u):$(id -u) /src/
+if [[ -n $image ]]; then
+    section "Building binaries"
+    docker container run --interactive --rm \
+        --mount type=bind,src="$(realpath "$recipedir")",dst=/recipe \
+        --mount type=bind,src="$(realpath "$srcdir")",dst=/src \
+        "$(image-name "$image")" /bin/bash \
+    <<CMDS
+        source /recipe/package
+        cd /src
+        build
+        chown -R $(id -u):$(id -u) /src/
 CMDS
+fi
 
 # Run packaging script
 section "Preparing package files"


### PR DESCRIPTION
This PR makes the `image=` metadata field and `build()` function optional. If they are omitted, no Docker container is started and the build phase is skipped. This is useful for packages that do not build any binary, currently `koreader` and `xochitl`.