### PR TITLE
Add version link

### DIFF
--- a/scripts/repo-build-web
+++ b/scripts/repo-build-web
@@ -169,7 +169,7 @@ WEBS
             <tr>
                 <td>$href</td>
                 <td>$pkgdesc</td>
-                <td>$pkgver</td>
+                <td><a href='./${pkgid}.ipk'>$pkgver</a></td>
                 <td><a href='https://spdx.org/licenses/$license.html'>$license</a></td>
             </tr>
 WEBS


### PR DESCRIPTION
Make the version number into a download link on the web listing page. This makes it easier to link other people to packages