### PR TITLE
Update chessmarkable to 0.6.0-1

### DIFF
--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -5,15 +5,15 @@
 pkgnames=(chessmarkable)
 pkgdesc="A chess game for the reMarkable"
 url=https://github.com/LinusCDE/chessmarkable
-pkgver=0.5.1-1
-timestamp=2020-12-24T12:35Z
+pkgver=0.6.0-1
+timestamp=2021-01-03T05:26Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/chessmarkable/archive/0.5.1-1.zip)
-sha256sums=(fac73b4cd6c6c928d858e8b0578ac7dac5372368743fb1b577bc7846fd671c52)
+source=(https://github.com/LinusCDE/chessmarkable/archive/0.6.0-1.zip)
+sha256sums=(3ad10a46da5a42f603947ad4dce960bdac2d646c0cd29b7bb3a60b8d308dd82a)
 
 build() {
     # Fall back to system-wide config


### PR DESCRIPTION
Adds the first draft (and probably final) to rotate the board in PvP mode when selected in the main menu.

I don't see any reason why this wouldn't work specifically on the rM 2 (libremarkable is updated but should've stayed the same in terms of features).

(https://github.com/LinusCDE/chessmarkable/releases/tag/0.6.0-1)