### PR TITLE
Fix KOReader build

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -11,7 +11,7 @@ section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
 
-source=(https://build.koreader.rocks/download/nightly/v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}/koreader-remarkable-v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}.zip)
+source=("https://build.koreader.rocks/download/nightly/v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}/koreader-remarkable-v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}.zip")
 sha256sums=(51052d0f45617009aebbeb964c5c9ab4ab329dce710fa894715a94217db297d9)
 
 package() {

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,14 +5,14 @@
 pkgname=koreader
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2020.09.29-2
-timestamp=2020-09-29T01:52Z
+pkgver=2020.09-53-1
+timestamp=2020-10-09T06:43Z
 section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
 
-source=(https://build.koreader.rocks/download/nightly/v2020.09-29-ge169b34_2020-09-29/koreader-remarkable-v2020.09-29-ge169b34_2020-09-29.zip)
-sha256sums=(05dcf25067bfec4c949274bad130823b23c771fde1a549a39f5eccca2320549b)
+source=(https://build.koreader.rocks/download/nightly/v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}/koreader-remarkable-v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}.zip)
+sha256sums=(51052d0f45617009aebbeb964c5c9ab4ab329dce710fa894715a94217db297d9)
 
 package() {
     install -d "$pkgdir"/opt/koreader

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -148,7 +148,7 @@ tarprefix() {
 
 # Curl command with flags suitable for scripting
 rcurl() {
-    curl --fail --silent --tlsv1.2 "$@"
+    curl --fail --silent --show-error --tlsv1.2 "$@"
 }
 
 # Curl command with flags suitable for scripting, restricted to HTTPS


### PR DESCRIPTION
KOReader nightly 2020.09-29 was removed from their servers, so this PR upgrades to 2020.09-53 to address that. We will need to update it to the latest stable release when it is released later in this month.

Also add the `--show-error` flag to curl invocations so that an explicit error message is shown in the build output when the source of a package is not available (previously, nothing was shown and the script simply exited).