### PR TITLE
Handle recipe metadata fields more safely

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -16,24 +16,68 @@ For consistency, those fields must be declared in the order they are described b
 
 > **Note:** The field names and semantics is inspired both by the [Debian control file format](https://www.debian.org/doc/debian-policy/ch-controlfields.html) and the [Arch Linux PKGBUILD format](https://wiki.archlinux.org/index.php/PKGBUILD).
 
-#### `pkgname` (required)
+#### `pkgname`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>String</td>
+    </tr>
+</table>
 
 Name of the built package.
 Must only contain ASCII lowercase letters, digits and dashes.
 Should match the upstream name as closely as possible.
 
-#### `pkgdesc` (required)
+#### `pkgdesc`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>String</td>
+    </tr>
+</table>
 
 Non-technical description for the package.
 This should help a potential user decide if the packaged application will be useful to them.
 Must start with a name (e.g. “Scientific calculator” instead of “A scientific calculator”).
 Do not explicit the fact that the package is for the reMarkable, because it is redundant (e.g. avoid “Scientific calculator ~~for the reMarkable~~”).
 
-#### `url` (required)
+#### `url`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>URL (string)</td>
+    </tr>
+</table>
 
 Link to the project home page, where sources and documentation may be found.
 
-#### `pkgver` (required)
+#### `pkgver`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>Debian-style version number (string)</td>
+    </tr>
+</table>
 
 Current version of the package.
 This is a Debian-style version number, that is equal to the concatenation of Arch-style versioning fields: `$epoch:$pkgver-$pkgrel`.
@@ -45,16 +89,38 @@ The [deb-version rules](https://manpages.debian.org/wheezy/dpkg-dev/deb-version.
     - Use the version number `0.0.0` if upstream has no versioning scheme, and then only use the package revision number for increasing the version number.
     - Use the `~beta` suffix for beta versions. `~` has a special meaning in Debian version numbers that makes it sort lower than any other character, even the empty string.
 
-#### `timestamp` (required)
+#### `timestamp`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>ISO-8601 timestamp (string)</td>
+    </tr>
+</table>
 
 ISO-8601-formatted date of publication of the packaged upstream release.
 Note that increasing the package version (the part after the final `-`) does not require updating the `timestamp`, as it should only reflect the last modification of the source code.
 
-#### `section` (required)
+#### `section`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>String</td>
+    </tr>
+</table>
 
 Choose one of the following sections:
 
-Section name    | Description
+Section         | Description
 ----------------|----------------------------------
 games           |
 launchers       | Automatically started after boot. Presents to the user a list of other apps that can be launched.
@@ -64,36 +130,113 @@ utils           | System tools.
 
 If the package does not fit into one of the existing sections, add a new one to this document. 
 
-#### `maintainer` (required)
+#### `maintainer`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>String</td>
+    </tr>
+</table>
 
 **TODO:** Documentation.
 
-#### `license` (required)
+#### `license`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>Yes</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>SPDX identifier (string)</td>
+    </tr>
+</table>
 
 [SPDX identifier](https://spdx.org/licenses/) of the license under which the upstream allows distribution. Note that this may be different from the license of the recipe file itself.
 
-#### `depends` (optional)
+#### `depends`
 
-Comma-separated list of package names that must be installed for this package to work.
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>No, defaults to <code>()</code></th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>Array of strings</td>
+    </tr>
+</table>
+
+List of package names that must be installed for this package to work.
 
 See <https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-dependencies-depends-recommends-suggests-enhances-pre-depends>.
 
-#### `conflicts` (optional)
+#### `conflicts`
 
-Comma-separated list of package names that must **NOT** be unpacked for this package to work.
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>No, defaults to <code>()</code></th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>Array of strings</td>
+    </tr>
+</table>
+
+List of package names that must **NOT** be unpacked for this package to work.
 
 See <https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts>.
 
-#### `image` (optional)
+#### `image`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>No, defaults to none</th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>String</td>
+    </tr>
+</table>
 
 Docker image used for building this package.
 It can be omitted only for packages which do not require a build step (see [below](#build-section-optional)).
 
-#### `source` (optional)
+#### `source` 
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>No, defaults to <code>()</code></th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>Array of strings</td>
+    </tr>
+</table>
 
 **TODO:** Documentation.
 
-#### `sha256sums` (optional)
+#### `sha256sums`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>No, defaults to <code>()</code></th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>Array of SHA-256 sums (strings)</td>
+    </tr>
+</table>
 
 **TODO:** Documentation.
 

--- a/docs/package.md
+++ b/docs/package.md
@@ -89,11 +89,11 @@ See <https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-
 Docker image used for building this package.
 It can be omitted only for packages which do not require a build step (see [below](#build-section-optional)).
 
-#### `source` (required)
+#### `source` (optional)
 
 **TODO:** Documentation.
 
-#### `sha256sums` (required)
+#### `sha256sums` (optional)
 
 **TODO:** Documentation.
 

--- a/package/harmony/package
+++ b/package/harmony/package
@@ -7,7 +7,7 @@ timestamp=2020-09-21T01:41+00:00
 section=utils
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
-conflicts=rmkit
+conflicts=(rmkit)
 
 image=python:v1.1
 source=(https://github.com/rmkit-dev/rmkit/archive/d3ebde163c2d50fe9258142e2d190710a58eb954.zip)

--- a/package/mines/package
+++ b/package/mines/package
@@ -5,9 +5,9 @@ url=https://github.com/rmkit-dev/rmkit
 pkgver=0.0.1-14
 timestamp=2020-09-21T01:41+00:00
 section=games
-conflicts=rmkit
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
+conflicts=(rmkit)
 
 image=python:v1.1
 source=(https://github.com/rmkit-dev/rmkit/archive/d3ebde163c2d50fe9258142e2d190710a58eb954.zip)

--- a/package/nao/package
+++ b/package/nao/package
@@ -7,8 +7,8 @@ timestamp=2020-09-27T01:41+00:00
 section=utils
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
-depends=simple
-conflicts=rmkit
+depends=(simple)
+conflicts=(rmkit)
 
 image=python:v1.1
 source=(https://github.com/rmkit-dev/rmkit/archive/ebcee8f32a701bc34e1be4d9f8fde106743ab692.zip)

--- a/package/remarkable-splash/package
+++ b/package/remarkable-splash/package
@@ -7,12 +7,11 @@ timestamp=2019-12-31T10:07Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
-depends=()
 
+image=qt:v1.1
 source=(https://github.com/ddvk/remarkable-splash/archive/e6e0b1e1f3604ab99fb7b476cd290b19c5644025.zip)
 sha256sums=(4aa3988707f9b66752ec9ec2f407cce2ac6e433ae7f06affea9f26957d206b4a)
 
-image=qt:v1.1
 build() {
     qmake
     make

--- a/package/rmservewacominput/package
+++ b/package/rmservewacominput/package
@@ -7,7 +7,7 @@ timestamp=2020-09-06T23:23Z
 section=utils
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
-depends=appmarkable
+depends=(appmarkable)
 
 image=base:v1.1
 source=(https://github.com/LinusCDE/rmWacomToMouse/archive/1a45d3446c8bc11de04800a702576056016875ed.zip)

--- a/package/simple/package
+++ b/package/simple/package
@@ -7,7 +7,7 @@ timestamp=2020-09-27T01:41+00:00
 section=utils
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
-conflicts=rmkit
+conflicts=(rmkit)
 
 image=python:v1.1
 source=(https://github.com/rmkit-dev/rmkit/archive/ebcee8f32a701bc34e1be4d9f8fde106743ab692.zip)

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -107,12 +107,12 @@ if [[ -n $image ]]; then
         --mount type=bind,src="$(realpath "$recipedir")",dst=/recipe \
         --mount type=bind,src="$(realpath "$srcdir")",dst=/src \
         "$(image-name "$image")" /bin/bash \
-    <<CMDS
-        source /recipe/package
-        cd /src
-        build
-        chown -R $(id -u):$(id -u) /src/
-CMDS
+    <<SCRIPT
+source /recipe/package
+cd /src
+build
+chown -R $(id -u):$(id -u) /src/
+SCRIPT
 fi
 
 # Run packaging script
@@ -146,7 +146,7 @@ maintainer-script-header() {
 #!/usr/bin/env bash
 set -e
 SCRIPT
-    dump-metadata
+    dump-fields
     cat scripts/install-lib
 }
 
@@ -211,7 +211,7 @@ section "Creating archives"
 pkgar="$ardir"/data.tar.gz
 ctlar="$ardir"/control.tar.gz
 versionar="$ardir"/debian-binary
-arar="$workdir/$(archive-name "$recipedir")"
+arar="$workdir/$(archive-name)"
 
 echo "2.0" >> "$versionar"
 rtar "$pkgar" "$pkgdir"

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -119,6 +119,47 @@ rsecurl() {
     rcurl --proto '=https' "$@"
 }
 
+# Check that a field is defined with the required type
+#
+# If an error occurs, this function prints an error message and exits the
+# script immediately. If the third argument is not 'optional', it is an error
+# if the field is not defined. If the third argument is 'nonempty', it is an
+# error if the field is an empty string.
+#
+# Arguments:
+#
+# $1 - Name of the field
+# $2 - Expected type of the field, 'string', 'array' or 'map'
+# $3 (optional) - Either 'nonempty' or 'optional'
+check-field() {
+    local signature="$(declare -p "$1" 2>/dev/null)"
+    local vartype=undefined
+
+    if [[ $signature =~ ^declare\ -- ]]; then
+        vartype=string
+    elif [[ $signature =~ ^declare\ -a ]]; then
+        vartype=array
+    elif [[ $signature =~ ^declare\ -A ]]; then
+        vartype=map
+    fi
+
+    if [[ $vartype = undefined ]]; then
+        if [[ $3 = optional ]]; then
+            return 1
+        else
+            error "The '$1' variable is not defined"
+        fi
+    else
+        if [[ $vartype != $2 ]]; then
+            error "The '$1' variable should be of type '$2', not '$vartype'"
+        fi
+
+        if [[ $3 = nonempty ]] && [[ -z ${!1} ]]; then
+            error "The '$1' variable should not be empty"
+        fi
+    fi
+}
+
 # Load metadata and functions defined in a package recipe
 #
 # Arguments:
@@ -127,25 +168,24 @@ rsecurl() {
 load-recipe() {
     source "$1"/package
 
-    [[ -z $pkgname ]] && error "Missing or empty 'pkgname' field"
-    [[ -z $pkgdesc ]] && error "Missing or empty 'pkgdesc' field"
-    [[ -z $url ]] && error "Missing or empty 'url' field"
-    [[ -z $pkgver ]] && error "Missing or empty 'pkgver' field"
-    [[ -z $timestamp ]] && error "Missing or empty 'timestamp' field"
-    [[ -z $section ]] && error "Missing or empty 'section' variable"
-    [[ -z $maintainer ]] && error "Missing or empty 'maintainer' variable"
-    [[ -z $license ]] && error "Missing or empty 'license' variable"
-    [[ -z $arch ]] && arch=armv7-3.2
+    # Check fields types
+    check-field pkgname string nonempty
+    check-field pkgdesc string nonempty
+    check-field url string nonempty
+    check-field pkgver string nonempty
+    check-field timestamp string nonempty
+    check-field section string nonempty
+    check-field maintainer string nonempty
+    check-field license string nonempty
+    check-field depends array optional || depends=()
+    check-field conflicts array optional || conflicts=()
+    check-field arch string optional || arch=armv7-3.2
+    check-field image string optional || image=
+    check-field source array optional || source=()
+    check-field sha256sums array optional || sha256sums=()
 
-    [[ -z $source ]] && error "Missing or empty 'source' variable"
-    [[ -z $sha256sums ]] && error "Missing or empty 'sha256sums' variable"
-
-    return 0
-}
-
-# Dump metadata of a package recipe that is currently loaded
-dump-metadata() {
-    declare -p \
+    # Make fields read-only
+    readonly \
         pkgname \
         pkgdesc \
         url \
@@ -155,22 +195,54 @@ dump-metadata() {
         maintainer \
         license \
         depends \
-        arch \
         conflicts \
+        arch \
         image \
         source \
         sha256sums \
-    2>/dev/null || true
+
+    # Check required functions
+    if ! declare -F package >/dev/null 2>&1; then
+        error "The 'package()' function is not defined"
+    fi
+
+    # Make defined functions read-only
+    readonly -f 2>/dev/null \
+        build \
+        package \
+        preinstall \
+        configure \
+        preremove \
+        postremove \
+        preupgrade \
+        postupgrade \
+    || true
 }
 
-# Generate the archive name of a package
-#
-# Arguments:
-#
-# $1 - Path to the package recipe
+# Dump metadata of the currently loaded package recipe
+dump-fields() {
+    declare -p 2>/dev/null \
+        pkgname \
+        pkgdesc \
+        url \
+        pkgver \
+        timestamp \
+        section \
+        maintainer \
+        license \
+        depends \
+        conflicts \
+        arch \
+        image \
+        source \
+        sha256sums
+
+    return 0
+}
+
+# Generate the archive name of the currently loaded package
 archive-name() {
-    (load-recipe "$1"
-     echo "${pkgname}_${pkgver}_${arch}.ipk")
+    echo "${pkgname}_${pkgver}_${arch}.ipk"
 }
 
 # Get the full tag of a Docker image

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -185,7 +185,7 @@ load-recipe() {
     check-field sha256sums array optional || sha256sums=()
 
     # Make fields read-only
-    readonly \
+    readonly 2>/dev/null \
         pkgname \
         pkgdesc \
         url \
@@ -200,6 +200,7 @@ load-recipe() {
         image \
         source \
         sha256sums \
+    || true
 
     # Check required functions
     if ! declare -F package >/dev/null 2>&1; then
@@ -235,9 +236,8 @@ dump-fields() {
         arch \
         image \
         source \
-        sha256sums
-
-    return 0
+        sha256sums \
+    || true
 }
 
 # Generate the archive name of the currently loaded package

--- a/scripts/repo-build
+++ b/scripts/repo-build
@@ -65,18 +65,19 @@ mkdir -p "$repodir"
 
 # Build each package or get it from the remote server
 for recipedir in "$recipesdir"/*; do
-    load-recipe "$recipedir"
-    arname="$(archive-name "$recipedir")"
+    (
+        load-recipe "$recipedir"
+        arname="$(archive-name)"
+        section "Building $pkgname $pkgver"
 
-    section "Building $pkgname $pkgver"
-
-    if [[ -n $forceflag ]] || ! rsecurl --remote-time "$remoterepo"/"$arname" -o "$repodir"/"$arname"; then
-        pkgworkdir="$pkgsworkdir"/"$pkgname"
-        "${BASH_SOURCE%/*}"/package-build "$recipedir" "$pkgworkdir"
-        mv "$pkgworkdir"/*.ipk "$repodir"
-    else
-        status "Reusing already built version from $remoterepo"
-    fi
+        if [[ -n $forceflag ]] || ! rsecurl --remote-time "$remoterepo"/"$arname" -o "$repodir"/"$arname"; then
+            pkgworkdir="$pkgsworkdir"/"$pkgname"
+            "${BASH_SOURCE%/*}"/package-build "$recipedir" "$pkgworkdir"
+            mv "$pkgworkdir"/*.ipk "$repodir"
+        else
+            status "Reusing already built version from $remoterepo"
+        fi
+    )
 done
 
 # Build packages index

--- a/scripts/repo-build
+++ b/scripts/repo-build
@@ -64,6 +64,7 @@ repodir="$workdir"/repo
 mkdir -p "$repodir"
 
 # Build each package or get it from the remote server
+# Each recipe is loaded in a subshell to avoid leaking metadata fields
 for recipedir in "$recipesdir"/*; do
     (
         load-recipe "$recipedir"


### PR DESCRIPTION
Fixes #64.

* Add basic typechecking to the `load-recipe` function.
* Make sure fields from a recipe do not leak to others when building the full repo.
* Mark fields as read-only so they cannot be accidentally overwritten in the script.