### PR TITLE
package: add rm2fb package

### DIFF
--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(rm2fb)
+timestamp=2020-10-10T01:41+00:00
+maintainer="raisjn <of.raisjn@gmail.com>"
+license=MIT
+pkgdesc="Remarkable2 Framebuffer"
+url="https://github.com/ddvk/remarkable2-framebuffer"
+pkgver=1.0.0-1
+section=utils
+version=1.0.0
+image=qt:v1.1
+source=(
+    https://github.com/ddvk/remarkable2-framebuffer/archive/bc2ec68014aaed3383c7134160d8c241adcda6c2.zip
+    rm2fb.service
+    rm2fb-server
+    rm2fb-client
+)
+sha256sums=(
+    2da10867d082cf72f7fa23cc664affd590bc9acce1c76d45b8153dfa0ae222e1
+    SKIP
+    SKIP
+    SKIP
+)
+
+build() {
+    qmake
+    make
+}
+
+package() {
+    mkdir -p "$pkgdir"/opt/lib "$pkgdir"/opt/etc "$pkgdir"/opt/bin
+    install -D -m 644 "$srcdir"/rm2fb.service "$pkgdir"/lib/systemd/system/rm2fb.service
+    install -D -m 755 "$srcdir"/src/client/librm2fb_client.so.${version} "$pkgdir"/opt/lib/
+    install -D -m 755 "$srcdir"/src/server/librm2fb_server.so.${version} "$pkgdir"/opt/lib/
+    # install -D -m 755 "$srcdir"/src/xofb/librm2fb_xofb.so.${version} "$pkgdir"/opt/lib/
+    install -D -m 644 "$srcdir"/rm2fb.service "$pkgdir"/lib/systemd/system/rm2fb.service
+    install -D -m 755 "$srcdir"/rm2fb-server "$pkgdir"/opt/bin/
+    install -D -m 755 "$srcdir"/rm2fb-client "$pkgdir"/opt/bin/
+}

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -13,13 +13,15 @@ section=utils
 version=1.0.0
 image=qt:v1.1
 source=(
-    https://github.com/ddvk/remarkable2-framebuffer/archive/5a518c8d3fe3fe500b33c620330d62094564173f.zip
+    https://github.com/ddvk/remarkable2-framebuffer/archive/cd2766864c7985fa50cdf85f4ae0a411d7ca4e56.zip
+    rm2fb.conf
     rm2fb.service
     rm2fb-server
     rm2fb-client
 )
 sha256sums=(
-    bbf090f83c8090f20f0319283279ecbde783fcb3ca9b8610b7dde309001592cd
+    c274c458270eec28950834bd28ff069a0af65e40fcc288a8ff28235001e8914f
+    SKIP
     SKIP
     SKIP
     SKIP
@@ -33,11 +35,15 @@ build() {
 
 package() {
     mkdir -p "$pkgdir"/opt/lib "$pkgdir"/opt/etc "$pkgdir"/opt/bin
-    install -D -m 644 "$srcdir"/rm2fb.service "$pkgdir"/lib/systemd/system/rm2fb.service
     install -D -m 755 "$srcdir"/src/client/librm2fb_client.so.${version} "$pkgdir"/opt/lib/
     install -D -m 755 "$srcdir"/src/server/librm2fb_server.so.${version} "$pkgdir"/opt/lib/
-    # install -D -m 755 "$srcdir"/src/xofb/librm2fb_xofb.so.${version} "$pkgdir"/opt/lib/
-    install -D -m 644 "$srcdir"/rm2fb.service "$pkgdir"/lib/systemd/system/rm2fb.service
     install -D -m 755 "$srcdir"/rm2fb-server "$pkgdir"/opt/bin/
     install -D -m 755 "$srcdir"/rm2fb-client "$pkgdir"/opt/bin/
+    install -D -m 644 "$srcdir"/rm2fb.conf "$pkgdir"/etc/systemd/system.conf.d/01-rm2fb.conf
+    install -D -m 644 "$srcdir"/rm2fb.service "$pkgdir"/lib/systemd/system/rm2fb.service
+}
+
+configure() {
+    systemctl daemon-reload
+    systemctl enable rm2fb --now
 }

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -13,13 +13,13 @@ section=utils
 version=1.0.0
 image=qt:v1.1
 source=(
-    https://github.com/ddvk/remarkable2-framebuffer/archive/bc2ec68014aaed3383c7134160d8c241adcda6c2.zip
+    https://github.com/ddvk/remarkable2-framebuffer/archive/5a518c8d3fe3fe500b33c620330d62094564173f.zip
     rm2fb.service
     rm2fb-server
     rm2fb-client
 )
 sha256sums=(
-    2da10867d082cf72f7fa23cc664affd590bc9acce1c76d45b8153dfa0ae222e1
+    bbf090f83c8090f20f0319283279ecbde783fcb3ca9b8610b7dde309001592cd
     SKIP
     SKIP
     SKIP
@@ -28,6 +28,7 @@ sha256sums=(
 build() {
     qmake
     make
+    arm-linux-gnueabihf-strip src/client/librm2f_client.so.1.0.0
 }
 
 package() {

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -48,3 +48,9 @@ configure() {
     systemctl enable rm2fb --now
     systemctl restart xochitl
 }
+
+preremove() {
+    echo "make sure to re-enable xochitl with 'systemctl enable xochitl --now'"
+    echo "and to disable / uninstall any launchers like draft, oxide or remux before"
+    echo "rebooting your tablet to complete the uninstallation"
+}

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -28,7 +28,7 @@ sha256sums=(
 build() {
     qmake
     make
-    arm-linux-gnueabihf-strip src/client/librm2f_client.so.1.0.0
+    arm-linux-gnueabihf-strip src/client/librm2fb_client.so.1.0.0
 }
 
 package() {

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -46,4 +46,5 @@ package() {
 configure() {
     systemctl daemon-reload
     systemctl enable rm2fb --now
+    systemctl restart xochitl
 }

--- a/package/rm2fb/rm2fb-client
+++ b/package/rm2fb/rm2fb-client
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2048
 LD_PRELOAD=/opt/lib/librm2fb_client.so.1.0.0 $*

--- a/package/rm2fb/rm2fb-client
+++ b/package/rm2fb/rm2fb-client
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-LD_PRELOAD=/opt/lib/librm2fb_client.so.1.0.0 "$*"
+LD_PRELOAD=/opt/lib/librm2fb_client.so.1.0.0 $*

--- a/package/rm2fb/rm2fb-client
+++ b/package/rm2fb/rm2fb-client
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+LD_PRELOAD=/opt/lib/librm2fb_client.so.1.0.0 "$*"

--- a/package/rm2fb/rm2fb-server
+++ b/package/rm2fb/rm2fb-server
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# we actually do want to execute this command
+# shellcheck disable=SC2091
+LD_PRELOAD=/opt/lib/librm2fb_server.so.1.0.0 $(command -v remarkable-shutdown)

--- a/package/rm2fb/rm2fb.conf
+++ b/package/rm2fb/rm2fb.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultEnvironment=LD_PRELOAD=/opt/lib/librm2fb_client.so.1.0.0

--- a/package/rm2fb/rm2fb.service
+++ b/package/rm2fb/rm2fb.service
@@ -1,0 +1,18 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=Remarkable2 Framebuffer Server
+After=opt.mount
+StartLimitInterval=30
+StartLimitBurst=5
+Conflicts=
+
+[Service]
+ExecStart=/opt/bin/rm2fb-server
+Restart=on-failure
+RestartSec=5
+Environment="HOME=/home/root"
+
+[Install]
+WantedBy=multi-user.target xochitl.service

--- a/package/rm2fb/rm2fb.service
+++ b/package/rm2fb/rm2fb.service
@@ -3,16 +3,18 @@
 
 [Unit]
 Description=Remarkable2 Framebuffer Server
+Before=xochitl.service
 After=opt.mount
 StartLimitInterval=30
 StartLimitBurst=5
 Conflicts=
 
 [Service]
-ExecStart=/opt/bin/rm2fb-server
+ExecStart=/usr/bin/remarkable-shutdown
 Restart=on-failure
 RestartSec=5
 Environment="HOME=/home/root"
+Environment="LD_PRELOAD=/opt/lib/librm2fb_server.so.1.0.0"
 
 [Install]
 WantedBy=multi-user.target xochitl.service


### PR DESCRIPTION
this adds rm2fb (ddvk/remarkable2-framebuffer) package, which is used for app compatibility on the rM2.

to run an app, first start `rm2fb-server`, then use `rm2fb-client <app>` to launch the app. 