### PR TITLE
Implement a strategy for renaming packages

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -135,6 +135,7 @@ launchers       | Apps that present to the user a list of other apps that they c
 math            | Apps to assist the user in performing mathematical tasks.
 readers         | Apps for reading and annotating documents (PDF, EPUB, …).
 utils           | System tools and various apps.
+old             | Deprecated or transitional packages. Packages in this section will not be listed in the package index.
 
 If the package does not fit into one of the existing sections, you are free to create a new one and document it here.
 
@@ -204,6 +205,25 @@ See <https://www.debian.org/doc/debian-policy/ch-relationships.html#binary-depen
 A list of package names that must **NOT** be unpacked at the same time as this package.
 
 See <https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts>.
+
+#### `replaces`
+
+<table>
+    <tr>
+        <th>Required?</th>
+        <td>No, defaults to <code>()</code></th>
+    </tr>
+    <tr>
+        <th>Type</th>
+        <td>Array of strings</td>
+    </tr>
+</table>
+
+A list of packages that this package wholly replaces.
+Installing this package will remove the replaced packages if they were previously installed.
+This is equivalent to a combination of the Debian `Provides`, `Conflicts` and `Replaces` fields.
+
+See <https://www.debian.org/doc/debian-policy/ch-relationships.html#replacing-whole-packages-forcing-their-removal>.
 
 #### `image`
 

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -2,7 +2,7 @@
 # Copyright (c) 2020 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-pkgnames=(harmony mines nao remux simple)
+pkgnames=(harmony minesweeper mines nao remux simple)
 timestamp=2020-10-10T01:41+00:00
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
@@ -38,11 +38,24 @@ harmony() {
     }
 }
 
+minesweeper() {
+    pkgdesc="Transitional package for mines - can safely be removed"
+    url="https://rmkit.dev/apps/minesweeper"
+    pkgver=0.0.1-15
+    section=old
+    depends=(mines)
+
+    package() {
+        return
+    }
+}
+
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.0.1-16
+    pkgver=0.0.1-17
     section=games
+    replaces=(minesweeper)
 
     package() {
         install -D -m 755 "$srcdir"/src/build/mines "$pkgdir"/opt/bin/mines

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -148,6 +148,11 @@ for pkgname in "${pkgnames[@]}"; do
             # Create control file
             readonly ctlfile="$ctldir"/control
 
+            debdepends=("${depends[@]}")
+            debprovides=("${replaces[@]}")
+            debconflicts=("${conflicts[@]}" "${replaces[@]}")
+            debreplaces=("${replaces[@]}")
+
             {
                 echo "Package: $pkgname"
                 echo "Description: $pkgdesc"
@@ -157,8 +162,14 @@ for pkgname in "${pkgnames[@]}"; do
                 echo "Maintainer: $maintainer"
                 echo "License: $license"
                 echo "Architecture: $arch"
-                [[ -n $depends ]] && echo "Depends: $(join-elements ", " "${depends[@]}")"
-                [[ -n $conflicts ]] && echo "Conflicts: $(join-elements ", " "${conflicts[@]}")"
+                [[ ${#debdepends[@]} -gt 0 ]] \
+                    && echo "Depends: $(join-elements ", " "${debdepends[@]}")"
+                [[ ${#debprovides[@]} -gt 0 ]] \
+                    && echo "Provides: $(join-elements ", " "${debprovides[@]}")"
+                [[ ${#debconflicts[@]} -gt 0 ]] \
+                    && echo "Conflicts: $(join-elements ", " "${debconflicts[@]}")"
+                [[ ${#debreplaces[@]} -gt 0 ]] \
+                    && echo "Replaces: $(join-elements ", " "${debreplaces[@]}")"
             } >> "$ctlfile"
 
             # Create maintainer scripts

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -329,6 +329,7 @@ load-recipe-pkg() {
     check-field license string nonempty
     check-field depends array optional || depends=()
     check-field conflicts array optional || conflicts=()
+    check-field replaces array optional || replaces=()
 
     # Make fields read-only
     readonly \
@@ -339,6 +340,7 @@ load-recipe-pkg() {
         license \
         depends \
         conflicts \
+        replaces \
         2> /dev/null || true
 
     # Check required functions
@@ -371,6 +373,7 @@ dump-fields() {
         license \
         depends \
         conflicts \
+        replaces \
         arch \
         image \
         source \

--- a/scripts/repo-build-web
+++ b/scripts/repo-build-web
@@ -123,6 +123,10 @@ readarray -t pkgsections < <(
 )
 
 for cursection in "${pkgsections[@]}"; do
+    if [[ $cursection == "old" ]]; then
+        continue
+    fi
+
     section "Making $cursection index"
 
     cat >> "$indexfile" << WEBS


### PR DESCRIPTION
* Create an `old` section for deprecated or transitional packages. This section is not included in the package listing.
* Add a `replaces` recipe field, equivalent to the `Provides`, `Conflicts` and `Replaces` Debian fields combined.
* Use these new features to add an upgrade path for renaming `minesweeper` to `mines`.

To test:

* Make a clean install of Toltec stable.
* Install `minesweeper` (version 0.0.1-14).
* Change the branch to <https://toltec-dev.org/dev/feature/renaming> in `/opt/etc/opkg.conf`.
* Run `opkg update` then `opkg upgrade`.

This seems to work on my device: the `mines` package is installed, then the `minesweeper` package is removed. Opkg generates an error however, which seems like it can be safely ignored.

```
Upgrading minesweeper on root from 0.0.1-14 to 0.0.1-15...
Downloading https://toltec-dev.org/dev/feature/renaming/minesweeper_0.0.1-15_armv7-3.2.ipk
Installing mines (0.0.1-17) to root...
Downloading https://toltec-dev.org/dev/feature/renaming/mines_0.0.1-17_armv7-3.2.ipk
Removing package minesweeper from root...
Configuring mines.
Collected errors:
 * pkg_run_script: Internal error: minesweeper has a NULL  tmp_unpack_dir.
  * prerm_upgrade_old_pkg: prerm script for package "minesweeper" failed
```

I’m not sure yet whether this is an Opkg bug or if I’m doing something wrong.