### PR TITLE
restream: Fix wrong hook name (postinstall → configure)

### DIFF
--- a/package/restream/package
+++ b/package/restream/package
@@ -26,8 +26,17 @@ package() {
     install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/restream
 }
 
-postinstall() {
-    printf "This app is only the device-side half of reStream. The companion script for consuming the output of this app can be found at https://github.com/rien/reStream\n"
-    printf "The script may need to be adjusted to target /opt/bin/restream instead of \$HOME/restream, or you can create a symlink on your device with\n"
-    printf "ln -s /opt/bin/restream \$HOME/restream\n"
+configure() {
+    cat << 'MSG'
+
+This app is only the device-side half of reStream. The companion script for
+consuming the output of this app can be found at
+<https://github.com/rien/reStream>.
+
+The script may need to be adjusted to target '/opt/bin/restream' instead of
+'$HOME/restream', or you can create a symlink on your device with:
+
+    ln -s /opt/bin/restream $HOME/restream
+
+MSG
 }


### PR DESCRIPTION
Also improve the formatting of the message.
This will be backported into the 2020-02 stable merge (#204).