### PR TITLE
Configure Opkg to fetch Entware packages using TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec.delab.re/bootstrap
-$ echo "3c792fe4dcd034dcbf52ddd242fa3816d48a776acdbd78b3bec2a7741416ed35  bootstrap" | sha256sum -c
+$ echo "2897bb7665ff0b992e629d674af6057510192833e9a6ea56287c1a13c5146632  bootstrap" | sha256sum -c
 $ bash bootstrap
 ```
 

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -152,6 +152,7 @@ entware-install() {
     wget --no-verbose "$entware_remote/opkg" -O /opt/bin/opkg
     chmod 755 /opt/bin/opkg
     wget --no-verbose "$entware_remote/opkg.conf" -O /opt/etc/opkg.conf
+    sed -i 's|http://|https://|g' /opt/etc/opkg.conf
     wget --no-verbose "$entware_remote/ld-2.27.so" -O /opt/lib/ld-2.27.so
     wget --no-verbose "$entware_remote/libc-2.27.so" -O /opt/lib/libc-2.27.so
     wget --no-verbose "$entware_remote/libgcc_s.so.1" -O /opt/lib/libgcc_s.so.1


### PR DESCRIPTION
When I merged remarkable_entware into the bootstrap script, I erroneously did not keep @LinusCDE’s sed line that changes `opkg.conf` so that Entware packages are fetched using TLS. Therefore, in the current state of the bootstrap script, Entware packages are fetched through raw HTTP.

This PR adds back [that missing line](https://github.com/LinusCDE/remarkable_entware/blob/4288859dd28ca57d91e16b96621261e20fee7807/entware_install.sh#L147).