### PR TITLE
Backport KOReader support for reMarkable 2

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -24,6 +24,7 @@ sha256sums=(
 
 prepare() {
     patch -p1 -d"$srcdir" < "$srcdir"/rm2-support.patch
+    rm "$srcdir"/rm2-support.patch
 }
 
 package() {

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2020.12-1
+pkgver=2020.12-2
 timestamp=2020-10-10T20:13Z
 section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -13,8 +13,18 @@ license=AGPL-3.0-or-later
 depends=(fbink fbdepth)
 
 _srcver="v${pkgver%-*}"
-source=("https://build.koreader.rocks/download/stable/$_srcver/koreader-remarkable-$_srcver.zip")
-sha256sums=(38db8f3895472828d7c1d63fc54db426135a8dbf8425633e299a1a9abfdb69b2)
+source=(
+    "https://build.koreader.rocks/download/stable/$_srcver/koreader-remarkable-$_srcver.zip"
+    rm2-support.patch
+)
+sha256sums=(
+    38db8f3895472828d7c1d63fc54db426135a8dbf8425633e299a1a9abfdb69b2
+    SKIP
+)
+
+prepare() {
+    patch -p1 -d"$srcdir" < "$srcdir"/rm2-support.patch
+}
 
 package() {
     install -d "$pkgdir"/opt/koreader
@@ -32,6 +42,7 @@ package() {
 configure() {
     echo "KOReader has an outstanding bug where it doesn't resize the screen properly when returning to Oxide. See Oxide's release notes for a workaround."
 }
+
 postremove() {
     # Check to see if tarnish is running and rot is available
     # shellcheck disable=SC2009

--- a/package/koreader/rm2-support.patch
+++ b/package/koreader/rm2-support.patch
@@ -1,0 +1,210 @@
+diff --git a/frontend/device/remarkable/device.lua b/frontend/device/remarkable/device.lua
+index 3589258d..de5e37b7 100644
+--- a/frontend/device/remarkable/device.lua
++++ b/frontend/device/remarkable/device.lua
+@@ -1,11 +1,24 @@
+ local Generic = require("device/generic/device") -- <= look at this file!
++local TimeVal = require("ui/timeval")
+ local logger = require("logger")
+ 
+ local function yes() return true end
+ local function no() return false end
+ 
++local EV_ABS = 3
++local ABS_X = 00
++local ABS_Y = 01
++local ABS_MT_POSITION_X = 53
++local ABS_MT_POSITION_Y = 54
++-- Resolutions from libremarkable src/framebuffer/common.rs
++local screen_width = 1404 -- unscaled_size_check: ignore
++local screen_height = 1872 -- unscaled_size_check: ignore
++local wacom_width = 15725 -- unscaled_size_check: ignore
++local wacom_height = 20967 -- unscaled_size_check: ignore
++local wacom_scale_x = screen_width / wacom_width
++local wacom_scale_y = screen_height / wacom_height
++
+ local Remarkable = Generic:new{
+-    model = "reMarkable",
+     isRemarkable = yes,
+     hasKeys = yes,
+     needsScreenRefreshAfterResume = no,
+@@ -17,39 +30,61 @@ local Remarkable = Generic:new{
+     display_dpi = 226,
+     -- Despite the SoC supporting it, it's finicky in practice (#6772)
+     canHWInvert = no,
+-    home_dir = "/mnt/root",
++    home_dir = "/home/root",
+ }
+ 
+-local EV_ABS = 3
+-local ABS_X = 00
+-local ABS_Y = 01
+-local ABS_MT_POSITION_X = 53
+-local ABS_MT_POSITION_Y = 54
+--- Resolutions from libremarkable src/framebuffer/common.rs
+-local screen_width = 1404 -- unscaled_size_check: ignore
+-local screen_height = 1872 -- unscaled_size_check: ignore
+-local wacom_width = 15725 -- unscaled_size_check: ignore
+-local wacom_height = 20967 -- unscaled_size_check: ignore
+-local wacom_scale_x = screen_width / wacom_width
+-local wacom_scale_y = screen_height / wacom_height
+-local mt_width = 767 -- unscaled_size_check: ignore
+-local mt_height = 1023 -- unscaled_size_check: ignore
+-local mt_scale_x = screen_width / mt_width
+-local mt_scale_y = screen_height / mt_height
+-local adjustTouchEvt = function(self, ev)
++local Remarkable1 = Remarkable:new{
++    model = "reMarkable",
++    mt_width = 767, -- unscaled_size_check: ignore
++    mt_height = 1023, -- unscaled_size_check: ignore
++    input_wacom = "/dev/input/event0",
++    input_ts = "/dev/input/event1",
++    input_buttons = "/dev/input/event2",
++    battery_path = "/sys/class/power_supply/bq27441-0/capacity",
++    status_path = "/sys/class/power_supply/bq27441-0/status",
++}
++
++function Remarkable1:adjustTouchEvent(ev, by)
++    if ev.type == EV_ABS then
++        ev.time = TimeVal:now()
++        -- Mirror X and Y and scale up both X & Y as touch input is different res from
++        -- display
++        if ev.code == ABS_MT_POSITION_X then
++            ev.value = (Remarkable1.mt_width - ev.value) *  by.mt_scale_x
++        end
++        if ev.code == ABS_MT_POSITION_Y then
++            ev.value = (Remarkable1.mt_height - ev.value) * by.mt_scale_y
++        end
++    end
++end
++
++local Remarkable2 = Remarkable:new{
++    model = "reMarkable 2",
++    mt_width = 1403, -- unscaled_size_check: ignore
++    mt_height = 1871, -- unscaled_size_check: ignore
++    input_wacom = "/dev/input/event1",
++    input_ts = "/dev/input/event2",
++    input_buttons = "/dev/input/event0",
++    battery_path = "/sys/class/power_supply/max77818_battery/capacity",
++    status_path = "/sys/class/power_supply/max77818-charger/status",
++}
++
++function Remarkable2:adjustTouchEvent(ev, by)
++    ev.time = TimeVal:now()
+     if ev.type == EV_ABS then
+-        -- Mirror X and scale up both X & Y as touch input is different res from
++        -- Mirror Y and scale up both X & Y as touch input is different res from
+         -- display
+         if ev.code == ABS_MT_POSITION_X then
+-            ev.value = (mt_width - ev.value) * mt_scale_x
++            ev.value = (ev.value) * by.mt_scale_x
+         end
+         if ev.code == ABS_MT_POSITION_Y then
+-            ev.value = (mt_height - ev.value) * mt_scale_y
++            ev.value = (Remarkable2.mt_height - ev.value) * by.mt_scale_y
+         end
+-        -- The Wacom input layer is non-multi-touch and
+-        -- uses its own scaling factor.
+-        -- The X and Y coordinates are swapped, and the (real) Y
+-        -- coordinate has to be inverted.
++    end
++end
++
++local adjustAbsEvt = function(self, ev)
++    if ev.type == EV_ABS then
+         if ev.code == ABS_X then
+             ev.code = ABS_Y
+             ev.value = (wacom_height - ev.value) * wacom_scale_y
+@@ -60,18 +95,29 @@ local adjustTouchEvt = function(self, ev)
+     end
+ end
+ 
++
+ function Remarkable:init()
+     self.screen = require("ffi/framebuffer_mxcfb"):new{device = self, debug = logger.dbg}
+-    self.powerd = require("device/remarkable/powerd"):new{device = self}
++    self.powerd = require("device/remarkable/powerd"):new{
++        device = self,
++        capacity_file = self.battery_path,
++        status_file = self.status_path,
++    }
+     self.input = require("device/input"):new{
+         device = self,
+         event_map = require("device/remarkable/event_map"),
+     }
+ 
+-    self.input.open("/dev/input/event0") -- Wacom
+-    self.input.open("/dev/input/event1") -- Touchscreen
+-    self.input.open("/dev/input/event2") -- Buttons
+-    self.input:registerEventAdjustHook(adjustTouchEvt)
++    self.input.open(self.input_wacom) -- Wacom
++    self.input.open(self.input_ts) -- Touchscreen
++    self.input.open(self.input_buttons) -- Buttons
++
++    local scalex = screen_width / self.mt_width
++    local scaley = screen_height / self.mt_height
++
++    self.input:registerEventAdjustHook(adjustAbsEvt)
++    self.input:registerEventAdjustHook(self.adjustTouchEvent, {mt_scale_x=scalex, mt_scale_y=scaley})
++
+     -- USB plug/unplug, battery charge/not charging are generated as fake events
+     self.input.open("fake_events")
+ 
+@@ -95,28 +141,49 @@ function Remarkable:setDateTime(year, month, day, hour, min, sec)
+     return os.execute(command) == 0
+ end
+ 
+-function Remarkable:_clearScreen()
+-    self.screen:clear()
+-    self.screen:refreshFull()
++function Remarkable1:suspend()
++    os.execute("systemctl suspend")
+ end
+ 
+-function Remarkable:suspend()
+-    self:_clearScreen()
++function Remarkable2:suspend()
+     os.execute("systemctl suspend")
++    -- While device is suspended, when the user presses the power button and wakes up the device,
++    -- a "Power" event is NOT sent.
++    -- So we schedule a manual `UIManager:resume` call just far enough in the future that it won't
++    -- trigger before the `systemctl suspend` command finishes suspending the device
++    local UIManager = require("ui/uimanager")
++    UIManager:scheduleIn(0.5, function()
++        UIManager:resume()
++    end)
+ end
+ 
+ function Remarkable:resume()
+ end
+ 
+ function Remarkable:powerOff()
+-    self:_clearScreen()
++    self.screen:clear()
++    self.screen:refreshFull()
+     os.execute("systemctl poweroff")
+ end
+ 
+ function Remarkable:reboot()
+-    self:_clearScreen()
+     os.execute("systemctl reboot")
+ end
+ 
+-return Remarkable
++local f = io.open("/sys/devices/soc0/machine")
++if not f then error("missing sysfs entry for a remarkable") end
++
++local deviceType = f:read("*line")
++f:close()
++
++logger.info("deviceType: ", deviceType)
+ 
++if deviceType == "reMarkable 2.0" then
++    if not os.getenv("RM2FB_SHIM") then
++        error("reMarkable2 requires RM2FB to work (https://github.com/ddvk/remarkable2-framebuffer)")
++    end
++
++    return Remarkable2
++else
++    return Remarkable1
++end


### PR DESCRIPTION
This patch contains the changes from koreader/koreader#6992, koreader/koreader#7066, and koreader/koreader#7065, which add support for reMarkable 2. They are expected to land in the future 2021.01 release.