### PR TITLE
Update retris to 0.6.1-1

### DIFF
--- a/package/retris/package
+++ b/package/retris/package
@@ -5,15 +5,15 @@
 pkgnames=(retris)
 pkgdesc="Tetris game"
 url=https://github.com/LinusCDE/retris
-pkgver=0.6.0-1
-timestamp=2020-11-28T15:23Z
+pkgver=0.6.1-1
+timestamp=2020-12-24T12:32Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/retris/archive/0.6.0-1.zip)
-sha256sums=(6f2bfd36c53f88f156cc953a7f16eb58ea293e1c450907a6d4d7655fef398ea5)
+source=(https://github.com/LinusCDE/retris/archive/0.6.1-1.zip)
+sha256sums=(1d7be2246904b1ed0ac0930229f0aec7a44ed660119357b7a6c49ffc8f751229)
 
 build() {
     # Fall back to system-wide config

--- a/package/retris/package
+++ b/package/retris/package
@@ -11,7 +11,7 @@ section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
-image=rust:v1.1
+image=rust:v1.2.1
 source=(https://github.com/LinusCDE/retris/archive/0.6.0-1.zip)
 sha256sums=(6f2bfd36c53f88f156cc953a7f16eb58ea293e1c450907a6d4d7655fef398ea5)
 

--- a/package/retris/package
+++ b/package/retris/package
@@ -5,15 +5,15 @@
 pkgnames=(retris)
 pkgdesc="Tetris game"
 url=https://github.com/LinusCDE/retris
-pkgver=0.5.8-2
-timestamp=2020-09-21T17:59Z
+pkgver=0.6.0-1
+timestamp=2020-11-28T15:23Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 image=rust:v1.1
-source=(https://github.com/LinusCDE/retris/archive/0.5.8-1.zip)
-sha256sums=(6a892cea5e0cabed94c8bc4e960314ec2af992a37ea419e5ec3e7c533bc9474b)
+source=(https://github.com/LinusCDE/retris/archive/0.6.0-1.zip)
+sha256sums=(6f2bfd36c53f88f156cc953a7f16eb58ea293e1c450907a6d4d7655fef398ea5)
 
 build() {
     # Fall back to system-wide config


### PR DESCRIPTION
Should have fully working input support for the rM 2.

@raisjn, could you test this with the shim?

A binary is available on [the release page](https://github.com/LinusCDE/retris/releases/tag/0.6.0-1). I also added the ipk to my test repo.