### PR TITLE
Add keywriter package

### DIFF
--- a/package/keywriter/keywriter.draft
+++ b/package/keywriter/keywriter.draft
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+name=keywriter
+desc=Markdown-enabled free writing app
+call=/opt/bin/keywriter
+term=:

--- a/package/keywriter/package
+++ b/package/keywriter/package
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(keywriter)
+pkgdesc="Markdown-enabled free writing app"
+url=https://github.com/dps/remarkable-keywriter
+pkgver=0.1.0-1
+timestamp=2019-07-13T06:27Z
+section=writing
+maintainer="Mattéo Delabre <spam@delab.re>"
+license=MIT
+
+image=qt:v1.2.2
+_sundown=37728fb2d7137ff7c37d0a474cb827a8d6d846d8
+source=(
+    https://github.com/dps/remarkable-keywriter/archive/c77ec3f65d9ff769f3f5dc85cc91abbf05aa163f.zip
+    "https://github.com/vmg/sundown/archive/$_sundown.zip"
+    keywriter.draft
+)
+noextract=("$_sundown.zip")
+sha256sums=(
+    acbd0b0f74793320b1399d2adb68c4647f128578c7786f80c1cf8472b16a36f7
+    3c594d8219b17acd140b7011b44ebc69ab9d68910da827494f8c9cc2f5b12ecf
+    SKIP
+)
+
+prepare() {
+    bsdtar -x \
+        --strip-components 1 \
+        --directory "$srcdir/sundown" \
+        --file "$srcdir/$_sundown.zip"
+}
+
+build() {
+    sed -i 's/linux-oe-g++/linux-arm-gnueabihf-g++/' edit.pro
+    qmake edit.pro
+    make
+}
+
+package() {
+    install -D -m 755 "$srcdir"/edit "$pkgdir"/opt/bin/keywriter
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft "$srcdir"/keywriter.draft
+}
+
+configure() {
+    mkdir -p /home/root/edit
+    echo "Created /home/root/edit for storing your Markdown files"
+}


### PR DESCRIPTION
The app can only be controlled by an USB OTG keyboard, which for now users have only managed to connect on rM1 (see
<https://github.com/dps/remarkable-keywriter/issues/14>).

The docs are a bit lacking, so if you want to test the app:

* the “home” button (middle one) opens a menu to select a file to edit in the `/home/root/edit` directory. By default `draft.md` is opened,
* the default view shows the content of the active file (or an empty screen if the file is empty) with any Markdown syntax properly rendered,
* switch between normal and edit mode by pressing \<Esc\>.