### PR TITLE
Add VNSee 0.3.0

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -10,10 +10,11 @@ Sourcing a package recipe must have no side effects: the metadata section can on
 ### Contents
 
 1. [Metadata section](#metadata-section)
-2. [Build section](#build-section)
-3. [Package section](#package-section)
-4. [Install section](#install-section)
-5. [Split packages](#split-packages)
+2. [Prepare section](#prepare-section)
+3. [Build section](#build-section)
+4. [Package section](#package-section)
+5. [Install section](#install-section)
+6. [Split packages](#split-packages)
 
 ### Metadata section
 
@@ -239,6 +240,24 @@ The list of sources files and archives needed to build the package.
 The [`build()`](#build-section) and [`package()`](#package-section) sections can access the files referenced in this array from the `$srcdir` directory.
 Each entry can either be a local path relative to the recipe file or a full URL that will be fetched from the Internet (any protocol supported by [curl](https://curl.haxx.se/) can be used here) when building the package.
 Archive files whose names end in `.zip`, `.tar.gz`, `.tar.xz`, or `.tar.bz` will be automatically extracted in place, with all container directories stripped.
+You can disable this behavior by adding the archive name to the `noextract` array.
+
+#### `noextract`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>No, defaults to <code>()</code></th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>Array of strings</td>
+    </tr>
+</table>
+
+List of archive names which should not be automatically extracted by the build script.
+You can provide a custom extraction logic in the [`prepare()` section](#prepare-section).
+Note that this list should only contain file names, not full paths, in contrast to the `source` array.
 
 #### `sha256sums`
 
@@ -257,6 +276,11 @@ List of SHA-256 checksums for the source files.
 After copying or downloading a source file to the `$srcdir` directory, the build script will verify its integrity by comparing its checksum with the one registered here.
 You can request to skip this verification by entering `SKIP` instead of a valid SHA-256 checksum (discouraged for files fetched from remote computers).
 This array must have exactly as many elements as the `source` array.
+
+### Prepare section
+
+The prepare section contains the `prepare()` function in which the source files may be prepared for the building step that follows.
+Common tasks include patching sources, extracting archives, and moving downloaded sources to the right location.
 
 ### Build section
 

--- a/package/vnsee/package
+++ b/package/vnsee/package
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(vnsee)
+pkgdesc="VNC client allowing you to use the device as a second screen"
+url=https://github.com/matteodelabre/vnsee
+pkgver=0.3.0-1
+timestamp=2020-10-23T14:02Z
+section=utils
+maintainer="Mattéo Delabre <spam@delab.re>"
+license=GPL-3.0-only
+
+image=base:v1.2.1
+_vnclib=LibVNCServer-0.9.13
+source=(
+    "https://github.com/matteodelabre/vnsee/archive/v${pkgver%-*}.zip"
+    "https://github.com/LibVNC/libvncserver/archive/$_vnclib.zip"
+)
+noextract=("$_vnclib.zip")
+sha256sums=(
+    700005ff7b09f2fc329a05c06fce810705e1ef3523611022765cb13df9f4a815
+    d209d70998a9b98f9120eeb82df7a17767796c477eaa8297e0a55856a977c54f
+)
+
+prepare() {
+    bsdtar -x \
+        --strip-components 1 \
+        --directory "$srcdir/libvncserver" \
+        --file "$srcdir/$_vnclib.zip"
+}
+
+build() {
+    mkdir build
+    cd build
+    cmake .. \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_TOOLCHAIN_FILE="/usr/share/cmake/$CHOST.cmake"
+    make
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/build/vnsee
+}

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -77,19 +77,27 @@ for ((i = 0; i < ${#source[@]}; ++i)); do
 
     rcurl --location "$srcurl" -o "$srcfilepath"
 
+    # Verify checksum if one was provided
     if [[ $checksum != SKIP ]] \
         && ! sha256sum -c <(echo "$checksum  $srcfilepath") > /dev/null 2>&1; then
         error "Checksum mismatch while fetching $srcfile"
     fi
 
     # Automatically extract source archives
-    if [[ $srcfilepath =~ \.(zip|tar\.gz|tar\.xz|tar\.bz)$ ]]; then
-        bsdtar -x \
-            --strip-components "$(tarprefix "$srcfilepath")" \
-            --directory "$srcdir" \
-            --file "$srcfilepath"
+    if ! has-element "$srcfile" "${noextract[@]}"; then
+        if [[ $srcfilepath =~ \.(zip|tar\.gz|tar\.xz|tar\.bz)$ ]]; then
+            bsdtar -x \
+                --strip-components "$(tarprefix "$srcfilepath")" \
+                --directory "$srcdir" \
+                --file "$srcfilepath"
+        fi
     fi
 done
+
+if [[ $(type -t prepare) == "function" ]]; then
+    section "Preparing source files"
+    prepare
+fi
 
 # Set atime and mtime to the SOURCE_DATE_EPOCH for all source files
 find "$srcdir" -exec touch --no-dereference --date="@${SOURCE_DATE_EPOCH}" {} +

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -280,6 +280,7 @@ load-recipe-header() {
     check-field arch string optional || arch=armv7-3.2
     check-field image string optional || image=
     check-field source array optional || source=()
+    check-field noextract array optional || noextract=()
     check-field sha256sums array optional || sha256sums=()
 
     # Make fields read-only
@@ -290,11 +291,15 @@ load-recipe-header() {
         arch \
         image \
         source \
+        noextract \
         sha256sums \
         2> /dev/null || true
 
     # Make defined functions read-only
-    readonly -f build 2> /dev/null || true
+    readonly -f \
+        prepare \
+        build \
+        2> /dev/null || true
 
     # Recipes containing several packages need to define a function
     # for each one, with package-specific data and functions
@@ -374,6 +379,7 @@ dump-fields() {
         arch \
         image \
         source \
+        noextract \
         sha256sums \
         2> /dev/null || true
 }


### PR DESCRIPTION
Since GitHub source code archives do not include submodules, I had to download the libvncserver submodule separately. This source needs to be placed in a specific subfolder of the $srcdir instead of the root, so we need to override the automatic archive extraction behavior in this case.

To enable that, the two following changes are also included in this PR:

* Add an optional `noextract` field to the recipes to allow disabling the automatic extraction of downloaded archives.
* Add a `prepare()` section for running tasks on the source files before the build Docker container is started.