### PR TITLE
Use the updated syntax for repo-build in workflows

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -15,7 +15,7 @@ jobs:
                 sudo apt-get install bsdtar tree
             - name: Build packages
               run: |
-                ./scripts/repo-build package build https://toltec.delab.re/stable
+                ./scripts/repo-build package build/packages build/repo https://toltec.delab.re/stable
             - name: Transfer packages and index
               run: |
                 mkdir -p private

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
                 sudo apt-get install bsdtar tree
             - name: Build packages
               run: |
-                ./scripts/repo-build package build https://toltec.delab.re/testing
+                ./scripts/repo-build package build/packages build/repo https://toltec.delab.re/testing
             - name: Transfer packages and index
               run: |
                 mkdir -p private


### PR DESCRIPTION
I forgot to update the workflows for publishing the testing and stable branches following the changes in #93. This PR fixes that.