### PR TITLE
[remux] update remux with shutdown fix for rM1

### DIFF
--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -9,11 +9,11 @@ license=MIT
 
 image=python:v1.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/fb8359fcac7eb22f481292265a01c01cf73e3279.zip
+    https://github.com/rmkit-dev/rmkit/archive/5ceb9d2faa4e145a8adb9bb32744c7c5a503ba23.zip
     remux.service
 )
 sha256sums=(
-    a9cd247500f1732c07760d7007e43ccd708cb3636d95f3c85d33e140adf6038a
+    460315560766d12eef3ffec196431e3cc32b991f2f4195b9783248e8efc9f7f1
     SKIP
 )
 

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -62,7 +62,7 @@ nao() {
 remux() {
     pkgdesc="App launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.0-2
+    pkgver=0.1.1-1
     section=launchers
 
     package() {

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -9,11 +9,11 @@ license=MIT
 
 image=python:v1.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/5ceb9d2faa4e145a8adb9bb32744c7c5a503ba23.zip
+    https://github.com/rmkit-dev/rmkit/archive/97fe490397d76c50b24f8895fd2a7813330b092a.zip
     remux.service
 )
 sha256sums=(
-    460315560766d12eef3ffec196431e3cc32b991f2f4195b9783248e8efc9f7f1
+    307ccf21e300d73bbabd31847d64c193f4c652cc90974d518fb9cdd8f6bf12d8
     SKIP
 )
 

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -9,11 +9,11 @@ license=MIT
 
 image=python:v1.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/118ba6642f1ee56d03bafd0808cb2d7fea635f36.zip
+    https://github.com/rmkit-dev/rmkit/archive/fb8359fcac7eb22f481292265a01c01cf73e3279.zip
     remux.service
 )
 sha256sums=(
-    155f4df72f02ede4d2abdce37fc59dce62a876c9778c1103de5a2205d7a6f0de
+    a9cd247500f1732c07760d7007e43ccd708cb3636d95f3c85d33e140adf6038a
     SKIP
 )
 
@@ -62,7 +62,7 @@ nao() {
 remux() {
     pkgdesc="App launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.0-1
+    pkgver=0.1.0-2
     section=launchers
 
     package() {


### PR DESCRIPTION
the new rM update (2.5) removes rtcwake from the system. this version of remux no longer depends on rtcwake