### PR TITLE
Update chessmarkable to 0.5.1-1

### DIFF
--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -5,15 +5,15 @@
 pkgnames=(chessmarkable)
 pkgdesc="A chess game for the reMarkable"
 url=https://github.com/LinusCDE/chessmarkable
-pkgver=0.4.2-1
-timestamp=2020-10-09T18:15Z
+pkgver=0.5.0-1
+timestamp=2020-11-28T16:18Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 image=rust:v1.1
-source=(https://github.com/LinusCDE/chessmarkable/archive/1a420d667b0b459c7439170fe16d184635eabe5a.zip)
-sha256sums=(98c17dafe671d89a404a2b8783445f416d3f96ab50f8dea34b3b08137843aae6)
+source=(https://github.com/LinusCDE/chessmarkable/archive/0.5.0-1.zip)
+sha256sums=(3fd39d47c7e6e5ff583cb282cacdb46633aa85f459db5e0bc7af00fa53d98040)
 
 build() {
     # Fall back to system-wide config

--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -11,7 +11,7 @@ section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
-image=rust:v1.1
+image=rust:v1.2.1
 source=(https://github.com/LinusCDE/chessmarkable/archive/0.5.0-1.zip)
 sha256sums=(3fd39d47c7e6e5ff583cb282cacdb46633aa85f459db5e0bc7af00fa53d98040)
 

--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -5,15 +5,15 @@
 pkgnames=(chessmarkable)
 pkgdesc="A chess game for the reMarkable"
 url=https://github.com/LinusCDE/chessmarkable
-pkgver=0.5.0-1
-timestamp=2020-11-28T16:18Z
+pkgver=0.5.1-1
+timestamp=2020-12-24T12:35Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/chessmarkable/archive/0.5.0-1.zip)
-sha256sums=(3fd39d47c7e6e5ff583cb282cacdb46633aa85f459db5e0bc7af00fa53d98040)
+source=(https://github.com/LinusCDE/chessmarkable/archive/0.5.1-1.zip)
+sha256sums=(fac73b4cd6c6c928d858e8b0578ac7dac5372368743fb1b577bc7846fd671c52)
 
 build() {
     # Fall back to system-wide config


### PR DESCRIPTION
Should have fully working input support for the rM 2. This version also uses a multithreaded bot algo that should be therefore faster.

@raisjn, could you test this with the shim and check whether the bot reponds faster (2nd move on Hard should be a lot faster on the rM2)?

A binary is available on [the release page](https://github.com/LinusCDE/chessmarkable/releases/tag/0.5.0-1). I also added the ipk to my test repo.