### PR TITLE
[rmkit] update remux with fix for broken wifi on suspend

### DIFF
--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -31,6 +31,8 @@ harmony() {
     package() {
         install -D -m 755 "$srcdir"/src/build/harmony "$pkgdir"/opt/bin/harmony
         install -D -m 644 "$srcdir"/src/harmony/harmony.draft "$pkgdir"/opt/etc/draft/harmony.draft
+        install -D -m 644 "$srcdir"/src/harmony/harmony.png "$pkgdir"/opt/etc/draft/icons/harmony.png
+
     }
 
     configure() {
@@ -47,6 +49,8 @@ mines() {
     package() {
         install -D -m 755 "$srcdir"/src/build/mines "$pkgdir"/opt/bin/mines
         install -D -m 644 "$srcdir"/src/minesweeper/mines.draft "$pkgdir"/opt/etc/draft/mines.draft
+        install -D -m 644 "$srcdir"/src/minesweeper/mines1.png "$pkgdir"/opt/etc/draft/icons/mines.png
+
     }
 }
 
@@ -60,6 +64,8 @@ nao() {
     package() {
         install -D -m 755 "$srcdir"/src/build/nao.sh "$pkgdir"/opt/bin/nao
         install -D -m 644 "$srcdir"/src/nao/nao.draft "$pkgdir"/opt/etc/draft/nao.draft
+        install -D -m 644 "$srcdir"/src/nao/nao.png "$pkgdir"/opt/etc/draft/icons/nao.png
+
     }
 }
 

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -9,11 +9,11 @@ license=MIT
 
 image=python:v1.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/9dd3f97e83fa0ec5343c48a9792b40c0c8e23ba4.zip
+    https://github.com/rmkit-dev/rmkit/archive/05b818e332f363dfa5c588894eb366a3cd9f1122.zip
     remux.service
 )
 sha256sums=(
-    247c8c935442b09a77562f2fd8a04969b9c2f07e6df80d923c6d6103e556581a
+    ae16e6906af39864f64574b5c1627d1191abe6aa3dc58628b8f19c0ab4cd0e24
     SKIP
 )
 
@@ -66,7 +66,7 @@ nao() {
 remux() {
     pkgdesc="App launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.2-1
+    pkgver=0.1.3-1
     section=launchers
 
     package() {

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -25,7 +25,7 @@ build() {
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.1.0-3
+    pkgver=0.1.0-4
     section=drawing
 
     package() {
@@ -43,7 +43,7 @@ harmony() {
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.1.0-2
+    pkgver=0.1.0-3
     section=games
 
     package() {
@@ -57,7 +57,7 @@ mines() {
 nao() {
     pkgdesc="Nao Package Manager: opkg UI built with SAS"
     url="https://rmkit.dev/apps/nao"
-    pkgver=0.1.0-2
+    pkgver=0.1.0-3
     section=utils
     depends=(simple)
 


### PR DESCRIPTION
this update fixes broken wifi on resume from suspend in remux

Test Plan:

* invoke suspend through remux's bottom right corner. 
* wake tablet up by pressing power button
* verify that network comes back up within a couple minutes (look at xochitl's network bar or use `ping` command, etc)