### PR TITLE
Reuse local repo artifacts in repo-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,13 @@ Available targets:
 
     repo            Build the repository and reuse archives from the remote
                     repository for existing package versions.
-    repo-force      Build the repository without reusing existing archives.
+    repo-local      Build the repository without using existing archives from
+		    the remote repository.
     repo-check      Compare the local repository to the remote one.
     RECIPE          Build any package individually.
     RECIPE-push     Push any built package to .cache/opkg on the reMarkable.
                     (Plug in your reMarkable first!)
+    clean           Remove all build artifacts.
 
 Where RECIPE is one of the following available recipes:
 
@@ -23,22 +25,22 @@ help:
 	@echo "$$USAGE"
 
 repo:
-	rm -rf build
-	./scripts/repo-build package build
+	./scripts/repo-build package build/packages build/repo
 
-repo-force:
-	rm -rf build
-	./scripts/repo-build -f package build
+repo-local:
+	./scripts/repo-build -l package build/packages build/repo
 
 repo-check:
 	./scripts/repo-check build/repo
 
 $(PACKAGES): %:
-	rm -rf build/packages/"${@}"
-	./scripts/package-build package/"${@}" build/packages/"${@}"
+	./scripts/package-build package/"${@}" build/packages
 
 $(PUSH_PACKAGES): %:
 	ssh root@"${HOST}" mkdir -p .cache/opkg
 	scp build/packages/"$(@:%-push=%)"/*.ipk root@"${HOST}":.cache/opkg
 
-.PHONY: help repo repo-force repo-check $(PACKAGES) $(PUSH_PACKAGES)
+clean:
+	rm -rf build
+
+.PHONY: help repo repo-local repo-check $(PACKAGES) $(PUSH_PACKAGES) clean

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ Available targets:
     repo            Build the repository and reuse archives from the remote
                     repository for existing package versions.
     repo-local      Build the repository without using existing archives from
-		    the remote repository.
+                    the remote repository.
     repo-check      Compare the local repository to the remote one.
     RECIPE          Build any package individually.
     RECIPE-push     Push any built package to .cache/opkg on the reMarkable.

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -6,7 +6,7 @@ source scripts/package-lib
 usage="$0 [OPTION]... RECIPEDIR WORKDIR
 
 Build a package following the recipe defined in RECIPEDIR.
-The WORKDIR must be a non-existent directory in which the build is performed.
+The build is carried out in subdirectories of WORKDIR.
 
 Arguments:
 
@@ -43,25 +43,28 @@ fi
 recipedir="$1"
 workdir="$2"
 
-# Create working directories
-[[ -d $workdir ]] && files="$(ls -qA -- "$workdir")" && [[ -n $files ]] \
-    && error "Working directory '$workdir' exists and is not empty"
-mkdir -p "$workdir"
-
-srcdir="$workdir"/src
-mkdir "$srcdir"
-
-pkgdir="$workdir"/pkg
-mkdir "$pkgdir"
-
-ctldir="$workdir"/control
-mkdir "$ctldir"
-
-ardir="$workdir"/ar
-mkdir "$ardir"
-
 # Load package info and script
 load-recipe "$recipedir"
+
+pkgid="$(package-id)"
+worksubdir="$workdir"/"$pkgid"
+
+# Create working directories
+[[ -d $worksubdir ]] && files="$(ls -qA -- "$worksubdir")" && [[ -n $files ]] \
+    && error "Working directory '$worksubdir' exists and is not empty"
+mkdir -p "$worksubdir"
+
+srcdir="$worksubdir"/src
+mkdir "$srcdir"
+
+pkgdir="$worksubdir"/pkg
+mkdir "$pkgdir"
+
+ctldir="$worksubdir"/control
+mkdir "$ctldir"
+
+ardir="$worksubdir"/ar
+mkdir "$ardir"
 
 # Use the declared timestamp as SOURCE_DATE_EPOCH
 # See <https://reproducible-builds.org/docs/source-date-epoch/>
@@ -211,7 +214,7 @@ section "Creating archives"
 pkgar="$ardir"/data.tar.gz
 ctlar="$ardir"/control.tar.gz
 versionar="$ardir"/debian-binary
-arar="$workdir/$(archive-name)"
+arar="$worksubdir/$pkgid.ipk"
 
 echo "2.0" >> "$versionar"
 rtar "$pkgar" "$pkgdir"

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -240,7 +240,7 @@ dump-fields() {
     || true
 }
 
-# Generate a ID for the currently loaded package recipe
+# Generate an ID for the currently loaded package recipe
 #
 # This name uniquely identifies the current version and target architecture
 # of the package recipe. It is used to name the resulting package.

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -240,9 +240,12 @@ dump-fields() {
     || true
 }
 
-# Generate the archive name of the currently loaded package
-archive-name() {
-    echo "${pkgname}_${pkgver}_${arch}.ipk"
+# Generate a ID for the currently loaded package recipe
+#
+# This name uniquely identifies the current version and target architecture
+# of the package recipe. It is used to name the resulting package.
+package-id() {
+    echo "${pkgname}_${pkgver}_${arch}"
 }
 
 # Get the full tag of a Docker image

--- a/scripts/repo-build
+++ b/scripts/repo-build
@@ -77,7 +77,7 @@ for recipedir in "$recipesdir"/*; do
                 scripts/package-build "$recipedir" "$workdir"
                 cp "$workdir"/"$pkgid"/"$pkgid".ipk "$repodir"
             else
-                status "Reusing $pkgid from $remoterepo"
+                section "Reusing $pkgid from $remoterepo"
             fi
         fi
     )

--- a/scripts/repo-build
+++ b/scripts/repo-build
@@ -3,25 +3,26 @@
 set -e
 source scripts/package-lib
 
-usage="$0 [OPTION]... RECIPESDIR WORKDIR [REMOTEREPO]
+usage="$0 [OPTION]... RECIPESDIR WORKDIR REPODIR [REMOTEREPO]
 
 Build new or updated packages defined in RECIPESDIR and create a package index.
-The WORKDIR must be a non-existent directory in which the builds are performed.
-If REMOTEREPO is omitted 'https://toltec.delab.re/testing' is used.
+Packages are built in subdirectories of WORKDIR and resulting artifacts are
+gathered in REPODIR.  If REMOTEREPO is omitted,
+'https://toltec.delab.re/testing' is used.
 
 Options:
 
     -h              Show this help message.
-    -f              Force building all the packages, even those for which
-                    an already built version exists on the remote."
+    -l              Only build packages locally, do not reuse existing packages
+                    from the publishing server."
 
 helpflag=
-forceflag=
+localflag=
 
-while getopts hf name; do
+while getopts hl name; do
     case $name in
         h) helpflag=1 ;;
-        f) forceflag=1 ;;
+        l) localflag=1 ;;
         *) error "Invalid option. Use the -h flag for more information." ;;
     esac
 done
@@ -34,49 +35,50 @@ if [[ -n $helpflag ]]; then
 fi
 
 if [[ $# -eq 0 ]]; then
-    error "Missing RECIPESDIR and WORKDIR arguments. Use the -h flag for more information."
+    error "Missing RECIPESDIR, WORKDIR and REPODIR arguments. Use the -h flag for more information."
 fi
 
 if [[ $# -eq 1 ]]; then
-    error "Missing WORKDIR argument. Use the -h flag for more information."
+    error "Missing WORKDIR and REPODIR arguments. Use the -h flag for more information."
+fi
+
+if [[ $# -eq 2 ]]; then
+    error "Missing REPODIR argument. Use the -h flag for more information."
 fi
 
 remoterepo="https://toltec.delab.re/testing"
 
-if [[ $# -eq 3 ]]; then
+if [[ $# -eq 4 ]]; then
     remoterepo="$3"
 fi
 
-if [[ $# -gt 3 ]]; then
+if [[ $# -gt 4 ]]; then
     error "Extraneous arguments. Use the -h flag for more information."
 fi
 
 recipesdir="$1"
+
 workdir="$2"
+mkdir -p "$workdir"
 
-pkgsworkdir="$workdir"/packages
-mkdir -p "$pkgsworkdir"
-
-repodir="$workdir"/repo
-
-[[ -d $repodir ]] && files="$(ls -qA -- "$repodir")" && [[ -n $files ]] \
-    && error "Repository directory '$repodir' exists and is not empty"
+repodir="$3"
 mkdir -p "$repodir"
 
-# Build each package or get it from the remote server
+# Build missing packages or get them from the remote server
 # Each recipe is loaded in a subshell to avoid leaking metadata fields
 for recipedir in "$recipesdir"/*; do
     (
         load-recipe "$recipedir"
-        arname="$(archive-name)"
-        section "Building $pkgname $pkgver"
+        pkgid="$(package-id)"
 
-        if [[ -n $forceflag ]] || ! rsecurl --remote-time "$remoterepo"/"$arname" -o "$repodir"/"$arname"; then
-            pkgworkdir="$pkgsworkdir"/"$pkgname"
-            "${BASH_SOURCE%/*}"/package-build "$recipedir" "$pkgworkdir"
-            mv "$pkgworkdir"/*.ipk "$repodir"
-        else
-            status "Reusing already built version from $remoterepo"
+        if [[ ! -f "$repodir"/"$pkgid.ipk" ]]; then
+            if [[ -n $localflag ]] || ! rsecurl --remote-time "$remoterepo"/"$pkgid.ipk" -o "$repodir"/"$pkgid.ipk"; then
+                section "Building $pkgid"
+                scripts/package-build "$recipedir" "$workdir"
+                cp "$workdir"/"$pkgid"/"$pkgid".ipk "$repodir"
+            else
+                status "Reusing $pkgid from $remoterepo"
+            fi
         fi
     )
 done

--- a/scripts/repo-build
+++ b/scripts/repo-build
@@ -49,7 +49,7 @@ fi
 remoterepo="https://toltec.delab.re/testing"
 
 if [[ $# -eq 4 ]]; then
-    remoterepo="$3"
+    remoterepo="$4"
 fi
 
 if [[ $# -gt 4 ]]; then


### PR DESCRIPTION
Fixes #91, closes #92.

* When running the repo-build script with an existing `build` directory, reuse the previous artifacts from that directory if they are still valid (i.e. matching versions).
* Rename the --force flag in the repo-build script to --local to avoid confusion since the flag does not force rebuilding the local artifacts, but only forces to build them locally when applicable.
* Add a new `clean` target to the Makefile.
* Make packages build workdirs unique per package version, so that they don’t conflict with existing previous versions, should the build directory be kept.