### PR TITLE
License the project under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 The Toltec Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 HOST?=10.11.99.1
 PACKAGES=$(shell ls package/)
 PUSH_PACKAGES=$(foreach app, $(PACKAGES), $(app)-push)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,3 +50,7 @@ You may also check it manually by running `make format` (or `make format-fix` to
 
 Compliance of shell scripts to Shellcheck will also automatically be checked.
 To check it manually, run `make lint` at the root of the repository (you need to have Shellcheck installed on your computer for this to work).
+
+### License
+
+By contributing to Toltec, you agree to place your contributions under the MIT license.

--- a/package/appmarkable/package
+++ b/package/appmarkable/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=appmarkable
 pkgdesc="Turn your program into a very simple app for draft"
 url="https://github.com/LinusCDE/appmarkable"

--- a/package/calculator/calculator.draft
+++ b/package/calculator/calculator.draft
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 name=calculator
 desc=Touch-based calculator
 call=/opt/bin/calculator

--- a/package/calculator/calculator.svg
+++ b/package/calculator/calculator.svg
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2020 The Toltec Contributors
+ SPDX-License-Identifier: MIT
+-->
 <svg width="256" height="256" version="1.1" viewBox="0 0 67.733 67.733" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <metadata>
   <rdf:RDF>

--- a/package/calculator/package
+++ b/package/calculator/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=calculator
 pkgdesc="Touch-based calculator"
 url=https://github.com/reHackable/Calculator

--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=chessmarkable
 pkgdesc="A chess game for the reMarkable"
 url=https://github.com/LinusCDE/chessmarkable

--- a/package/draft/draft.service
+++ b/package/draft/draft.service
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 [Unit]
 Description=Launcher which wraps around the standard interface
 After=home.mount

--- a/package/draft/package
+++ b/package/draft/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=draft
 pkgdesc="Launcher which wraps around the standard interface"
 url=https://github.com/dixonary/draft-reMarkable

--- a/package/fingerterm/fingerterm.draft
+++ b/package/fingerterm/fingerterm.draft
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 name=fingerterm
 desc=Terminal emulator with an on-screen touch keyboard
 call=/opt/bin/fingerterm

--- a/package/fingerterm/package
+++ b/package/fingerterm/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=fingerterm
 pkgdesc="Terminal emulator with an on-screen touch keyboard"
 url=https://github.com/dixonary/fingerterm-reMarkable

--- a/package/harmony/package
+++ b/package/harmony/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=harmony
 pkgdesc="Procedural sketching app"
 url="https://rmkit.dev/apps/harmony"

--- a/package/koreader/koreader
+++ b/package/koreader/koreader
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 KO_DONT_GRAB_INPUT=1 bash /opt/koreader/koreader.sh

--- a/package/koreader/koreader.draft
+++ b/package/koreader/koreader.draft
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 name=KOReader
 desc=ebook reader
 imgFile=koreader

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=koreader
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader

--- a/package/mines/package
+++ b/package/mines/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=minesweeper
 pkgdesc="Mine detection game"
 url=https://rmkit.dev/apps/minesweeper

--- a/package/nao/package
+++ b/package/nao/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=nao
 pkgdesc="Nao Package Manager: opkg UI built with SAS"
 url="https://rmkit.dev/apps/nao"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=oxide
 pkgdesc="Launcher application"
 url=https://github.com/Eeems/oxide

--- a/package/plato/package
+++ b/package/plato/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=plato
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato

--- a/package/recrossable/package
+++ b/package/recrossable/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=recrossable
 pkgdesc="Solve crossword puzzles"
 url=https://github.com/sandsmark/recrossable

--- a/package/recrossable/recrossable.draft
+++ b/package/recrossable/recrossable.draft
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 name=recrossable
 desc=Solve crossword puzzles
 call=/opt/bin/recrossable

--- a/package/recrossable/recrossable.svg
+++ b/package/recrossable/recrossable.svg
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2020 The Toltec Contributors
+ SPDX-License-Identifier: MIT
+-->
 <svg width="256" height="256" version="1.1" viewBox="0 0 67.733 67.733" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
  <metadata>
   <rdf:RDF>

--- a/package/remarkable-splash/package
+++ b/package/remarkable-splash/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=remarkable-splash
 pkgdesc="show a splashscreen + shutdown replacement that does not clear the screen"
 url=https://github.com/ddvk/remarkable-splash

--- a/package/remux/package
+++ b/package/remux/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=remux
 pkgdesc="App launcher that supports multi-tasking applications"
 url="https://rmkit.dev/apps/remux"

--- a/package/remux/remux.service
+++ b/package/remux/remux.service
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 [Unit]
 Description=App launcher that supports multi-tasking applications
 After=xochitl.service opt.mount

--- a/package/retris/package
+++ b/package/retris/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=retris
 pkgdesc="Tetris game"
 url=https://github.com/LinusCDE/retris

--- a/package/rmservewacominput/package
+++ b/package/rmservewacominput/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=rmservewacominput
 pkgdesc="Serve pen input on port 33333"
 url=https://github.com/LinusCDE/rmWacomToMouse

--- a/package/simple/package
+++ b/package/simple/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=simple
 pkgdesc="Simple app script for writing scripted applications"
 url="https://rmkit.dev/apps/sas"

--- a/package/xochitl/package
+++ b/package/xochitl/package
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 pkgname=xochitl
 pkgdesc="Read documents and take notes"
 url=https://remarkable.com

--- a/package/xochitl/xochitl.draft
+++ b/package/xochitl/xochitl.draft
@@ -1,3 +1,6 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
 name=xochitl
 desc=Read documents and take notes
 call=/usr/bin/xochitl

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
 
 #
 # install-lib

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
 
 set -e
 source scripts/package-lib

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
 
 #
 # package-lib

--- a/scripts/repo-build
+++ b/scripts/repo-build
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
 
 set -e
 source scripts/package-lib

--- a/scripts/repo-build-web
+++ b/scripts/repo-build-web
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
 
 set -e
 source scripts/package-lib

--- a/scripts/repo-check
+++ b/scripts/repo-check
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
 
 set -e
 source scripts/package-lib


### PR DESCRIPTION
If this PR is approved, all the code in Toltec (except otherwise stated, in particular in the `scripts/opkg` folder) will be licensed under the MIT license. Past and future contributors would retain their copyright, but agree to place their contributions under that license.

It needs to be approved by all the contributors: @fenollp, @Eeems, @LinusCDE, @raisjnn.