### PR TITLE
[issue->pr] how-to-enable says to disable shutdown.target

### DIFF
--- a/package/draft/package
+++ b/package/draft/package
@@ -5,7 +5,7 @@
 pkgnames=(draft)
 pkgdesc="Launcher which wraps around the standard interface"
 url=https://github.com/dixonary/draft-reMarkable
-pkgver=0.2.0-16
+pkgver=0.2.0-17
 timestamp=2020-07-20T10:23Z
 section=launchers
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish)
-pkgver=2.0.3~beta-1
+pkgver=2.0.3~beta-2
 timestamp=2021-01-07T03:28Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -101,7 +101,7 @@ nao() {
 remux() {
     pkgdesc="App launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.5-1
+    pkgver=0.1.5-2
     section=launchers
 
     package() {

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -48,7 +48,7 @@ get-conflicts() {
 # Commands to run to achieve the desired result
 how-to-enable() {
     for conflict in $(get-conflicts "$1"); do
-        if is-enabled "$conflict"; then
+        if is-enabled "$conflict" && echo "$conflict" | grep -q '\.service$'; then
             echo "$ systemctl disable --now ${conflict/.service/}"
         fi
     done

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -34,7 +34,7 @@ is-enabled() {
 # List of conflicting units
 get-conflicts() {
     systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}' \
-        | awk 'BEGIN { ORS=" " }; { for(i = 1; i <= NF; i++) if($i != "shutdown.target") print $i }'
+        |  sed 's|\bshutdown.target\b||'
 }
 
 # Print instructions about how to enable a given systemd service and disable

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -34,7 +34,7 @@ is-enabled() {
 # List of conflicting units
 get-conflicts() {
     systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}' \
-        |  sed 's|\bshutdown.target\b||'
+        | sed 's|\bshutdown.target\b||'
 }
 
 # Print instructions about how to enable a given systemd service and disable

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -33,7 +33,8 @@ is-enabled() {
 #
 # List of conflicting units
 get-conflicts() {
-    systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}'
+    systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}' \
+        | awk 'BEGIN { ORS=" " }; { for(i = 1; i <= NF; i++) if ($i != "shutdown.target") print $i }'
 }
 
 # Print instructions about how to enable a given systemd service and disable
@@ -48,7 +49,7 @@ get-conflicts() {
 # Commands to run to achieve the desired result
 how-to-enable() {
     for conflict in $(get-conflicts "$1"); do
-        if is-enabled "$conflict" && echo "$conflict" | grep -q '\.service$'; then
+        if is-enabled "$conflict"; then
             echo "$ systemctl disable --now ${conflict/.service/}"
         fi
     done

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -34,7 +34,7 @@ is-enabled() {
 # List of conflicting units
 get-conflicts() {
     systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}' \
-        | awk 'BEGIN { ORS=" " }; { for(i = 1; i <= NF; i++) if ($i != "shutdown.target") print $i }'
+        | awk 'BEGIN { ORS=" " }; { for(i = 1; i <= NF; i++) if($i != "shutdown.target") print $i }'
 }
 
 # Print instructions about how to enable a given systemd service and disable

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -33,6 +33,8 @@ is-enabled() {
 #
 # List of conflicting units
 get-conflicts() {
+    # systemd automatically adds a conflict with "shutdown.target" to all
+    # service units (see systemd.service(5), section "Automatic Dependencies")
     systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}' \
         | sed 's|\bshutdown.target\b||'
 }


### PR DESCRIPTION
Continuation of issue #207.

Fix by ignoring all conflicts that are not ending in ".service".

Should we filter in the `get-conflicts()` function instead? The docs of the function don't deny it returning non-service files.