### PR TITLE
Update koreader to v2020.09.29-1

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -2,14 +2,14 @@
 pkgname=koreader
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2020.09-2
-timestamp=2020-09-17T01:52Z
+pkgver=2020.09.29-1
+timestamp=2020-09-29T01:52Z
 section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
 
-source=(https://github.com/koreader/koreader/releases/download/v2020.09/koreader-remarkable-v2020.09.zip)
-sha256sums=(fea9014e5f277362785922110cd979ec6a8c264838a5541a08c77f96540c8b75)
+source=(https://build.koreader.rocks/download/nightly/v2020.09-29-ge169b34_2020-09-29/koreader-remarkable-v2020.09-29-ge169b34_2020-09-29.zip)
+sha256sums=(05dcf25067bfec4c949274bad130823b23c771fde1a549a39f5eccca2320549b)
 
 package() {
     install -d "$pkgdir"/opt/koreader


### PR DESCRIPTION
update to koreader nightly build which has the multi-task friendly patches for disabling input grabbing and resolution changing. 

this removes: 'term=killall luajit -9' because KOReader can now be paused properly. 