### PR TITLE
Add koreader nightly with rM2 support

### DIFF
--- a/package/koreader-nightly/koreader
+++ b/package/koreader-nightly/koreader
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+KO_DONT_GRAB_INPUT=1 bash /opt/koreader/koreader.sh

--- a/package/koreader-nightly/koreader.draft
+++ b/package/koreader-nightly/koreader.draft
@@ -1,0 +1,8 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+name=KOReader (dev)
+desc=ebook reader
+imgFile=koreader
+call=/opt/bin/koreader
+term=killall -9 luajit

--- a/package/koreader-nightly/package
+++ b/package/koreader-nightly/package
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(koreader-nightly)
+pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
+url=https://github.com/koreader/koreader
+pkgver=2020.12-82-1
+timestamp=2021-01-06T06:43Z
+section=readers
+maintainer="raisjn <of.raisjn@gmail.com>"
+license=AGPL-3.0-or-later
+conflicts=(koreader)
+
+source=("https://build.koreader.rocks/download/nightly/v${pkgver%-[[:alnum:]]*}-ge157395_${timestamp:0:10}/koreader-remarkable-v${pkgver%-[[:alnum:]]*}-ge157395_${timestamp:0:10}.zip")
+sha256sums=(0b2e6ba65438d5385e3c89d13bb34c7c0717e7a4101306c1491387a9c6d2b080)
+
+package() {
+    install -d "$pkgdir"/opt/koreader
+    cp -R "$srcdir"/* "$pkgdir"/opt/koreader/
+    rm "$pkgdir"/opt/koreader/koreader*zip
+
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png
+    install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
+}


### PR DESCRIPTION
instead of updating koreader package,  add a package for koreader-nightly that conflicts with the main koreader package.