### PR TITLE
Update plato to 0.9.1-12 (rM2 bugfix)

### DIFF
--- a/package/plato/package
+++ b/package/plato/package
@@ -5,15 +5,15 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.1-11
-timestamp=2020-12-25T19:13Z
+pkgver=0.9.1-12
+timestamp=2020-12-28T17:53Z
 section=readers
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-5.zip)
-sha256sums=(e4203ffa79630259de495ce2076cce2e857f352333450a24588328ddcd76de6b)
+source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-6.zip)
+sha256sums=(f452189141844beb4ba15439ee440ea861ccfde283e9363ea92518296ea58417)
 
 build() {
     # Get needed build packages


### PR DESCRIPTION
Just noticed, that plato might have a bug on the rM 2, since the `/dev/input/` paths were not changed depending on the model:

- De-selecting "Input by -> Pen" will actually disable the power button (Pen will continue to work).
- De-selecting "Input by -> Touch" will actually disable the Pen (touch will continue to work).

The above bugs should be present on 0.9.1-11 but not on this version (0.9.1-12). The package is available at https://rmtestrepo.cosmos-ink.net/ for faster testing. The new version will behave the same on the rM 1 (verified it quickly).

As per suggesion from @Eeems in discord, I would recommend that I would be nice, if it could get squeezed into the stable window. (I'm not sure how many actually use this feature if any.)