### PR TITLE
Fix reboot-guard dependency

### DIFF
--- a/package/reboot-guard/package
+++ b/package/reboot-guard/package
@@ -10,7 +10,7 @@ timestamp=2020-05-04T06:16Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=GPL-3.0
-depends=(xochitl python)
+depends=(xochitl python3)
 
 source=(
     https://github.com/stephanritscher/reboot-guard/archive/34d5df49d9fb914ab74d9b85d726aaa503b972a9.zip

--- a/package/reboot-guard/package
+++ b/package/reboot-guard/package
@@ -5,7 +5,7 @@
 pkgname=reboot-guard
 pkgdesc="Block systemd-initiated poweroff/reboot/halt until configurable condition checks pass"
 url=https://github.com/stephanritscher/reboot-guard
-pkgver=1.0.1-1
+pkgver=1.0.1-2
 timestamp=2020-05-04T06:16Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"


### PR DESCRIPTION
Entware’s Python package is called `python3` and not `python`.