### PR TITLE
Stable merge window for week 52 of 2020

### DIFF
--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -5,15 +5,15 @@
 pkgnames=(chessmarkable)
 pkgdesc="A chess game for the reMarkable"
 url=https://github.com/LinusCDE/chessmarkable
-pkgver=0.4.2-1
-timestamp=2020-10-09T18:15Z
+pkgver=0.5.1-1
+timestamp=2020-12-24T12:35Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
-image=rust:v1.1
-source=(https://github.com/LinusCDE/chessmarkable/archive/1a420d667b0b459c7439170fe16d184635eabe5a.zip)
-sha256sums=(98c17dafe671d89a404a2b8783445f416d3f96ab50f8dea34b3b08137843aae6)
+image=rust:v1.2.1
+source=(https://github.com/LinusCDE/chessmarkable/archive/0.5.1-1.zip)
+sha256sums=(fac73b4cd6c6c928d858e8b0578ac7dac5372368743fb1b577bc7846fd671c52)
 
 build() {
     # Fall back to system-wide config

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish)
-pkgver=2.0.1~beta-1
+pkgver=2.0.1~beta-2
 timestamp=2020-12-06T20:09Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
@@ -36,7 +36,7 @@ oxide() {
     pkgdesc="Launcher application"
     url=https://github.com/Eeems/oxide/tree/master/applications/launcher
     section=launchers
-    depends=(erode fret tarnish xochitl)
+    depends=(erode fret tarnish xochitl rot)
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/opt/bin/oxide

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,15 +5,15 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.1-11
-timestamp=2020-12-25T19:13Z
+pkgver=0.9.1-12
+timestamp=2020-12-28T17:53Z
 section=readers
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-5.zip)
-sha256sums=(e4203ffa79630259de495ce2076cce2e857f352333450a24588328ddcd76de6b)
+source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-6.zip)
+sha256sums=(f452189141844beb4ba15439ee440ea861ccfde283e9363ea92518296ea58417)
 
 build() {
     # Get needed build packages

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,15 +5,15 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.1-10
-timestamp=2020-09-26T02:41Z
+pkgver=0.9.1-11
+timestamp=2020-12-25T19:13Z
 section=readers
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 
-image=rust:v1.1
-source=(https://github.com/LinusCDE/plato/archive/d8536f8f90ddbd9ac54a787ee5c2d9d966d08c0f.zip)
-sha256sums=(c78eed996a82286c82dd7a68484ee9f8ceaed7cc0842a59dc710724a45605a71)
+image=rust:v1.2.1
+source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-5.zip)
+sha256sums=(e4203ffa79630259de495ce2076cce2e857f352333450a24588328ddcd76de6b)
 
 build() {
     # Get needed build packages

--- a/package/retris/package
+++ b/package/retris/package
@@ -5,15 +5,15 @@
 pkgnames=(retris)
 pkgdesc="Tetris game"
 url=https://github.com/LinusCDE/retris
-pkgver=0.5.8-2
-timestamp=2020-09-21T17:59Z
+pkgver=0.6.1-1
+timestamp=2020-12-24T12:32Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
-image=rust:v1.1
-source=(https://github.com/LinusCDE/retris/archive/0.5.8-1.zip)
-sha256sums=(6a892cea5e0cabed94c8bc4e960314ec2af992a37ea419e5ec3e7c533bc9474b)
+image=rust:v1.2.1
+source=(https://github.com/LinusCDE/retris/archive/0.6.1-1.zip)
+sha256sums=(1d7be2246904b1ed0ac0930229f0aec7a44ed660119357b7a6c49ffc8f751229)
 
 build() {
     # Fall back to system-wide config

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -8,7 +8,7 @@ maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 pkgdesc="Remarkable2 Framebuffer"
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1.0.0-1
+pkgver=1.0.0-2
 section=utils
 version=1.0.0
 image=qt:v1.1
@@ -46,11 +46,20 @@ package() {
 configure() {
     systemctl daemon-reload
     systemctl enable rm2fb --now
-    systemctl restart xochitl
+    # Restart xochitl if it's running
+    if systemctl --quiet is-active xochitl; then
+        # Reset the crash count so we don't trigger remarkable-fail
+        echo "0" > /tmp/crashnum
+        systemctl restart xochitl
+    fi
 }
 
 preremove() {
-    echo "make sure to re-enable xochitl with 'systemctl enable xochitl --now'"
-    echo "and to disable / uninstall any launchers like draft, oxide or remux before"
+    echo -n "make sure "
+    if ! systemctl --quiet --is-enabled xochtil; then
+        echo "to re-enable xochitl with 'systemctl enable xochitl --now'"
+        echo -n "and "
+    fi
+    echo "to disable / uninstall any launchers like draft, oxide or remux before"
     echo "rebooting your tablet to complete the uninstallation"
 }

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -56,7 +56,7 @@ configure() {
 
 preremove() {
     echo -n "make sure "
-    if ! systemctl --quiet --is-enabled xochtil; then
+    if ! systemctl --quiet is-enabled xochtil; then
         echo "to re-enable xochitl with 'systemctl enable xochitl --now'"
         echo -n "and "
     fi

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(rm2fb)
+timestamp=2020-10-10T01:41+00:00
+maintainer="raisjn <of.raisjn@gmail.com>"
+license=MIT
+pkgdesc="Remarkable2 Framebuffer"
+url="https://github.com/ddvk/remarkable2-framebuffer"
+pkgver=1.0.0-1
+section=utils
+version=1.0.0
+image=qt:v1.1
+source=(
+    https://github.com/ddvk/remarkable2-framebuffer/archive/cd2766864c7985fa50cdf85f4ae0a411d7ca4e56.zip
+    rm2fb.conf
+    rm2fb.service
+    rm2fb-server
+    rm2fb-client
+)
+sha256sums=(
+    c274c458270eec28950834bd28ff069a0af65e40fcc288a8ff28235001e8914f
+    SKIP
+    SKIP
+    SKIP
+    SKIP
+)
+
+build() {
+    qmake
+    make
+    arm-linux-gnueabihf-strip src/client/librm2fb_client.so.1.0.0
+}
+
+package() {
+    mkdir -p "$pkgdir"/opt/lib "$pkgdir"/opt/etc "$pkgdir"/opt/bin
+    install -D -m 755 "$srcdir"/src/client/librm2fb_client.so.${version} "$pkgdir"/opt/lib/
+    install -D -m 755 "$srcdir"/src/server/librm2fb_server.so.${version} "$pkgdir"/opt/lib/
+    install -D -m 755 "$srcdir"/rm2fb-server "$pkgdir"/opt/bin/
+    install -D -m 755 "$srcdir"/rm2fb-client "$pkgdir"/opt/bin/
+    install -D -m 644 "$srcdir"/rm2fb.conf "$pkgdir"/etc/systemd/system.conf.d/01-rm2fb.conf
+    install -D -m 644 "$srcdir"/rm2fb.service "$pkgdir"/lib/systemd/system/rm2fb.service
+}
+
+configure() {
+    systemctl daemon-reload
+    systemctl enable rm2fb --now
+    systemctl restart xochitl
+}
+
+preremove() {
+    echo "make sure to re-enable xochitl with 'systemctl enable xochitl --now'"
+    echo "and to disable / uninstall any launchers like draft, oxide or remux before"
+    echo "rebooting your tablet to complete the uninstallation"
+}

--- a/package/rm2fb/rm2fb-client
+++ b/package/rm2fb/rm2fb-client
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2048
+LD_PRELOAD=/opt/lib/librm2fb_client.so.1.0.0 $*

--- a/package/rm2fb/rm2fb-server
+++ b/package/rm2fb/rm2fb-server
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# we actually do want to execute this command
+# shellcheck disable=SC2091
+LD_PRELOAD=/opt/lib/librm2fb_server.so.1.0.0 $(command -v remarkable-shutdown)

--- a/package/rm2fb/rm2fb.conf
+++ b/package/rm2fb/rm2fb.conf
@@ -1,0 +1,2 @@
+[Manager]
+DefaultEnvironment=LD_PRELOAD=/opt/lib/librm2fb_client.so.1.0.0

--- a/package/rm2fb/rm2fb.service
+++ b/package/rm2fb/rm2fb.service
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=Remarkable2 Framebuffer Server
+Before=xochitl.service
+After=opt.mount
+StartLimitInterval=30
+StartLimitBurst=5
+Conflicts=
+
+[Service]
+ExecStart=/usr/bin/remarkable-shutdown
+Restart=on-failure
+RestartSec=5
+Environment="HOME=/home/root"
+Environment="LD_PRELOAD=/opt/lib/librm2fb_server.so.1.0.0"
+
+[Install]
+WantedBy=multi-user.target xochitl.service

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -25,12 +25,14 @@ build() {
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.1.0-3
+    pkgver=0.1.0-4
     section=drawing
 
     package() {
         install -D -m 755 "$srcdir"/src/build/harmony "$pkgdir"/opt/bin/harmony
         install -D -m 644 "$srcdir"/src/harmony/harmony.draft "$pkgdir"/opt/etc/draft/harmony.draft
+        install -D -m 644 "$srcdir"/src/harmony/harmony.png "$pkgdir"/opt/etc/draft/icons/harmony.png
+
     }
 
     configure() {
@@ -41,25 +43,29 @@ harmony() {
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.1.0-2
+    pkgver=0.1.0-3
     section=games
 
     package() {
         install -D -m 755 "$srcdir"/src/build/mines "$pkgdir"/opt/bin/mines
         install -D -m 644 "$srcdir"/src/minesweeper/mines.draft "$pkgdir"/opt/etc/draft/mines.draft
+        install -D -m 644 "$srcdir"/src/minesweeper/mines1.png "$pkgdir"/opt/etc/draft/icons/mines.png
+
     }
 }
 
 nao() {
     pkgdesc="Nao Package Manager: opkg UI built with SAS"
     url="https://rmkit.dev/apps/nao"
-    pkgver=0.1.0-2
+    pkgver=0.1.0-3
     section=utils
     depends=(simple)
 
     package() {
         install -D -m 755 "$srcdir"/src/build/nao.sh "$pkgdir"/opt/bin/nao
         install -D -m 644 "$srcdir"/src/nao/nao.draft "$pkgdir"/opt/etc/draft/nao.draft
+        install -D -m 644 "$srcdir"/src/nao/nao.png "$pkgdir"/opt/etc/draft/icons/nao.png
+
     }
 }
 

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -9,11 +9,11 @@ license=MIT
 
 image=python:v1.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/97fe490397d76c50b24f8895fd2a7813330b092a.zip
+    https://github.com/rmkit-dev/rmkit/archive/05b818e332f363dfa5c588894eb366a3cd9f1122.zip
     remux.service
 )
 sha256sums=(
-    307ccf21e300d73bbabd31847d64c193f4c652cc90974d518fb9cdd8f6bf12d8
+    ae16e6906af39864f64574b5c1627d1191abe6aa3dc58628b8f19c0ab4cd0e24
     SKIP
 )
 
@@ -25,19 +25,23 @@ build() {
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.1.0-1
+    pkgver=0.1.0-3
     section=drawing
 
     package() {
         install -D -m 755 "$srcdir"/src/build/harmony "$pkgdir"/opt/bin/harmony
         install -D -m 644 "$srcdir"/src/harmony/harmony.draft "$pkgdir"/opt/etc/draft/harmony.draft
     }
+
+    configure() {
+        mkdir -p /home/root/harmony/saved_images
+    }
 }
 
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.1.0-1
+    pkgver=0.1.0-2
     section=games
 
     package() {
@@ -49,7 +53,7 @@ mines() {
 nao() {
     pkgdesc="Nao Package Manager: opkg UI built with SAS"
     url="https://rmkit.dev/apps/nao"
-    pkgver=0.1.0-1
+    pkgver=0.1.0-2
     section=utils
     depends=(simple)
 
@@ -62,7 +66,7 @@ nao() {
 remux() {
     pkgdesc="App launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.1-1
+    pkgver=0.1.3-1
     section=launchers
 
     package() {
@@ -94,7 +98,7 @@ remux() {
 simple() {
     pkgdesc="Simple app script for writing scripted applications"
     url="https://rmkit.dev/apps/sas"
-    pkgver=0.1.0-1
+    pkgver=0.1.0-2
     section=utils
 
     package() {


### PR DESCRIPTION
Updated Packages:

* chessmarkable -> 0.5.1-1
* oxide -> 2.0.1~beta-2
* plato -> 0.9.1-11
* retris -> 0.6.1-1
* rmkit
  * harmony -> 0.1.0-3
  * mines -> 0.1.0-2
  * nao -> 0.1.0-2
  * remux -> 0.1.3-1
  * simple -> 0.1.0-2

New Packages:

* rm2fb -> 1.0.0