### PR TITLE
Launch the PR label checker on more events

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,9 +1,9 @@
 name: pr-labels
 on:
     pull_request:
-        types: [opened, edited, labeled, unlabeled]
+        types: [opened, reopened, synchronize, edited, labeled, unlabeled]
 jobs:
-    check-tag:
+    check-labels:
         name: Check that PRs against the stable branch are labelled correctly
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
(Follow-up to #189)

It looks like each time a commit is added to a PR, all status checks are lost. Therefore, if we don’t re-run the label-checking workflow after each new commit on a PR, we end up with a missing status check that cannot be solved without manually triggering the “edited”, “labeled” or “unlabeled” events (i.e., adding/removing a label, or changing PR metadata).

This changeset adds the “reopened” and “synchronize” events to the set of events that trigger the pr-labels workflow, which should cover all cases.