### PR TITLE
Stable merge window for week 02 of 2021

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,13 @@
+name: pr-labels
+on:
+    pull_request:
+        types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+jobs:
+    check-labels:
+        name: Check that PRs against the stable branch are labelled correctly
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check labels
+              run: |
+                [[ "${{ github.base_ref }}" != stable ]] \
+                || [[ "${{ contains(github.event.pull_request.labels.*.name, 'merge') }}" == true ]]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "3eefd43f5c80ea4b7b8bb60475a5ebe23d895fc2eb12d3174d1b7594a6a0c6d5  bootstrap" | sha256sum -c
+$ echo "cbe83d1ae2d3ef6291a2b57202bb59aace14f2f1849bbdb09552a7419995294a  bootstrap" | sha256sum -c
 $ bash bootstrap
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "cbe83d1ae2d3ef6291a2b57202bb59aace14f2f1849bbdb09552a7419995294a  bootstrap" | sha256sum -c
+$ echo "3eefd43f5c80ea4b7b8bb60475a5ebe23d895fc2eb12d3174d1b7594a6a0c6d5  bootstrap" | sha256sum -c
 $ bash bootstrap
 ```
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,8 @@ We welcome contributions from anyone, regarding for example [reporting bugs](#re
 To make a request or report a bug, you simply need to [open a new issue](../../../issues/new/choose).
 
 To directly propose changes, the basic procedure is to fork this repository, make the desired changes in your newly created local copy, and open a pull request.
+**When creating your pull request, make sure to target the `testing` branch instead of the default `stable` branch** (PRs against the `stable` branch will not be merged).
+
 When proposing changes, please make sure that you follow the [style guide](#style-guide).
 After you submit your pull request, a maintainer will take time to review your changes, request modifications and then merge your changes into the repository if they fit.
 

--- a/package/appmarkable/package
+++ b/package/appmarkable/package
@@ -5,7 +5,7 @@
 pkgnames=(appmarkable)
 pkgdesc="Turn your program into a very simple app for draft"
 url="https://github.com/LinusCDE/appmarkable"
-pkgver=0.0.0-6
+pkgver=0.0.0-7
 timestamp=2020-09-07T00:16Z
 section=utils
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -18,7 +18,6 @@ sha256sums=(0422cee28668d4e7ff554c26884e45ec63feff840eec92e6b8b2e8a7905a9d3b)
 build() {
     rm -r .cargo/
     cargo build --release --target=armv7-unknown-linux-gnueabihf
-    arm-linux-gnueabihf-strip target/armv7-unknown-linux-gnueabihf/release/appmarkable
 }
 
 package() {

--- a/package/calculator/package
+++ b/package/calculator/package
@@ -5,7 +5,7 @@
 pkgnames=(calculator)
 pkgdesc="Touch-based calculator"
 url=https://github.com/reHackable/Calculator
-pkgver=0.0.0-12
+pkgver=0.0.0-13
 timestamp=2020-08-20T12:28Z
 section=math
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -5,22 +5,21 @@
 pkgnames=(chessmarkable)
 pkgdesc="A chess game for the reMarkable"
 url=https://github.com/LinusCDE/chessmarkable
-pkgver=0.5.1-1
-timestamp=2020-12-24T12:35Z
+pkgver=0.6.0-2
+timestamp=2021-01-03T05:26Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/chessmarkable/archive/0.5.1-1.zip)
-sha256sums=(fac73b4cd6c6c928d858e8b0578ac7dac5372368743fb1b577bc7846fd671c52)
+source=(https://github.com/LinusCDE/chessmarkable/archive/0.6.0-1.zip)
+sha256sums=(3ad10a46da5a42f603947ad4dce960bdac2d646c0cd29b7bb3a60b8d308dd82a)
 
 build() {
     # Fall back to system-wide config
     rm .cargo/config
 
     cargo build --release --bin chessmarkable
-    arm-linux-gnueabihf-strip target/armv7-unknown-linux-gnueabihf/release/chessmarkable
 }
 
 package() {

--- a/package/dotnet/package
+++ b/package/dotnet/package
@@ -12,7 +12,7 @@ pkgnames=(
     aspnet-targeting-pack
     netstandard-targeting-pack
 )
-pkgver=3.1.10-1
+pkgver=3.1.10-2
 timestamp=2020-12-27T18:48Z
 maintainer="Eeems <eeems@eeems.email>"
 url=https://www.microsoft.com/net/core

--- a/package/draft/package
+++ b/package/draft/package
@@ -5,7 +5,7 @@
 pkgnames=(draft)
 pkgdesc="Launcher which wraps around the standard interface"
 url=https://github.com/dixonary/draft-reMarkable
-pkgver=0.2.0-15
+pkgver=0.2.0-16
 timestamp=2020-07-20T10:23Z
 section=launchers
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/evtest/package
+++ b/package/evtest/package
@@ -5,7 +5,7 @@
 pkgnames=(evtest)
 pkgdesc="Kernel evdev device information and monitor"
 url=https://gitlab.freedesktop.org/libevdev/evtest
-pkgver=1.34-1
+pkgver=1.34-2
 timestamp=2020-12-30T02:52Z
 section=utils
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -24,7 +24,6 @@ build() {
     ./autogen.sh --host armv7
     ./configure --host armv7
     make
-    arm-linux-gnueabihf-strip evtest
 }
 
 package() {

--- a/package/fbink/package
+++ b/package/fbink/package
@@ -4,7 +4,7 @@
 
 pkgnames=(fbink fbdepth fbink-doom)
 url=https://github.com/NiLuJe/FBInk
-pkgver=1.23.1-1
+pkgver=1.23.1-2
 timestamp=2020-12-14T12:30Z
 section=util
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/fingerterm/package
+++ b/package/fingerterm/package
@@ -5,7 +5,7 @@
 pkgnames=(fingerterm)
 pkgdesc="Terminal emulator with an on-screen touch keyboard"
 url=https://github.com/dixonary/fingerterm-reMarkable
-pkgver=1.3.5-9
+pkgver=1.3.5-10
 timestamp=2017-12-08T15:40Z
 section=utils
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/keywriter/keywriter.draft
+++ b/package/keywriter/keywriter.draft
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+name=keywriter
+desc=Markdown-enabled free writing app
+call=/opt/bin/keywriter
+term=:

--- a/package/keywriter/package
+++ b/package/keywriter/package
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(keywriter)
+pkgdesc="Markdown-enabled free writing app"
+url=https://github.com/dps/remarkable-keywriter
+pkgver=0.1.0-1
+timestamp=2019-07-13T06:27Z
+section=writing
+maintainer="Mattéo Delabre <spam@delab.re>"
+license=MIT
+
+image=qt:v1.2.2
+_sundown=37728fb2d7137ff7c37d0a474cb827a8d6d846d8
+source=(
+    https://github.com/dps/remarkable-keywriter/archive/c77ec3f65d9ff769f3f5dc85cc91abbf05aa163f.zip
+    "https://github.com/vmg/sundown/archive/$_sundown.zip"
+    keywriter.draft
+)
+noextract=("$_sundown.zip")
+sha256sums=(
+    acbd0b0f74793320b1399d2adb68c4647f128578c7786f80c1cf8472b16a36f7
+    3c594d8219b17acd140b7011b44ebc69ab9d68910da827494f8c9cc2f5b12ecf
+    SKIP
+)
+
+prepare() {
+    bsdtar -x \
+        --strip-components 1 \
+        --directory "$srcdir/sundown" \
+        --file "$srcdir/$_sundown.zip"
+}
+
+build() {
+    sed -i 's/linux-oe-g++/linux-arm-gnueabihf-g++/' edit.pro
+    qmake edit.pro
+    make
+}
+
+package() {
+    install -D -m 755 "$srcdir"/edit "$pkgdir"/opt/bin/keywriter
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft "$srcdir"/keywriter.draft
+}
+
+configure() {
+    mkdir -p /home/root/edit
+    echo "Created /home/root/edit for storing your Markdown files"
+}

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2020.12-1
+pkgver=2020.12-2
 timestamp=2020-10-10T20:13Z
 section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -13,8 +13,19 @@ license=AGPL-3.0-or-later
 depends=(fbink fbdepth)
 
 _srcver="v${pkgver%-*}"
-source=("https://build.koreader.rocks/download/stable/$_srcver/koreader-remarkable-$_srcver.zip")
-sha256sums=(38db8f3895472828d7c1d63fc54db426135a8dbf8425633e299a1a9abfdb69b2)
+source=(
+    "https://build.koreader.rocks/download/stable/$_srcver/koreader-remarkable-$_srcver.zip"
+    rm2-support.patch
+)
+sha256sums=(
+    38db8f3895472828d7c1d63fc54db426135a8dbf8425633e299a1a9abfdb69b2
+    SKIP
+)
+
+prepare() {
+    patch -p1 -d"$srcdir" < "$srcdir"/rm2-support.patch
+    rm "$srcdir"/rm2-support.patch
+}
 
 package() {
     install -d "$pkgdir"/opt/koreader
@@ -32,6 +43,7 @@ package() {
 configure() {
     echo "KOReader has an outstanding bug where it doesn't resize the screen properly when returning to Oxide. See Oxide's release notes for a workaround."
 }
+
 postremove() {
     # Check to see if tarnish is running and rot is available
     # shellcheck disable=SC2009

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2020.10-2
+pkgver=2020.12-1
 timestamp=2020-10-10T20:13Z
 section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -14,23 +14,28 @@ depends=(fbink fbdepth)
 
 _srcver="v${pkgver%-*}"
 source=("https://build.koreader.rocks/download/stable/$_srcver/koreader-remarkable-$_srcver.zip")
-sha256sums=(a646c52e22c2ea47aa8b4677cc8060b979dcbadb718ce111ad8489233780da10)
+sha256sums=(38db8f3895472828d7c1d63fc54db426135a8dbf8425633e299a1a9abfdb69b2)
 
 package() {
     install -d "$pkgdir"/opt/koreader
     cp -R "$srcdir"/* "$pkgdir"/opt/koreader/
     rm "$pkgdir"/opt/koreader/koreader*zip
+    rm "$pkgdir"/opt/koreader/{fbink,fbdepth}
+    ln -s /opt/bin/fbink "$pkgdir"/opt/koreader/fbink
+    ln -s /opt/bin/fbdepth "$pkgdir"/opt/koreader/fbdepth
 
     install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
     install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png
     install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
-    rm "$pkgdir"/opt/koreader/{fbink,fbdepth}
-    ln -s /opt/bin/fbink "$pkgdir"/opt/koreader/fbink
-    ln -s /opt/bin/fbdepth "$pkgdir"/opt/koreader/fbdepth
 }
 
 configure() {
-    if systemctl list-units --full -all | grep -Fq "tarnish.service"; then
-        echo "KOReader has an outstanding bug where it doesn't resize the screen properly when returning to Oxide. See Oxide's release notes for a workaround."
+    echo "KOReader has an outstanding bug where it doesn't resize the screen properly when returning to Oxide. See Oxide's release notes for a workaround."
+}
+postremove() {
+    # Check to see if tarnish is running and rot is available
+    # shellcheck disable=SC2009
+    if systemctl list-units --full -all | grep -Fq 'tarnish.service' || [[ "$(ps | grep tarnish | grep -v grep)" != "" ]]; then
+        echo "You may need to manually remove the application entry for KOReader in Oxide."
     fi
 }

--- a/package/koreader/rm2-support.patch
+++ b/package/koreader/rm2-support.patch
@@ -1,0 +1,210 @@
+diff --git a/frontend/device/remarkable/device.lua b/frontend/device/remarkable/device.lua
+index 3589258d..de5e37b7 100644
+--- a/frontend/device/remarkable/device.lua
++++ b/frontend/device/remarkable/device.lua
+@@ -1,11 +1,24 @@
+ local Generic = require("device/generic/device") -- <= look at this file!
++local TimeVal = require("ui/timeval")
+ local logger = require("logger")
+ 
+ local function yes() return true end
+ local function no() return false end
+ 
++local EV_ABS = 3
++local ABS_X = 00
++local ABS_Y = 01
++local ABS_MT_POSITION_X = 53
++local ABS_MT_POSITION_Y = 54
++-- Resolutions from libremarkable src/framebuffer/common.rs
++local screen_width = 1404 -- unscaled_size_check: ignore
++local screen_height = 1872 -- unscaled_size_check: ignore
++local wacom_width = 15725 -- unscaled_size_check: ignore
++local wacom_height = 20967 -- unscaled_size_check: ignore
++local wacom_scale_x = screen_width / wacom_width
++local wacom_scale_y = screen_height / wacom_height
++
+ local Remarkable = Generic:new{
+-    model = "reMarkable",
+     isRemarkable = yes,
+     hasKeys = yes,
+     needsScreenRefreshAfterResume = no,
+@@ -17,39 +30,61 @@ local Remarkable = Generic:new{
+     display_dpi = 226,
+     -- Despite the SoC supporting it, it's finicky in practice (#6772)
+     canHWInvert = no,
+-    home_dir = "/mnt/root",
++    home_dir = "/home/root",
+ }
+ 
+-local EV_ABS = 3
+-local ABS_X = 00
+-local ABS_Y = 01
+-local ABS_MT_POSITION_X = 53
+-local ABS_MT_POSITION_Y = 54
+--- Resolutions from libremarkable src/framebuffer/common.rs
+-local screen_width = 1404 -- unscaled_size_check: ignore
+-local screen_height = 1872 -- unscaled_size_check: ignore
+-local wacom_width = 15725 -- unscaled_size_check: ignore
+-local wacom_height = 20967 -- unscaled_size_check: ignore
+-local wacom_scale_x = screen_width / wacom_width
+-local wacom_scale_y = screen_height / wacom_height
+-local mt_width = 767 -- unscaled_size_check: ignore
+-local mt_height = 1023 -- unscaled_size_check: ignore
+-local mt_scale_x = screen_width / mt_width
+-local mt_scale_y = screen_height / mt_height
+-local adjustTouchEvt = function(self, ev)
++local Remarkable1 = Remarkable:new{
++    model = "reMarkable",
++    mt_width = 767, -- unscaled_size_check: ignore
++    mt_height = 1023, -- unscaled_size_check: ignore
++    input_wacom = "/dev/input/event0",
++    input_ts = "/dev/input/event1",
++    input_buttons = "/dev/input/event2",
++    battery_path = "/sys/class/power_supply/bq27441-0/capacity",
++    status_path = "/sys/class/power_supply/bq27441-0/status",
++}
++
++function Remarkable1:adjustTouchEvent(ev, by)
++    if ev.type == EV_ABS then
++        ev.time = TimeVal:now()
++        -- Mirror X and Y and scale up both X & Y as touch input is different res from
++        -- display
++        if ev.code == ABS_MT_POSITION_X then
++            ev.value = (Remarkable1.mt_width - ev.value) *  by.mt_scale_x
++        end
++        if ev.code == ABS_MT_POSITION_Y then
++            ev.value = (Remarkable1.mt_height - ev.value) * by.mt_scale_y
++        end
++    end
++end
++
++local Remarkable2 = Remarkable:new{
++    model = "reMarkable 2",
++    mt_width = 1403, -- unscaled_size_check: ignore
++    mt_height = 1871, -- unscaled_size_check: ignore
++    input_wacom = "/dev/input/event1",
++    input_ts = "/dev/input/event2",
++    input_buttons = "/dev/input/event0",
++    battery_path = "/sys/class/power_supply/max77818_battery/capacity",
++    status_path = "/sys/class/power_supply/max77818-charger/status",
++}
++
++function Remarkable2:adjustTouchEvent(ev, by)
++    ev.time = TimeVal:now()
+     if ev.type == EV_ABS then
+-        -- Mirror X and scale up both X & Y as touch input is different res from
++        -- Mirror Y and scale up both X & Y as touch input is different res from
+         -- display
+         if ev.code == ABS_MT_POSITION_X then
+-            ev.value = (mt_width - ev.value) * mt_scale_x
++            ev.value = (ev.value) * by.mt_scale_x
+         end
+         if ev.code == ABS_MT_POSITION_Y then
+-            ev.value = (mt_height - ev.value) * mt_scale_y
++            ev.value = (Remarkable2.mt_height - ev.value) * by.mt_scale_y
+         end
+-        -- The Wacom input layer is non-multi-touch and
+-        -- uses its own scaling factor.
+-        -- The X and Y coordinates are swapped, and the (real) Y
+-        -- coordinate has to be inverted.
++    end
++end
++
++local adjustAbsEvt = function(self, ev)
++    if ev.type == EV_ABS then
+         if ev.code == ABS_X then
+             ev.code = ABS_Y
+             ev.value = (wacom_height - ev.value) * wacom_scale_y
+@@ -60,18 +95,29 @@ local adjustTouchEvt = function(self, ev)
+     end
+ end
+ 
++
+ function Remarkable:init()
+     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
+-    self.powerd = require("device/remarkable/powerd"):new{device = self}
++    self.powerd = require("device/remarkable/powerd"):new{
++        device = self,
++        capacity_file = self.battery_path,
++        status_file = self.status_path,
++    }
+     self.input = require("device/input"):new{
+         device = self,
+         event_map = require("device/remarkable/event_map"),
+     }
+ 
+-    self.input.open("/dev/input/event0") -- Wacom
+-    self.input.open("/dev/input/event1") -- Touchscreen
+-    self.input.open("/dev/input/event2") -- Buttons
+-    self.input:registerEventAdjustHook(adjustTouchEvt)
++    self.input.open(self.input_wacom) -- Wacom
++    self.input.open(self.input_ts) -- Touchscreen
++    self.input.open(self.input_buttons) -- Buttons
++
++    local scalex = screen_width / self.mt_width
++    local scaley = screen_height / self.mt_height
++
++    self.input:registerEventAdjustHook(adjustAbsEvt)
++    self.input:registerEventAdjustHook(self.adjustTouchEvent, {mt_scale_x=scalex, mt_scale_y=scaley})
++
+     -- USB plug/unplug, battery charge/not charging are generated as fake events
+     self.input.open("fake_events")
+ 
+@@ -95,28 +141,49 @@ function Remarkable:setDateTime(year, month, day, hour, min, sec)
+     return os.execute(command) == 0
+ end
+ 
+-function Remarkable:_clearScreen()
+-    self.screen:clear()
+-    self.screen:refreshFull()
++function Remarkable1:suspend()
++    os.execute("systemctl suspend")
+ end
+ 
+-function Remarkable:suspend()
+-    self:_clearScreen()
++function Remarkable2:suspend()
+     os.execute("systemctl suspend")
++    -- While device is suspended, when the user presses the power button and wakes up the device,
++    -- a "Power" event is NOT sent.
++    -- So we schedule a manual `UIManager:resume` call just far enough in the future that it won't
++    -- trigger before the `systemctl suspend` command finishes suspending the device
++    local UIManager = require("ui/uimanager")
++    UIManager:scheduleIn(0.5, function()
++        UIManager:resume()
++    end)
+ end
+ 
+ function Remarkable:resume()
+ end
+ 
+ function Remarkable:powerOff()
+-    self:_clearScreen()
++    self.screen:clear()
++    self.screen:refreshFull()
+     os.execute("systemctl poweroff")
+ end
+ 
+ function Remarkable:reboot()
+-    self:_clearScreen()
+     os.execute("systemctl reboot")
+ end
+ 
+-return Remarkable
++local f = io.open("/sys/devices/soc0/machine")
++if not f then error("missing sysfs entry for a remarkable") end
++
++local deviceType = f:read("*line")
++f:close()
++
++logger.info("deviceType: ", deviceType)
+ 
++if deviceType == "reMarkable 2.0" then
++    if not os.getenv("RM2FB_SHIM") then
++        error("reMarkable2 requires RM2FB to work (https://github.com/ddvk/remarkable2-framebuffer)")
++    end
++
++    return Remarkable2
++else
++    return Remarkable1
++end

--- a/package/micro/package
+++ b/package/micro/package
@@ -5,7 +5,7 @@
 pkgnames=(micro)
 pkgdesc="a modern and intuitive terminal-based text editor"
 url=https://micro-editor.github.io/
-pkgver=2.0.8-1
+pkgver=2.0.8-2
 timestamp=2020-10-06T22:44Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish)
-pkgver=2.0.1~beta-3
-timestamp=2020-12-06T20:09Z
+pkgver=2.0.3~beta-1
+timestamp=2021-01-07T03:28Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
-source=(https://github.com/Eeems/oxide/releases/download/v2.0.1-beta/oxide.zip)
-sha256sums=(02c0561b0478d4108916d618ad1bced77e549121f1e2770d35314b94c2852dfe)
+source=(https://github.com/Eeems/oxide/releases/download/v2.0.3-beta/oxide.zip)
+sha256sums=(c35f62d33ec954d88fc36fd9853bcb37e54ac45b936364f4014bf6d4b69725e1)
 
 erode() {
     pkgdesc="Task manager"

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,7 +5,7 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.1-12
+pkgver=0.9.1-13
 timestamp=2020-12-28T17:53Z
 section=readers
 maintainer="Linus K. <linus@cosmos-ink.net>"

--- a/package/reboot-guard/package
+++ b/package/reboot-guard/package
@@ -5,7 +5,7 @@
 pkgnames=(reboot-guard)
 pkgdesc="Block systemd-initiated poweroff/reboot/halt until configurable condition checks pass"
 url=https://github.com/stephanritscher/reboot-guard
-pkgver=1.0.1-3
+pkgver=1.0.1-4
 timestamp=2020-05-04T06:16Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/recrossable/package
+++ b/package/recrossable/package
@@ -5,7 +5,7 @@
 pkgnames=(recrossable)
 pkgdesc="Solve crossword puzzles"
 url=https://github.com/sandsmark/recrossable
-pkgver=0.0.0-2
+pkgver=0.0.0-3
 timestamp=2020-10-05T08:43Z
 section=games
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/remarkable-splash/package
+++ b/package/remarkable-splash/package
@@ -5,7 +5,7 @@
 pkgnames=(remarkable-splash)
 pkgdesc="show a splashscreen + shutdown replacement that does not clear the screen"
 url=https://github.com/ddvk/remarkable-splash
-pkgver=1.0-1
+pkgver=1.0-2
 timestamp=2019-12-31T10:07Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/restream/package
+++ b/package/restream/package
@@ -26,8 +26,17 @@ package() {
     install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/restream
 }
 
-postinstall() {
-    printf "This app is only the device-side half of reStream. The companion script for consuming the output of this app can be found at https://github.com/rien/reStream\n"
-    printf "The script may need to be adjusted to target /opt/bin/restream instead of \$HOME/restream, or you can create a symlink on your device with\n"
-    printf "ln -s /opt/bin/restream \$HOME/restream\n"
+configure() {
+    cat << 'MSG'
+
+This app is only the device-side half of reStream. The companion script for
+consuming the output of this app can be found at
+<https://github.com/rien/reStream>.
+
+The script may need to be adjusted to target '/opt/bin/restream' instead of
+'$HOME/restream', or you can create a symlink on your device with:
+
+    ln -s /opt/bin/restream $HOME/restream
+
+MSG
 }

--- a/package/restream/package
+++ b/package/restream/package
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(restream)
+pkgdesc="A binary framebuffer capture tool for the reStream script"
+url=https://github.com/rien/reStream
+pkgver=0.0.0-1
+timestamp=2021-01-01T13:55:28Z
+section=utils
+maintainer="Dan Shick <dan.shick@gmail.com>"
+license=MIT
+conflicts=(rm2fb)
+image=rust:v1.2.1
+source=(https://github.com/rien/reStream/archive/c41b87778953513cd52d9c58b3cc5ce52825700e.zip)
+sha256sums=(89da0932f17a546f194b816eb28a83f84f2484a1508d545bfce2115908248fc3)
+
+build() {
+    # Fall back to system-wide config
+    rm .cargo/config
+
+    cargo build --release --bin restream
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/restream
+}
+
+postinstall() {
+    printf "This app is only the device-side half of reStream. The companion script for consuming the output of this app can be found at https://github.com/rien/reStream\n"
+    printf "The script may need to be adjusted to target /opt/bin/restream instead of \$HOME/restream, or you can create a symlink on your device with\n"
+    printf "ln -s /opt/bin/restream \$HOME/restream\n"
+}

--- a/package/retris/package
+++ b/package/retris/package
@@ -5,7 +5,7 @@
 pkgnames=(retris)
 pkgdesc="Tetris game"
 url=https://github.com/LinusCDE/retris
-pkgver=0.6.1-1
+pkgver=0.6.1-2
 timestamp=2020-12-24T12:32Z
 section=games
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -20,7 +20,6 @@ build() {
     rm .cargo/config
 
     cargo build --release
-    arm-linux-gnueabihf-strip target/armv7-unknown-linux-gnueabihf/release/retris
 }
 
 package() {

--- a/package/rm2-suspend-fix/package
+++ b/package/rm2-suspend-fix/package
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(rm2-suspend-fix)
+pkgdesc="Fix issue where suspend breaks networking on the reMarkable 2"
+url=https://toltec-dev.org/
+pkgver=0.0.0-1
+timestamp=2021-01-04T22:40Z
+section=utils
+maintainer="Eeems <eeems@eeems.email>"
+license=MIT
+
+source=(rm2-suspend-fix.sh)
+sha256sums=(SKIP)
+
+package() {
+    install -D -m 744 -t "$pkgdir"/lib/systemd/system-sleep/ "$srcdir"/rm2-suspend-fix.sh
+}

--- a/package/rm2-suspend-fix/rm2-suspend-fix.sh
+++ b/package/rm2-suspend-fix/rm2-suspend-fix.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Inspired by https://blog.christophersmart.com/2016/05/11/running-scripts-before-and-after-suspend-with-systemd/comment-page-1/
+
+if [[ "${1}" == "pre" ]]; then
+    rmmod brcmfmac
+elif [[ "${1}" == "post" ]]; then
+    modprobe brcmfmac
+fi

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -8,7 +8,7 @@ maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 pkgdesc="Remarkable2 Framebuffer"
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1.0.0-3
+pkgver=1.0.0-5
 section=utils
 version=1.0.0
 image=qt:v1.1
@@ -30,7 +30,6 @@ sha256sums=(
 build() {
     qmake
     make
-    arm-linux-gnueabihf-strip src/client/librm2fb_client.so.1.0.0
 }
 
 package() {
@@ -59,7 +58,7 @@ preremove() {
         systemctl disable rm2fb --now
     fi
     echo -n "make sure "
-    if ! systemctl --quiet is-enabled xochtil; then
+    if ! is-enabled xochitl.service; then
         echo "to re-enable xochitl with 'systemctl enable xochitl --now'"
         echo -n "and "
     fi

--- a/package/rmkit/genie.service
+++ b/package/rmkit/genie.service
@@ -1,0 +1,17 @@
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=Gesture launcher
+After=opt.mount
+StartLimitInterval=30
+StartLimitBurst=5
+
+[Service]
+ExecStart=/opt/bin/genie /opt/etc/genie.conf
+Restart=on-failure
+RestartSec=5
+Environment="HOME=/home/root"
+
+[Install]
+WantedBy=multi-user.target

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -2,18 +2,20 @@
 # Copyright (c) 2020 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-pkgnames=(harmony mines nao remux simple)
-timestamp=2020-10-10T01:41+00:00
+pkgnames=(genie harmony mines nao remux simple)
+timestamp=2021-01-05T14:03-08:00
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 
 image=python:v1.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/91b71447f26f23a7677f0f2b6e33b0d91fa3dc12.zip
+    https://github.com/rmkit-dev/rmkit/archive/eafbc08fc890dfa9130455d59425bdbc32e230a8.zip
     remux.service
+    genie.service
 )
 sha256sums=(
-    76179badd00b5656581997c0aec723277d89fdb6aec85ac8886314b8808e190c
+    65623d8684eae192a58da94379d11a637c9cdb9b939964a82e06dbc4216ea22e
+    SKIP
     SKIP
 )
 
@@ -22,10 +24,37 @@ build() {
     make
 }
 
+genie() {
+    pkgdesc="Gesture engine that connects commands to gestures"
+    url="https://rmkit.dev/apps/genie"
+    pkgver=0.1.0-1
+    section=utils
+
+    package() {
+        install -D -m 755 "$srcdir"/src/build/genie "$pkgdir"/opt/bin/genie
+        install -D -m 644 "$srcdir"/genie.service "$pkgdir"/lib/systemd/system/genie.service
+        install -D -m 644 "$srcdir"/src/genie/example.conf "$pkgdir"/opt/etc/genie.example.conf
+    }
+
+    configure() {
+        systemctl daemon-reload
+        echo "Run 'systemctl enable genie --now' to enable genie"
+    }
+
+    preremove() {
+        echo "Disabling $pkgname"
+        systemctl disable --now "$pkgname"
+    }
+
+    postremove() {
+        systemctl daemon-reload
+    }
+}
+
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.1.0-4
+    pkgver=0.1.0-5
     section=drawing
 
     package() {
@@ -43,7 +72,7 @@ harmony() {
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.1.0-3
+    pkgver=0.1.0-4
     section=games
 
     package() {
@@ -57,7 +86,7 @@ mines() {
 nao() {
     pkgdesc="Nao Package Manager: opkg UI built with SAS"
     url="https://rmkit.dev/apps/nao"
-    pkgver=0.1.0-3
+    pkgver=0.1.0-4
     section=utils
     depends=(simple)
 
@@ -72,7 +101,7 @@ nao() {
 remux() {
     pkgdesc="App launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.4-1
+    pkgver=0.1.5-1
     section=launchers
 
     package() {
@@ -104,7 +133,7 @@ remux() {
 simple() {
     pkgdesc="Simple app script for writing scripted applications"
     url="https://rmkit.dev/apps/sas"
-    pkgver=0.1.0-2
+    pkgver=0.1.0-3
     section=utils
 
     package() {

--- a/package/rmservewacominput/package
+++ b/package/rmservewacominput/package
@@ -5,7 +5,7 @@
 pkgnames=(rmservewacominput)
 pkgdesc="Serve pen input on port 33333"
 url=https://github.com/LinusCDE/rmWacomToMouse
-pkgver=0.2.5-8
+pkgver=0.2.5-9
 timestamp=2020-09-06T23:23Z
 section=utils
 maintainer="Linus K. <linus@cosmos-ink.net>"

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,7 +5,7 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Toltec installation script"
 url=https://toltec-dev.org/
-pkgver=0.0.0-1
+pkgver=0.0.1-2
 timestamp=2020-12-27T18:48Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/vnsee/package
+++ b/package/vnsee/package
@@ -5,7 +5,7 @@
 pkgnames=(vnsee)
 pkgdesc="VNC client allowing you to use the device as a second screen"
 url=https://github.com/matteodelabre/vnsee
-pkgver=0.3.0-1
+pkgver=0.3.0-2
 timestamp=2020-10-23T14:02Z
 section=utils
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -5,7 +5,7 @@
 pkgnames=(whiteboard-hypercard)
 pkgdesc="Real-time collaboration, drawing or whiteboarding"
 url=https://github.com/fenollp/reMarkable-tools
-pkgver=0.3.0-1
+pkgver=0.3.0-2
 timestamp=2020-09-23T18:01Z
 section=drawing
 maintainer="Pierre Fenoll <pierrefenoll@gmail.com>"
@@ -25,7 +25,6 @@ build() {
     cd marauder
     rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
     cargo build --release --bin whiteboard --locked
-    arm-linux-gnueabihf-strip target/armv7-unknown-linux-gnueabihf/release/whiteboard
 }
 
 package() {

--- a/package/xochitl/package
+++ b/package/xochitl/package
@@ -5,7 +5,7 @@
 pkgnames=(xochitl)
 pkgdesc="Read documents and take notes"
 url=https://remarkable.com
-pkgver=0.0.0-1
+pkgver=0.0.0-2
 timestamp=2020-09-24T18:48Z
 section=readers
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -21,35 +21,13 @@ set -eE
 [[ -z $wget_path ]] && wget_path=/home/root/.local/bin/wget
 
 # Path for the systemd unit that mounts Entware to /opt
-[[ -z $old_systemd_mount_path ]] && old_systemd_mount_path=/etc/systemd/system/opt.mount
 [[ -z $systemd_mount_path ]] && systemd_mount_path=/lib/systemd/system/opt.mount
 
 # Path where the actual Entware distribution resides (will be mounted to /opt)
 [[ -z $entware_path ]] && entware_path=/home/root/.entware
 
-# Find out used branch or get default one
-get-branch() {
-    local opkg_conf=$entware_path/etc/opkg.conf
-    # shellcheck disable=SC2002
-    branch=$(cat "$opkg_conf" | grep "^src/gz" | while read -r line; do
-        # Is this the toltec repo?
-        if [[ "$(echo "$line" | awk '{print $2}')" == "toltec" ]]; then
-            local url
-            url=$(echo "$line" | awk '{print $3}')
-            if ! echo "$url" | grep -q https://toltec-dev.org/; then
-                # If it's the wrong domain skip, we don't know how to get the branch
-                continue
-            fi
-            echo "${url/'https://toltec-dev.org/'/}"
-            return
-        fi
-    done)
-    # Default to stable if there was no result
-    [[ "$branch" != "" ]] && echo "$branch" || echo stable
-}
-
 # Toltec branch to use for this install - you almost always want 'stable'
-[[ -z $toltec_branch ]] && toltec_branch=$(get-branch)
+[[ -z $toltec_branch ]] && toltec_branch="stable"
 
 # Remove all temporary files
 cleanup() {
@@ -128,18 +106,6 @@ wget-bootstrap() {
 entware-mount() {
     mkdir -p /opt
     mkdir -p "$entware_path"
-
-    if [[ ! -f $old_systemd_mount_path ]] && [[ ! -f $systemd_mount_path ]]; then
-        # The user was probably using https://github.com/Evidlo/remarkable_entware
-        # before switching to toltec. Removing old .mount file to prevent duplicate files
-        log "Updating opt.mount location"
-
-        if systemctl -q is-enabled opt.mount; then
-            # Remove path to old file if still symlinked
-            systemctl disable opt.mount
-        fi
-        rm $old_systemd_mount_path
-    fi
 
     # Create systemd mount unit to mount over /opt on reboot
     cat > "$systemd_mount_path" << UNIT

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -21,13 +21,35 @@ set -eE
 [[ -z $wget_path ]] && wget_path=/home/root/.local/bin/wget
 
 # Path for the systemd unit that mounts Entware to /opt
+[[ -z $old_systemd_mount_path ]] && old_systemd_mount_path=/etc/systemd/system/opt.mount
 [[ -z $systemd_mount_path ]] && systemd_mount_path=/lib/systemd/system/opt.mount
 
 # Path where the actual Entware distribution resides (will be mounted to /opt)
 [[ -z $entware_path ]] && entware_path=/home/root/.entware
 
+# Find out used branch or get default one
+get-branch() {
+    local opkg_conf=$entware_path/etc/opkg.conf
+    # shellcheck disable=SC2002
+    branch=$(cat "$opkg_conf" | grep "^src/gz" | while read -r line; do
+        # Is this the toltec repo?
+        if [[ "$(echo "$line" | awk '{print $2}')" == "toltec" ]]; then
+            local url
+            url=$(echo "$line" | awk '{print $3}')
+            if ! echo "$url" | grep -q https://toltec-dev.org/; then
+                # If it's the wrong domain skip, we don't know how to get the branch
+                continue
+            fi
+            echo "${url/'https://toltec-dev.org/'/}"
+            return
+        fi
+    done)
+    # Default to stable if there was no result
+    [[ "$branch" != "" ]] && echo "$branch" || echo stable
+}
+
 # Toltec branch to use for this install - you almost always want 'stable'
-[[ -z $toltec_branch ]] && toltec_branch="stable"
+[[ -z $toltec_branch ]] && toltec_branch=$(get-branch)
 
 # Remove all temporary files
 cleanup() {
@@ -106,6 +128,18 @@ wget-bootstrap() {
 entware-mount() {
     mkdir -p /opt
     mkdir -p "$entware_path"
+
+    if [[ ! -f $old_systemd_mount_path ]] && [[ ! -f $systemd_mount_path ]]; then
+        # The user was probably using https://github.com/Evidlo/remarkable_entware
+        # before switching to toltec. Removing old .mount file to prevent duplicate files
+        log "Updating opt.mount location"
+
+        if systemctl -q is-enabled opt.mount; then
+            # Remove path to old file if still symlinked
+            systemctl disable opt.mount
+        fi
+        rm $old_systemd_mount_path
+    fi
 
     # Create systemd mount unit to mount over /opt on reboot
     cat > "$systemd_mount_path" << UNIT

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -8,20 +8,19 @@
 # Common functions used by the install scripts
 #
 
-# Check whether a systemd unit exists and is enabled
+# Check whether a systemd unit exists and is in an enabled-like state
+# ("enabled", "enabled-runtime", "alias", "static", "indirect", "generated"
+# or "transient")
 #
 # Arguments:
 #
-# $1 - Full name of the systemd unit, e.g. "xochitl.service"
+# $1 - Name of the systemd unit, e.g. "xochitl.service" or "xochitl"
 #
 # Exit code:
 #
 # 0 if the unit exists and is enabled, 1 otherwise
 is-enabled() {
-    # Note that we must invert the condition so that the exit code indicates
-    # a failure when the unit exists and is disabled or when the unit does
-    # not exist
-    ! systemctl list-unit-files "$1" | awk "/$1/{exit \$2 == \"enabled\"}"
+    systemctl --quiet is-enabled "$1" 2> /dev/null
 }
 
 # Get a list of systemd units with which the given unit conflicts

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -148,6 +148,16 @@ for pkgname in "${pkgnames[@]}"; do
             # Run packaging script
             package
 
+            section "Stripping $pkgname"
+            docker container run --interactive --rm \
+                --mount type=bind,src="$(realpath "$pkgdir")",dst=/pkg \
+                "$(image-name "${image:-base:v1.2.2}")" /bin/bash \
+                << "SCRIPT"
+find /pkg -print0 -type f | xargs --null "${CROSS_COMPILE}strip" --strip-all &> /dev/null || true
+SCRIPT
+            find "$pkgdir" -print0 -type f | xargs --null strip --strip-all &> /dev/null || true
+
+            section "Finalizing package $pkgname"
             # Show package contents
             if command -v tree &> /dev/null; then
                 tree -np "$pkgdir" | tail +2


### PR DESCRIPTION
Tooling changes:

* Make `stable` the default branch.
* Strip binaries by default.
* Use `systemctl is-enabled` instead of `systemctl list-unit-files` to see whether a unit is enabled or not.

~~Installer changes:~~

* ~~Improve migration path from remarkable\_entware regarding the location of the `opt.mount` configuration file.~~
* ~~Keep existing branch configuration if an install of Toltec already exists.~~

Updated packages (not listing the packages that were only updated because of the strip changes):

* chessmarkable 0.5.1-1 → 0.6.0-2
* koreader 2020.10-2 → 2020.12-2
* oxide 2.0.1\~beta-3 → 2.0.3\~beta-1
* fret 2.0.1\~beta-3 → 2.0.3\~beta-1
* tarnish 2.0.1\~beta-3 → 2.0.3\~beta-1
* erode 2.0.1\~beta-3 → 2.0.3\~beta-1
* rot 2.0.1\~beta-3 → 2.0.3\~beta-1
* rm2fb 1.0.0-3 → 1.0.0-5
* remux 0.1.4-1 → 0.1.5-1

New packages:

* keywriter 0.1.0-1
* restream 0.0.0-1
* rm2-suspend-fix 0.0.0-1
* genie 0.1.0-1