### PR TITLE
Update KOReader to version 2020.10

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,14 +5,15 @@
 pkgname=koreader
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2020.09-53-1
-timestamp=2020-10-09T06:43Z
+pkgver=2020.10-1
+timestamp=2020-10-10T20:13Z
 section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
 
-source=("https://build.koreader.rocks/download/nightly/v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}/koreader-remarkable-v${pkgver%-[[:alnum:]]*}-gb8fa553_${timestamp:0:10}.zip")
-sha256sums=(51052d0f45617009aebbeb964c5c9ab4ab329dce710fa894715a94217db297d9)
+_srcver="v${pkgver%-*}"
+source=("https://build.koreader.rocks/download/stable/$_srcver/koreader-remarkable-$_srcver.zip")
+sha256sums=(a646c52e22c2ea47aa8b4677cc8060b979dcbadb718ce111ad8489233780da10)
 
 package() {
     install -d "$pkgdir"/opt/koreader


### PR DESCRIPTION
Contains rM-specific fixes: koreader/koreader#6772, koreader/koreader#6676, koreader/koreader#6769.

This also fixes the issue with the nightly versioning scheme.