### PR TITLE
Fix handling packages with multiple dependencies

### DIFF
--- a/package/reboot-guard/package
+++ b/package/reboot-guard/package
@@ -5,7 +5,7 @@
 pkgname=reboot-guard
 pkgdesc="Block systemd-initiated poweroff/reboot/halt until configurable condition checks pass"
 url=https://github.com/stephanritscher/reboot-guard
-pkgver=1.0.1~1
+pkgver=1.0.1-1
 timestamp=2020-05-04T06:16Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -143,8 +143,8 @@ ctlfile="$ctldir"/control
     echo "Maintainer: $maintainer"
     echo "License: $license"
     echo "Architecture: $arch"
-    [[ -n $depends ]] && echo "Depends: $depends"
-    [[ -n $conflicts ]] && echo "Conflicts: $conflicts"
+    [[ -n $depends ]] && echo "Depends: $(join-elements ", " "${depends[@]}")"
+    [[ -n $conflicts ]] && echo "Conflicts: $(join-elements ", " "${conflicts[@]}")"
 } >> "$ctlfile"
 
 # Create maintainer scripts

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -156,6 +156,29 @@ rsecurl() {
     rcurl --proto '=https' "$@"
 }
 
+# Join elements with the given delimiter
+#
+# Arguments:
+#
+# $1 - Separator string
+# $2... - Elements to join
+#
+# Output:
+#
+# Joined string.
+join-elements() {
+    local sep="$1"
+    local cursep=""
+    shift
+
+    for arg; do
+        echo -n "$cursep$arg"
+        cursep="$sep"
+    done
+
+    echo
+}
+
 # Check that a field is defined with the required type
 #
 # If an error occurs, this function prints an error message and exits the


### PR DESCRIPTION
Previously only the first element of the $depends (resp. $conflicts) array was used to build the list of dependencies (resp. conflicting packages) of a packages, due to an error in the build script. This caused an error in the generated package for `reboot-guard`, where the `python` dependency was not automatically installed. This PR fixes that.

It also changes the version of `reboot-guard` from `1.0.1~1` to `1.0.1-1` to bring it in line with other package versions.