### PR TITLE
Add restream to toltec

### DIFF
--- a/package/restream/package
+++ b/package/restream/package
@@ -10,7 +10,7 @@ timestamp=2021-01-01T13:55:28Z
 section=utils
 maintainer="Dan Shick <dan.shick@gmail.com>"
 license=MIT
-
+conflicts=(rm2fb)
 image=rust:v1.2.1
 source=(https://github.com/rien/reStream/archive/c41b87778953513cd52d9c58b3cc5ce52825700e.zip)
 sha256sums=(89da0932f17a546f194b816eb28a83f84f2484a1508d545bfce2115908248fc3)

--- a/package/restream/package
+++ b/package/restream/package
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(restream)
+pkgdesc="A binary framebuffer capture tool for the reStream script"
+url=https://github.com/rien/reStream
+pkgver=0.0.0-c41b877
+timestamp=2021-01-01T14:55:28+01:00
+section=utils
+maintainer="Dan Shick <dan.shick@gmail.com>"
+license=MIT
+
+image=rust:v1.2.1
+source=(https://github.com/rien/reStream/archive/c41b87778953513cd52d9c58b3cc5ce52825700e.zip)
+sha256sums=(89da0932f17a546f194b816eb28a83f84f2484a1508d545bfce2115908248fc3)
+
+build() {
+    # Fall back to system-wide config
+    rm .cargo/config
+
+    cargo build --release --bin restream
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/restream
+}

--- a/package/restream/package
+++ b/package/restream/package
@@ -5,8 +5,8 @@
 pkgnames=(restream)
 pkgdesc="A binary framebuffer capture tool for the reStream script"
 url=https://github.com/rien/reStream
-pkgver=0.0.0-c41b877
-timestamp=2021-01-01T14:55:28+01:00
+pkgver=0.0.0-1
+timestamp=2021-01-01T13:55:28Z
 section=utils
 maintainer="Dan Shick <dan.shick@gmail.com>"
 license=MIT
@@ -24,4 +24,10 @@ build() {
 
 package() {
     install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/restream
+}
+
+postinstall() {
+    printf "This app is only the device-side half of reStream. The companion script for consuming the output of this app can be found at https://github.com/rien/reStream\n"
+    printf "The script may need to be adjusted to target /opt/bin/restream instead of \$HOME/restream, or you can create a symlink on your device with\n"
+    printf "ln -s /opt/bin/restream \$HOME/restream\n"
 }


### PR DESCRIPTION
Adds restream helper binary to toltec. restream will need to update the script to stop assuming that this binary is in the home directory, and rely on it being in the path. Additionally, another PR (in progress) will add support for rm2fb users.