### PR TITLE
Update plato to 0.9.13-1

### DIFF
--- a/package/plato/package
+++ b/package/plato/package
@@ -5,15 +5,15 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.1-13
-timestamp=2020-12-28T17:53Z
+pkgver=0.9.13-1
+timestamp=2021-01-13T23:43Z
 section=readers
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-6.zip)
-sha256sums=(f452189141844beb4ba15439ee440ea861ccfde283e9363ea92518296ea58417)
+source=(https://github.com/LinusCDE/plato/archive/0.9.13-rm-release-7.zip)
+sha256sums=(17718d74066e5cbec043c98b52958a311eb793674751d6b7789b5baff2227f96)
 
 build() {
     # Get needed build packages


### PR DESCRIPTION
- Updated base version from 0.9.1 to 0.9.13
- Added "Ignored Buttons" to main menu

[(Changelog)](https://github.com/LinusCDE/plato/releases/tag/0.9.13-rm-release-7)

The version should most likely function the same on the rM 2 as the release before it. Probably just check that it runs any maybe whether buttons are disabled and the settings saved.

EDIT: One variation the rM 2 should have is that only the "Power" button should be shown in "Disabled Buttons".