### PR TITLE
Update plato to 0.9.1-11

### DIFF
--- a/package/plato/package
+++ b/package/plato/package
@@ -5,15 +5,15 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.1-10
-timestamp=2020-09-26T02:41Z
+pkgver=0.9.1-11
+timestamp=2020-12-25T19:13Z
 section=readers
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 
-image=rust:v1.1
-source=(https://github.com/LinusCDE/plato/archive/d8536f8f90ddbd9ac54a787ee5c2d9d966d08c0f.zip)
-sha256sums=(c78eed996a82286c82dd7a68484ee9f8ceaed7cc0842a59dc710724a45605a71)
+image=rust:v1.2.1
+source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-5.zip)
+sha256sums=(e4203ffa79630259de495ce2076cce2e857f352333450a24588328ddcd76de6b)
 
 build() {
     # Get needed build packages


### PR DESCRIPTION
This update makes plato compatible with the rM 2 as long as the shim is used. The "Quit to Xochitl"-Option will also only show up when the actual xochitl.service was running. Not just the potentially freezed xochitl binary. So users will not be able to start xochitl.service through the menu when using a launcher but can continue to use it standalone as well.

@raisjn The state is the basically same as the binary I sent in #rm2 for testing. Feel free to validate this again though.