### PR TITLE
Update Oxide to v2.0.3-beta

### DIFF
--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish)
-pkgver=2.0.1~beta-4
+pkgver=2.0.2~beta-1
 timestamp=2020-12-06T20:09Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
-source=(https://github.com/Eeems/oxide/releases/download/v2.0.1-beta/oxide.zip)
-sha256sums=(02c0561b0478d4108916d618ad1bced77e549121f1e2770d35314b94c2852dfe)
+source=(https://github.com/Eeems/oxide/releases/download/v2.0.2-beta/oxide.zip)
+sha256sums=(b9e9518262204808052053170295a4d84fcb8c5971f6b6924cf6e209cecc12b4)
 
 erode() {
     pkgdesc="Task manager"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish)
-pkgver=2.0.2~beta-1
-timestamp=2021-01-07T00:47Z
+pkgver=2.0.3~beta-1
+timestamp=2021-01-07T03:28Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
-source=(https://github.com/Eeems/oxide/releases/download/v2.0.2-beta/oxide.zip)
-sha256sums=(b9e9518262204808052053170295a4d84fcb8c5971f6b6924cf6e209cecc12b4)
+source=(https://github.com/Eeems/oxide/releases/download/v2.0.3-beta/oxide.zip)
+sha256sums=(c35f62d33ec954d88fc36fd9853bcb37e54ac45b936364f4014bf6d4b69725e1)
 
 erode() {
     pkgdesc="Task manager"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -4,7 +4,7 @@
 
 pkgnames=(erode fret oxide rot tarnish)
 pkgver=2.0.2~beta-1
-timestamp=2020-12-06T20:09Z
+timestamp=2021-01-07T00:47Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 


### PR DESCRIPTION
See release notes for issues fixed: https://github.com/Eeems/oxide/releases/tag/v2.0.2-beta and https://github.com/Eeems/oxide/releases/tag/v2.0.3-beta