### PR TITLE
Improve source archive extraction

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -205,10 +205,10 @@ See <https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-
     </tr>
 </table>
 
-Docker image used for building this package.
+Docker image to use for building the package.
 It can be omitted only for packages which do not require a build step (see [below](#build-section-optional)).
 
-#### `source` 
+#### `source`
 
 <table>
     <tr>
@@ -221,7 +221,10 @@ It can be omitted only for packages which do not require a build step (see [belo
     </tr>
 </table>
 
-**TODO:** Documentation.
+List of sources needed to build the package.
+Files referenced in this array can be accessed from the `$srcdir` directory during the [build](#build-section-optional) and [package](#package-section-optional) sections.
+Each entry can either be a local path relative to the recipe file, or a full URL that will be fetched from the Internet (any protocol supported by [curl](https://curl.haxx.se/) can be used here) when building the package.
+Archive files whose names end in `.zip`, `.tar.gz`, `.tar.xz` or `.tar.bz` will be automatically extracted in place, with all container directories stripped.
 
 #### `sha256sums`
 
@@ -236,7 +239,10 @@ It can be omitted only for packages which do not require a build step (see [belo
     </tr>
 </table>
 
-**TODO:** Documentation.
+List of SHA-256 checksums for the source files.
+After copying or downloading a source file to the `$srcdir` directory, the build script will verify its integrity by comparing its checksum with the one registered here.
+You can request to skip this verification by entering `SKIP` instead of a valid SHA-256 checksum (discouraged for files fetched from remote computers).
+This array must have exactly as much elements as the `source` array.
 
 ### Build section (optional)
 

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -5,7 +5,7 @@
 pkgname=oxide
 pkgdesc="Launcher application"
 url=https://github.com/Eeems/oxide
-pkgver=2.0~beta-3
+pkgver=2.0~beta-4
 timestamp=2020-09-26T20:53Z
 section=launchers
 maintainer="Eeems <eeems@eeems.email>"
@@ -16,13 +16,12 @@ source=(https://github.com/Eeems/oxide/releases/download/v2.0-beta/oxide.zip)
 sha256sums=(d3bac44b96c78726fcbfbd8f7a23d3bd4e4ae3f1f794714190100ebe602a8433)
 
 package() {
-    unzip "$srcdir"/oxide.zip -d "$pkgdir"
+    install -D -m 644 -t "$pkgdir"/etc/dbus-1/system.d "$srcdir"/etc/dbus-1/system.d/codes.eeems.oxide.conf
+    install -D -m 644 -t "$pkgdir"/lib/systemd/system "$srcdir"/etc/systemd/system/tarnish.service
 
-    install -D -m 644 -t "$pkgdir"/lib/systemd/system "$pkgdir"/etc/systemd/system/tarnish.service
-    rm -r "$pkgdir"/etc/systemd
-
-    rm "$pkgdir"/opt/etc/draft/xochitl.draft
-    rm "$pkgdir"/opt/etc/draft/icons/xochitl.png
+    install -d "$pkgdir"/opt
+    cp -r "$srcdir"/opt/bin "$pkgdir"/opt
+    install -D -m 644 -t "$pkgdir"/opt/etc "$srcdir"/opt/etc/oxide.conf
 }
 
 configure() {

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -85,20 +85,22 @@ for ((i = 0; i < ${#source[@]}; ++i)); do
     fi
 
     srcfile="$(basename "$srcurl")"
+    srcfilepath="$srcdir/$srcfile"
     status "$srcfile"
 
-    rcurl --location "$srcurl" -o "$srcdir"/"$srcfile"
+    rcurl --location "$srcurl" -o "$srcfilepath"
 
     if [[ $checksum != SKIP ]] \
-        && ! sha256sum -c <(echo "$checksum $srcdir/$srcfile") > /dev/null 2>&1; then
+        && ! sha256sum -c <(echo "$checksum  $srcfilepath") > /dev/null 2>&1; then
         error "Checksum mismatch while fetching $srcfile"
     fi
 
-    if [[ $srcdir/$srcfile =~ \.(zip|tar\.gz)$ ]]; then
+    # Automatically extract source archives
+    if [[ $srcfilepath =~ \.(zip|tar\.gz|tar\.xz|tar\.bz)$ ]]; then
         bsdtar -x \
-            --strip-components 1 \
+            --strip-components "$(tarprefix "$srcfilepath")" \
             --directory "$srcdir" \
-            --file "$srcdir"/"$srcfile"
+            --file "$srcfilepath"
     fi
 done
 

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -111,6 +111,41 @@ tardiff() {
     fi
 }
 
+# Compute how many containing folders can be safely stripped from a tar archive
+# without losing data
+#
+# Arguments:
+#
+# $1 - Path to an archive
+#
+# Output:
+#
+# Number of containing folders in the archive
+tarprefix() {
+    local contents
+    contents="$(bsdtar -t --file "$1")"
+
+    # Find the longest common prefix in the archive files
+    local strip_depth=0
+    local fields="\$1"
+
+    while [[ "$(echo "$contents" | sed 's/\/$//' \
+        | awk -F/ "NF>=$((strip_depth + 1)) { print $fields }" \
+        | sort | uniq | wc -l)" == "1" ]]; do
+        ((++strip_depth))
+        fields="$fields\"/\"\$$((strip_depth + 1))"
+    done
+
+    # If there’s only one file in the archive, keep the last component
+    if [[ "$(echo "$contents" | sed 's/\/$//' \
+        | awk -F/ "NF>=$strip_depth { print \$0 }" \
+        | wc -l)" == "1" ]]; then
+        ((--strip_depth))
+    fi
+
+    echo "$strip_depth"
+}
+
 # Curl command with flags suitable for scripting
 rcurl() {
     curl --fail --silent --tlsv1.2 "$@"


### PR DESCRIPTION
Behavior change
---------------

Previously, the topmost directories were always stripped when extracting source archives, which was confusing when the archive contained more than one top-level directory (see <https://github.com/toltec-dev/toltec/pull/74#discussion_r495615907>).

This PR changes that behavior to a more prudent one, which finds the longest folder prefix in the archive (potentially empty), and removes it when extracting the archive’s files. For example, when extracting an archive containing:

    a/b/c/file1.txt
    a/b/c/file2.txt

the `a/b/c/` prefix will be removed. When extracting an archive containing:

    a/file1.txt
    b/file2.txt

both the `a/` and `b/` folders will be kept.

Changes
-------

* Implement the new behavior
* Document it in docs/package.md#sources
* Update oxide to take advantage of this