### PR TITLE
Fix base image for stripping not found

### DIFF
--- a/scripts/package-build
+++ b/scripts/package-build
@@ -151,7 +151,7 @@ for pkgname in "${pkgnames[@]}"; do
             section "Stripping $pkgname"
             docker container run --interactive --rm \
                 --mount type=bind,src="$(realpath "$pkgdir")",dst=/pkg \
-                "$(image-name base:v1.2.2)" /bin/bash \
+                "$(image-name "$image")" /bin/bash \
                 << "SCRIPT"
 find /pkg -print0 -type f | xargs --null arm-linux-gnueabihf-strip --strip-all &> /dev/null || true
 SCRIPT

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -153,7 +153,7 @@ for pkgname in "${pkgnames[@]}"; do
                 --mount type=bind,src="$(realpath "$pkgdir")",dst=/pkg \
                 "$(image-name "$image")" /bin/bash \
                 << "SCRIPT"
-find /pkg -print0 -type f | xargs --null arm-linux-gnueabihf-strip --strip-all &> /dev/null || true
+find /pkg -print0 -type f | xargs --null "${CROSS_COMPILE}strip" --strip-all &> /dev/null || true
 SCRIPT
             find "$pkgdir" -print0 -type f | xargs --null strip --strip-all &> /dev/null || true
 

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -151,7 +151,7 @@ for pkgname in "${pkgnames[@]}"; do
             section "Stripping $pkgname"
             docker container run --interactive --rm \
                 --mount type=bind,src="$(realpath "$pkgdir")",dst=/pkg \
-                "$(image-name base)" /bin/bash \
+                "$(image-name base:v1.2.2)" /bin/bash \
                 << "SCRIPT"
 find /pkg -print0 -type f | xargs --null arm-linux-gnueabihf-strip --strip-all &> /dev/null || true
 SCRIPT


### PR DESCRIPTION
When trying to build the keywriter package (#195) for testing on my server (since my internet at home for some reason takes ages to pull new images), I encountered the following error:

![grafik](https://user-images.githubusercontent.com/22298664/103905873-6ff2d580-50ff-11eb-97c1-af363cfa5dd8.png)

The error seems to be that the image was specified without an version and the default ("latest") is not used by us and was not found.

@Eeems @matteodelabre This for now just assumed a version, but we should consider using taking the version part of the already specified image or something else to keep that hidden part in the code somehow up to date.

I'll use this version for building keywriter for now, but I guess this should not be the final fix.