### PR TITLE
Prevent unwanted PRs against stable

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,13 @@
+name: pr-labels
+on:
+    pull_request:
+        types: [opened, edited, labeled, unlabeled]
+jobs:
+    check-tag:
+        name: Check that PRs against the stable branch are labelled correctly
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check labels
+              run: |
+                [[ "${{ github.base_ref }}" != stable ]] \
+                || [[ "${{ contains(github.event.pull_request.labels.*.name, 'merge') }}" == true ]]

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,8 @@ We welcome contributions from anyone, regarding for example [reporting bugs](#re
 To make a request or report a bug, you simply need to [open a new issue](../../../issues/new/choose).
 
 To directly propose changes, the basic procedure is to fork this repository, make the desired changes in your newly created local copy, and open a pull request.
+**When creating your pull request, make sure to target the `testing` branch instead of the default `stable` branch** (PRs against the `stable` branch will not be merged).
+
 When proposing changes, please make sure that you follow the [style guide](#style-guide).
 After you submit your pull request, a maintainer will take time to review your changes, request modifications and then merge your changes into the repository if they fit.
 


### PR DESCRIPTION
(Part of fixing #174)

* Add a workflow check that fails if a PR targets the `stable` branch and does not have the `merge` label.
* Warn future contributors that they should target the `testing` branch instead of the default `stable` branch.