### PR TITLE
Stable merge window for week 03 of 2020

### DIFF
--- a/.github/actions/discord-send/action.yml
+++ b/.github/actions/discord-send/action.yml
@@ -1,0 +1,51 @@
+name: Send a Discord message
+description: Send a message to a Discord channel
+inputs:
+    channel:
+        description: Identifier of the channel to send the message to
+        required: true
+    token:
+        description: API access token
+        required: true
+    title:
+        description: Title of the message to send
+        required: true
+    link:
+        description: URL to link the message title to
+        required: true
+    color:
+        description: Color to annotate the message with
+        required: true
+    message:
+        description: Content of the message to send
+        required: true
+runs:
+    using: composite
+    steps:
+        - name: Post to the Discord REST API
+          shell: bash
+          env:
+              MSG_TITLE: ${{ inputs.title }}
+              MSG_LINK: ${{ inputs.link }}
+              MSG_COLOR: ${{ inputs.color }}
+              MSG_VALUE: ${{ inputs.message }}
+          run: |
+            payload="$(jq --null-input --compact-output --monochrome-output \
+                --arg title "$MSG_TITLE" \
+                --arg link "$MSG_LINK" \
+                --arg color "$MSG_COLOR" \
+                --arg message "$MSG_VALUE" \
+                '{
+                    username: "Toltec",
+                    avatar_url: "https://avatars0.githubusercontent.com/u/71158884",
+                    embeds: [{
+                        title: $title,
+                        url: $link,
+                        color: $color,
+                        description: $message,
+                    }]
+                }')"
+            curl --silent --show-error --fail \
+                 --header "Content-Type: application/json" \
+                 --data "$payload" \
+                 'https://discord.com/api/webhooks/${{ inputs.channel }}/${{ inputs.token }}'

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,37 @@
+name: Setup Toltec dependencies
+runs:
+    using: "composite"
+    steps:
+        - name: Install Ubuntu packages
+          shell: bash
+          run: |
+            sudo apt-get update -yq
+            sudo apt-get install -yq bsdtar tree
+        - name: Install shfmt and Shellcheck
+          shell: bash
+          run: |
+            install_dir=/usr/local/bin
+
+            # Install shfmt
+            shfmt_version=v3.2.1
+            shfmt_checksum=43439b996942b53dfafa9b6ff084f394555d049c98fb7ec37978f7668b43e1be
+            sudo curl --location --silent --fail --tlsv1.2 --proto '=https' \
+                --output "$install_dir"/shfmt \
+                https://github.com/mvdan/sh/releases/download/"$shfmt_version"/shfmt_"$shfmt_version"_linux_amd64
+            sha256sum -c <(echo "$shfmt_checksum $install_dir/shfmt") > /dev/null 2>&1
+            sudo chmod a+x "$install_dir"/shfmt
+
+            # Install Shellcheck (Ubuntu’s version is too old)
+            shellcheck_version=v0.7.1
+            shellcheck_checksum=64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8
+            shellcheck_arname=shellcheck.tar.xz
+            curl --location --silent --fail --tlsv1.2 --proto '=https' \
+                --output "$shellcheck_arname" \
+                https://github.com/koalaman/shellcheck/releases/download/"$shellcheck_version"/shellcheck-"$shellcheck_version".linux.x86_64.tar.xz
+            sha256sum -c <(echo "$shellcheck_checksum $shellcheck_arname") > /dev/null 2>&1
+            tar -xf "$shellcheck_arname" --strip-components=1 \
+                shellcheck-"$shellcheck_version"/shellcheck
+            rm "$shellcheck_arname"
+            chmod a+x shellcheck
+            sudo chown root:root shellcheck
+            sudo mv shellcheck "$install_dir"

--- a/.github/actions/sync-repository/action.yml
+++ b/.github/actions/sync-repository/action.yml
@@ -1,0 +1,31 @@
+name: Sync with remote repository
+description: Synchronize packages with a remote repository
+inputs:
+    local-path:
+        description: Path to the directory containing the packages to push
+        required: true
+    ssh-key:
+        description: Private SSH key to access the remote repository
+        required: true
+    ssh-known-hosts:
+        description: Public SSH key of the remote repository
+        required: true
+    remote-path:
+        description: Path to the remote directory to place the packages in
+        required: true
+runs:
+    using: composite
+    steps:
+        - name: rsync packages and index
+          shell: bash
+          run: |
+            mkdir -p private
+            chmod 700 private
+            echo '${{ inputs.ssh-key }}' > private/id_rsa
+            echo '${{ inputs.ssh-known-hosts }}' > private/known_hosts
+            chmod 600 private/*
+            rsync --archive --verbose --compress --delete \
+                -e "ssh -i private/id_rsa -o UserKnownHostsFile=private/known_hosts" \
+                '${{ inputs.local-path }}' \
+                '${{ inputs.remote-path }}'
+            rm -r private

--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -9,5 +9,5 @@ jobs:
         steps:
             - name: Check labels
               run: |
-                [[ "${{ github.base_ref }}" != stable ]] \
-                || [[ "${{ contains(github.event.pull_request.labels.*.name, 'merge') }}" == true ]]
+                [[ '${{ github.base_ref }}' != stable ]] \
+                || [[ '${{ contains(github.event.pull_request.labels.*.name, 'merge') }}' == true ]]

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,33 +8,8 @@ jobs:
         steps:
             - name: Checkout the Git repository
               uses: actions/checkout@v2
-            - name: Install missing tools
-              run: |
-                install_dir=/usr/local/bin
-
-                # Install shfmt
-                shfmt_version=v3.1.2
-                shfmt_checksum=c5794c1ac081f0028d60317454fe388068ab5af7740a83e393515170a7157dce
-                sudo curl --location --silent --fail --tlsv1.2 --proto '=https' \
-                    --output "$install_dir"/shfmt \
-                    https://github.com/mvdan/sh/releases/download/"$shfmt_version"/shfmt_"$shfmt_version"_linux_amd64
-                sha256sum -c <(echo "$shfmt_checksum $install_dir/shfmt") > /dev/null 2>&1
-                sudo chmod a+x "$install_dir"/shfmt
-
-                # Install Shellcheck (Ubuntu’s version is too old)
-                shellcheck_version=v0.7.1
-                shellcheck_checksum=64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8  
-                shellcheck_arname=shellcheck.tar.xz
-                curl --location --silent --fail --tlsv1.2 --proto '=https' \
-                    --output "$shellcheck_arname" \
-                    https://github.com/koalaman/shellcheck/releases/download/"$shellcheck_version"/shellcheck-"$shellcheck_version".linux.x86_64.tar.xz
-                sha256sum -c <(echo "$shellcheck_checksum $shellcheck_arname") > /dev/null 2>&1
-                tar -xf "$shellcheck_arname" --strip-components=1 \
-                    shellcheck-"$shellcheck_version"/shellcheck
-                rm "$shellcheck_arname"
-                chmod a+x shellcheck
-                sudo chown root:root shellcheck
-                sudo mv shellcheck "$install_dir"
+            - name: Setup Toltec environment
+              uses: ./.github/actions/setup
             - name: Check formatting
               run: make format
             - name: Check for erroneous constructs
@@ -46,10 +21,10 @@ jobs:
         steps:
             - name: Checkout the Git repository
               uses: actions/checkout@v2
-            - name: Install missing tools
-              run: sudo apt-get install bsdtar tree
+            - name: Setup Toltec environment
+              uses: ./.github/actions/setup
             - name: Build packages
-              run: make repo
+              run: remote_repo='https://toltec-dev.org/${{ github.base_ref }}' make repo-new
             - name: Save the build output
               uses: actions/upload-artifact@v2
               with:

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -10,21 +10,25 @@ jobs:
         steps:
             - name: Checkout the Git repository
               uses: actions/checkout@v2
-            - name: Install missing tools
-              run: |
-                sudo apt-get install bsdtar tree
+            - name: Setup Toltec dependencies
+              uses: ./.github/actions/setup
             - name: Build packages
               run: |
                 remote_repo="https://toltec-dev.org/stable" make repo
-            - name: Transfer packages and index
-              run: |
-                mkdir -p private
-                chmod 700 private
-                echo "${{ secrets.SSH_PRIVATE_KEY }}" > private/id_rsa
-                echo "${{ secrets.SSH_KNOWN_HOSTS }}" > private/known_hosts
-                chmod 600 private/*
-                rsync -avz \
-                    -e "ssh -i private/id_rsa -o UserKnownHostsFile=private/known_hosts" \
-                    build/repo/ "${{ secrets.REMOTE }}":/srv/toltec/stable
-                scp -i private/id_rsa -o UserKnownHostsFile=private/known_hosts \
-                    scripts/bootstrap/bootstrap "${{ secrets.REMOTE }}":/srv/toltec
+            - name: Sync packages with the remote repository
+              uses: ./.github/actions/sync-repository
+              with:
+                local-path: build/repo/
+                ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+                ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+                remote-path: ${{ secrets.REMOTE }}:/srv/toltec/stable
+            - name: Send notification to Discord
+              continue-on-error: true
+              uses: ./.github/actions/discord-send
+              with:
+                channel: ${{ secrets.DISCORD_STABLE_CHANNEL_ID }}
+                token: ${{ secrets.DISCORD_STABLE_CHANNEL_TOKEN }}
+                title: New Toltec stable update available
+                link: https://toltec-dev.org/stable
+                color: 0x2ea043
+                message: ${{ github.event.head_commit.message }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,19 +10,25 @@ jobs:
         steps:
             - name: Checkout the Git repository
               uses: actions/checkout@v2
-            - name: Install missing tools
-              run: |
-                sudo apt-get install bsdtar tree
+            - name: Setup Toltec dependencies
+              uses: ./.github/actions/setup
             - name: Build packages
               run: |
                 remote_repo="https://toltec-dev.org/testing" make repo
-            - name: Transfer packages and index
-              run: |
-                mkdir -p private
-                chmod 700 private
-                echo "${{ secrets.SSH_PRIVATE_KEY }}" > private/id_rsa
-                echo "${{ secrets.SSH_KNOWN_HOSTS }}" > private/known_hosts
-                chmod 600 private/*
-                rsync -avz \
-                    -e "ssh -i private/id_rsa -o UserKnownHostsFile=private/known_hosts" \
-                    build/repo/ "${{ secrets.REMOTE }}":/srv/toltec/testing
+            - name: Sync packages with the remote repository
+              uses: ./.github/actions/sync-repository
+              with:
+                local-path: build/repo/
+                ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+                ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+                remote-path: ${{ secrets.REMOTE }}:/srv/toltec/testing
+            - name: Send notification to Discord
+              continue-on-error: true
+              uses: ./.github/actions/discord-send
+              with:
+                channel: ${{ secrets.DISCORD_TESTING_CHANNEL_ID }}
+                token: ${{ secrets.DISCORD_TESTING_CHANNEL_TOKEN }}
+                title: New Toltec testing update available
+                link: https://toltec-dev.org/testing
+                color: 0xe3b341
+                message: ${{ github.event.head_commit.message }}

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ Building packages:
                     repository for existing package versions.
     repo-local      Build the repository without using existing archives from
                     the remote repository.
+    repo-new        Build only the new packages in the repository based
+                    on what exists in the remote repository.
     RECIPE          Build packages from the given recipe.
     RECIPE-push     Push built packages from the given recipe to the
                     .cache/opkg directory on the reMarkable.
@@ -42,6 +44,9 @@ repo:
 
 repo-local:
 	./scripts/repo-build -l package build/package build/repo "$$remote_repo"
+
+repo-new:
+	./scripts/repo-build -n package build/package build/repo "$$remote_repo"
 
 repo-check:
 	./scripts/repo-check build/repo

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "cbe83d1ae2d3ef6291a2b57202bb59aace14f2f1849bbdb09552a7419995294a  bootstrap" | sha256sum -c
+$ echo "46f556b06f5624b48e974ae040b6213828eff6aa2cc78618a4d8961a27cdc8b3  bootstrap" | sha256sum -c
 $ bash bootstrap
 ```
 

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,0 +1,3 @@
+## Code of Conduct
+
+Please see [the Toltec organization](https://github.com/toltec-dev/organization/blob/main/docs/code_of_conduct.md)’s code of conduct document.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,17 +11,17 @@ To directly propose changes, the basic procedure is to fork this repository, mak
 When proposing changes, please make sure that you follow the [style guide](#style-guide).
 After you submit your pull request, a maintainer will take time to review your changes, request modifications and then merge your changes into the repository if they fit.
 
-### Common contributions
+### Common Contributions
 
-#### Requesting a package
-
-**TODO**
-
-#### Reporting a bug
+#### Requesting a Package
 
 **TODO**
 
-#### Adding a new package
+#### Reporting a Bug
+
+**TODO**
+
+#### Adding a New Package
 
 See [instructions for creating a package recipe](package.md).
 
@@ -33,15 +33,15 @@ See [instructions for creating a package recipe](package.md).
 * for new packages, submit a pull request with the title: [$PACKAGE][$VERSION] - New Package
 * for updating packages, submit a pull request with the title: [$PACKAGE][$VERSION] - Updated Package
 
-#### Upgrading a package
+#### Upgrading a Package
 
 **TODO**
 
-#### Improving the documentation
+#### Improving the Documentation
 
 **TODO**
 
-### Style guide
+### Style Guide
 
 All contributions must follow the project’s [style guide](../.editorconfig).
 Shell scripts must also comply to [Shellcheck](https://github.com/koalaman/shellcheck).
@@ -52,6 +52,11 @@ You may also check it manually by running `make format` (or `make format-fix` to
 
 Compliance of shell scripts to Shellcheck will also automatically be checked.
 To check it manually, run `make lint` at the root of the repository (you need to have Shellcheck installed on your computer for this to work).
+
+### Code of Conduct
+
+Please note that this project is released with a [Contributor Code of Conduct](docs/code_of_conduct.md).
+By participating in this project you agree to abide by its terms.
 
 ### License
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,3 @@
+## Security Policy
+
+Please see [the Toltec organization](https://github.com/toltec-dev/organization/blob/main/docs/security.md)’s security policy.

--- a/package/calculator/package
+++ b/package/calculator/package
@@ -40,7 +40,6 @@ build() {
 
 package() {
     install -D -m 755 "$srcdir"/Calculator "$pkgdir"/opt/bin/calculator
-
     install -D -m 644 -t "$pkgdir"/opt/etc/draft "$srcdir"/calculator.draft
     install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons "$srcdir"/calculator.png
 }

--- a/package/draft/package
+++ b/package/draft/package
@@ -5,7 +5,7 @@
 pkgnames=(draft)
 pkgdesc="Launcher which wraps around the standard interface"
 url=https://github.com/dixonary/draft-reMarkable
-pkgver=0.2.0-16
+pkgver=0.2.0-17
 timestamp=2020-07-20T10:23Z
 section=launchers
 maintainer="Mattéo Delabre <spam@delab.re>"

--- a/package/koreader/KOReader.oxide
+++ b/package/koreader/KOReader.oxide
@@ -1,0 +1,12 @@
+{
+  "displayName": "KOReader",
+  "description": "An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats",
+  "bin": "/opt/bin/koreader",
+  "icon": "/opt/etc/draft/icons/koreader.png",
+  "type": "foreground",
+  "events": {
+    "pause": "/opt/koreader/fbdepth -d 16 -r 1",
+    "stop": "/opt/koreader/fbdepth -d 16 -r 1",
+    "resume": "/opt/koreader/fbdepth -d 8 -r 1"
+  }
+}

--- a/package/koreader/koreader.draft
+++ b/package/koreader/koreader.draft
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 name=KOReader
-desc=ebook reader
+desc=An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats
 imgFile=koreader
 call=/opt/bin/koreader
 term=killall -9 luajit

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="An ebook reader application supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2020.12-2
+pkgver=2020.12-3
 timestamp=2020-10-10T20:13Z
 section=readers
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -15,10 +15,14 @@ depends=(fbink fbdepth)
 _srcver="v${pkgver%-*}"
 source=(
     "https://build.koreader.rocks/download/stable/$_srcver/koreader-remarkable-$_srcver.zip"
+    koreader.draft
+    KOReader.oxide
     rm2-support.patch
 )
 sha256sums=(
     38db8f3895472828d7c1d63fc54db426135a8dbf8425633e299a1a9abfdb69b2
+    SKIP
+    SKIP
     SKIP
 )
 
@@ -35,19 +39,8 @@ package() {
     ln -s /opt/bin/fbink "$pkgdir"/opt/koreader/fbink
     ln -s /opt/bin/fbdepth "$pkgdir"/opt/koreader/fbdepth
 
-    install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$recipedir"/koreader.draft
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft/ "$srcdir"/koreader.draft
+    install -D -m 644 -t "$pkgdir"/opt/usr/share/applications/ "$srcdir"/KOReader.oxide
     install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons/ "$srcdir"/resources/koreader.png
     install -D -m 755 -t "$pkgdir"/opt/bin/ "$recipedir"/koreader
-}
-
-configure() {
-    echo "KOReader has an outstanding bug where it doesn't resize the screen properly when returning to Oxide. See Oxide's release notes for a workaround."
-}
-
-postremove() {
-    # Check to see if tarnish is running and rot is available
-    # shellcheck disable=SC2009
-    if systemctl list-units --full -all | grep -Fq 'tarnish.service' || [[ "$(ps | grep tarnish | grep -v grep)" != "" ]]; then
-        echo "You may need to manually remove the application entry for KOReader in Oxide."
-    fi
 }

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -9,7 +9,7 @@ maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
 source=(https://github.com/Eeems/oxide/releases/download/v2.1/oxide.zip)
-sha256sums=(79d94a2ac256dc7d01865ec93a63537afc1e8b9870e8789d4583819666b8a339)
+sha256sums=(f3f50688db7a11fab74caeb607f23f26f8315ff1d3ec28566f408d4301af26be)
 
 erode() {
     pkgdesc="Task manager"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -2,23 +2,24 @@
 # Copyright (c) 2020 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-pkgnames=(erode fret oxide rot tarnish)
-pkgver=2.0.3~beta-1
+pkgnames=(erode fret oxide rot tarnish decay)
+pkgver=2.1~beta-1
 timestamp=2021-01-07T03:28Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
-source=(https://github.com/Eeems/oxide/releases/download/v2.0.3-beta/oxide.zip)
-sha256sums=(c35f62d33ec954d88fc36fd9853bcb37e54ac45b936364f4014bf6d4b69725e1)
+source=(https://github.com/Eeems/oxide/releases/download/v2.1/oxide.zip)
+sha256sums=(ca5b58a98242cfaf846545c391dca75dc4d13e443764e656cdc621ce07d091f8)
 
 erode() {
     pkgdesc="Task manager"
     url=https://github.com/Eeems/oxide/tree/master/applications/process-manager
     section=utils
-    depends=(tarnish)
+    depends=("tarnish (= $pkgver)")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/opt/bin/erode
+        install -D -m 644 -t "$pkgdir"/opt/usr/share/applications "$srcdir"/opt/usr/share/applications/codes.eeems.erode.oxide
     }
 }
 
@@ -26,9 +27,11 @@ fret() {
     pkgdesc="Take screenshots"
     url=https://github.com/Eeems/oxide/tree/master/applications/screenshot-tool
     section=utils
+    depends=("tarnish (= $pkgver)")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/opt/bin/fret
+        install -D -m 644 -t "$pkgdir"/opt/usr/share/applications "$srcdir"/opt/usr/share/applications/codes.eeems.fret.oxide
     }
 }
 
@@ -36,13 +39,13 @@ oxide() {
     pkgdesc="Launcher application"
     url=https://github.com/Eeems/oxide/tree/master/applications/launcher
     section=launchers
-    depends=(erode fret tarnish xochitl rot)
+    depends=("erode  (= $pkgver)" "fret (= $pkgver)" "tarnish (= $pkgver)" "rot (= $pkgver)" "decay (= $pkgver)")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/opt/bin/oxide
         install -D -m 644 -t "$pkgdir"/opt/etc "$srcdir"/opt/etc/oxide.conf
+        install -D -m 644 -t "$pkgdir"/opt/usr/share/applications "$srcdir"/opt/usr/share/applications/codes.eeems.oxide.oxide
     }
-
     configure() {
         if ! is-enabled "tarnish.service"; then
             echo ""
@@ -56,9 +59,8 @@ oxide() {
 rot() {
     pkgdesc="Manage Oxide settings through the command line"
     url=https://github.com/Eeems/oxide/tree/master/applications/settings-manager
-    pkgver=1.0.0
     section=utils
-    depends=(tarnish)
+    depends=("tarnish (= $pkgver)")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/opt/bin/rot
@@ -69,25 +71,39 @@ tarnish() {
     pkgdesc="Service managing power states, connectivity and buttons"
     url=https://github.com/Eeems/oxide/tree/master/applications/system-service
     section=utils
+    depends=(xochitl)
 
     package() {
         install -D -m 644 -t "$pkgdir"/etc/dbus-1/system.d "$srcdir"/etc/dbus-1/system.d/codes.eeems.oxide.conf
         install -D -m 644 -t "$pkgdir"/lib/systemd/system "$srcdir"/etc/systemd/system/tarnish.service
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/opt/bin/tarnish
     }
-
     configure() {
         systemctl daemon-reload
     }
-
     preremove() {
-        if systemctl list-units --full -all | grep -Fq 'tarnish.service'; then
-            echo "Disabling $pkgname"
-            systemctl disable --now tarnish
+        if is-active tarnish; then
+            echo "Stopping tarnish"
+            systemctl stop tarnish
+        fi
+        if is-enabled tarnish; then
+            echo "Disabling tarnish"
+            systemctl disable tarnish
         fi
     }
-
     postremove() {
         systemctl daemon-reload
+    }
+}
+
+decay() {
+    pkgdesc="Lockscreen application"
+    url=https://github.com/Eeems/oxide/tree/master/applications/lockscreen
+    section=utils
+    depends=("tarnish (= $pkgver)")
+
+    package() {
+        install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/opt/bin/decay
+        install -D -m 644 -t "$pkgdir"/opt/usr/share/applications "$srcdir"/opt/usr/share/applications/codes.eeems.decay.oxide
     }
 }

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -9,7 +9,7 @@ maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
 source=(https://github.com/Eeems/oxide/releases/download/v2.1/oxide.zip)
-sha256sums=(ca5b58a98242cfaf846545c391dca75dc4d13e443764e656cdc621ce07d091f8)
+sha256sums=(79d94a2ac256dc7d01865ec93a63537afc1e8b9870e8789d4583819666b8a339)
 
 erode() {
     pkgdesc="Task manager"

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,15 +5,15 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.1-13
-timestamp=2020-12-28T17:53Z
+pkgver=0.9.13-1
+timestamp=2021-01-13T23:43Z
 section=readers
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 
 image=rust:v1.2.1
-source=(https://github.com/LinusCDE/plato/archive/0.9.1-rm-release-6.zip)
-sha256sums=(f452189141844beb4ba15439ee440ea861ccfde283e9363ea92518296ea58417)
+source=(https://github.com/LinusCDE/plato/archive/0.9.13-rm-release-7.zip)
+sha256sums=(17718d74066e5cbec043c98b52958a311eb793674751d6b7789b5baff2227f96)
 
 build() {
     # Get needed build packages

--- a/package/rmkit/genie.service
+++ b/package/rmkit/genie.service
@@ -12,6 +12,8 @@ ExecStart=/opt/bin/genie /opt/etc/genie.conf
 Restart=on-failure
 RestartSec=5
 Environment="HOME=/home/root"
+Environment="PATH=/opt/bin:/opt/sbin:/opt/usr/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+
 
 [Install]
 WantedBy=multi-user.target

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -3,18 +3,18 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(genie harmony mines nao remux simple)
-timestamp=2021-01-05T14:03-08:00
+timestamp=2021-01-12T14:03-08:00
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 
 image=python:v1.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/eafbc08fc890dfa9130455d59425bdbc32e230a8.zip
+    https://github.com/rmkit-dev/rmkit/archive/f7f808c28593435f7243a02d0280691345639f1c.zip
     remux.service
     genie.service
 )
 sha256sums=(
-    65623d8684eae192a58da94379d11a637c9cdb9b939964a82e06dbc4216ea22e
+    12c56e9ef48a45376c714e7587a292ffda907f5589a46e2af29d349b9b7873bb
     SKIP
     SKIP
 )
@@ -27,7 +27,7 @@ build() {
 genie() {
     pkgdesc="Gesture engine that connects commands to gestures"
     url="https://rmkit.dev/apps/genie"
-    pkgver=0.1.0-1
+    pkgver=0.1.1-1
     section=utils
 
     package() {
@@ -61,7 +61,6 @@ harmony() {
         install -D -m 755 "$srcdir"/src/build/harmony "$pkgdir"/opt/bin/harmony
         install -D -m 644 "$srcdir"/src/harmony/harmony.draft "$pkgdir"/opt/etc/draft/harmony.draft
         install -D -m 644 "$srcdir"/src/harmony/harmony.png "$pkgdir"/opt/etc/draft/icons/harmony.png
-
     }
 
     configure() {
@@ -79,7 +78,6 @@ mines() {
         install -D -m 755 "$srcdir"/src/build/mines "$pkgdir"/opt/bin/mines
         install -D -m 644 "$srcdir"/src/minesweeper/mines.draft "$pkgdir"/opt/etc/draft/mines.draft
         install -D -m 644 "$srcdir"/src/minesweeper/mines1.png "$pkgdir"/opt/etc/draft/icons/mines.png
-
     }
 }
 
@@ -94,14 +92,13 @@ nao() {
         install -D -m 755 "$srcdir"/src/build/nao.sh "$pkgdir"/opt/bin/nao
         install -D -m 644 "$srcdir"/src/nao/nao.draft "$pkgdir"/opt/etc/draft/nao.draft
         install -D -m 644 "$srcdir"/src/nao/nao.png "$pkgdir"/opt/etc/draft/icons/nao.png
-
     }
 }
 
 remux() {
     pkgdesc="App launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.5-1
+    pkgver=0.1.6-2
     section=launchers
 
     package() {
@@ -133,7 +130,7 @@ remux() {
 simple() {
     pkgdesc="Simple app script for writing scripted applications"
     url="https://rmkit.dev/apps/sas"
-    pkgver=0.1.0-3
+    pkgver=0.1.1-1
     section=utils
 
     package() {

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Copyright (c) 2020 The Toltec Contributors
+# Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
 pkgnames=(toltec-bootstrap)
 pkgdesc="Toltec installation script"
 url=https://toltec-dev.org/
-pkgver=0.0.1-2
-timestamp=2020-12-27T18:48Z
+pkgver=0.0.1-3
+timestamp=2021-01-15T20:15Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/package/xochitl/package
+++ b/package/xochitl/package
@@ -5,7 +5,7 @@
 pkgnames=(xochitl)
 pkgdesc="Read documents and take notes"
 url=https://remarkable.com
-pkgver=0.0.0-2
+pkgver=0.0.0-3
 timestamp=2020-09-24T18:48Z
 section=readers
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -14,8 +14,10 @@ license=Apache-2.0
 source=(
     xochitl.png
     xochitl.draft
+    xochitl.oxide
 )
 sha256sums=(
+    SKIP
     SKIP
     SKIP
 )
@@ -24,4 +26,5 @@ package() {
     install -d "$pkgdir"/opt/etc/draft "$pkgdir"/opt/etc/draft/icons
     install -D -m 644 -t "$pkgdir"/opt/etc/draft "$srcdir"/xochitl.draft
     install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons "$srcdir"/xochitl.png
+    install -D -m 644 -t "$pkgdir"/opt/usr/share/applications "$srcdir"/xochitl.oxide
 }

--- a/package/xochitl/xochitl.oxide
+++ b/package/xochitl/xochitl.oxide
@@ -1,0 +1,6 @@
+{
+	"displayName": "Xochitl",
+	"description": "Read documents and take notes",
+	"bin": "/usr/bin/xochitl",
+	"icon": "/opt/etc/draft/icons/xochitl.png"
+}

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2020 The Toltec Contributors
+# Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
 #
@@ -21,13 +21,25 @@ set -eE
 [[ -z $wget_path ]] && wget_path=/home/root/.local/bin/wget
 
 # Path for the systemd unit that mounts Entware to /opt
+[[ -z $old_systemd_mount_path ]] && old_systemd_mount_path=/etc/systemd/system/opt.mount
 [[ -z $systemd_mount_path ]] && systemd_mount_path=/lib/systemd/system/opt.mount
 
 # Path where the actual Entware distribution resides (will be mounted to /opt)
 [[ -z $entware_path ]] && entware_path=/home/root/.entware
 
-# Toltec branch to use for this install - you almost always want 'stable'
-[[ -z $toltec_branch ]] && toltec_branch="stable"
+# Find out current branch or get default one
+get-branch() {
+    local opkg_conf="$entware_path/etc/opkg.conf"
+    local branch
+    if [[ -f "$opkg_conf" ]]; then
+        # Get the first (...) value (aka \1) of the pattern if matching
+        branch="$(sed -E 's|^src/gz\s+toltec\s+https://toltec-dev.org/([[:alnum:]]*).*$|\1|;t;d' "$opkg_conf" | head -n1)"
+    fi
+    echo "${branch:-stable}"
+}
+
+# Toltec branch to use for this install - you almost always want the default
+[[ -z $toltec_branch ]] && toltec_branch="$(get-branch)"
 
 # Remove all temporary files
 cleanup() {
@@ -71,8 +83,8 @@ error-cleanup() {
 # Install a local wget binary which supports TLS (the original one
 # installed on the reMarkable does not) in the PATH
 wget-bootstrap() {
-    local wget_remote=https://toltec-dev.org/thirdparty/bin/wget-v1.20.3
-    local wget_checksum=8d447c6eb0a39e705f45bea900b12eef07142ea3da0809aca4dd44fe4110cdfd
+    local wget_remote=https://toltec-dev.org/thirdparty/bin/wget-v1.21.1
+    local wget_checksum=8798fcdabbe560722a02f95b30385926e4452e2c98c15c2c217583eaa0db30fc
 
     if [[ ! -x $wget_path ]]; then
         if [[ -e $wget_path ]]; then
@@ -106,6 +118,18 @@ wget-bootstrap() {
 entware-mount() {
     mkdir -p /opt
     mkdir -p "$entware_path"
+
+    if [[ -f $old_systemd_mount_path ]] && [[ ! -f $systemd_mount_path ]]; then
+        # The user was probably using https://github.com/Evidlo/remarkable_entware
+        # before switching to toltec. Removing old .mount file to prevent duplicate files
+        log "Updating opt.mount location"
+
+        if systemctl -q is-enabled opt.mount; then
+            # Remove path to old file if still symlinked
+            systemctl disable opt.mount
+        fi
+        rm $old_systemd_mount_path
+    fi
 
     # Create systemd mount unit to mount over /opt on reboot
     cat > "$systemd_mount_path" << UNIT

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -23,6 +23,20 @@ is-enabled() {
     systemctl --quiet is-enabled "$1" 2> /dev/null
 }
 
+# Check whether a systemd unit is in an active state
+# ("running")
+#
+# Arguments:
+#
+# $1 - Name of the systemd unit, e.g. "xochitl.service" or "xochitl"
+#
+# Exit code:
+#
+# 0 if the unit exists and is enabled, 1 otherwise
+is-active() {
+    systemctl --quiet is-active "$1" 2> /dev/null
+}
+
 # Get a list of systemd units with which the given unit conflicts
 #
 # Arguments:
@@ -33,7 +47,10 @@ is-enabled() {
 #
 # List of conflicting units
 get-conflicts() {
-    systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}'
+    # systemd automatically adds a conflict with "shutdown.target" to all
+    # service units (see systemd.service(5), section "Automatic Dependencies")
+    systemctl show "$1" | awk -F'=' '/^Conflicts=/{print $2}' \
+        | sed 's|\bshutdown.target\b||'
 }
 
 # Print instructions about how to enable a given systemd service and disable
@@ -54,4 +71,21 @@ how-to-enable() {
     done
 
     echo "$ systemctl enable --now ${1/.service/}"
+}
+
+# Reload Oxide applications if tarnish is running
+#
+# Output:
+#
+# Status message
+reload-oxide-apps() {
+    if ! is-active tarnish.service; then
+        return
+    fi
+    echo -n "Reloading Oxide applications: "
+    if ! /opt/bin/rot apps call reload 2> /dev/null; then
+        echo "Failed!"
+    else
+        echo "Done!"
+    fi
 }

--- a/scripts/package-build
+++ b/scripts/package-build
@@ -148,14 +148,16 @@ for pkgname in "${pkgnames[@]}"; do
             # Run packaging script
             package
 
-            section "Stripping $pkgname"
-            docker container run --interactive --rm \
-                --mount type=bind,src="$(realpath "$pkgdir")",dst=/pkg \
-                "$(image-name "${image:-base:v1.2.2}")" /bin/bash \
-                << "SCRIPT"
+            if ! has-element "nostrip" "${flags[@]}"; then
+                section "Stripping $pkgname"
+                docker container run --interactive --rm \
+                    --mount type=bind,src="$(realpath "$pkgdir")",dst=/pkg \
+                    "$(image-name "${image:-base:v1.2.2}")" /bin/bash \
+                    << "SCRIPT"
 find /pkg -print0 -type f | xargs --null "${CROSS_COMPILE}strip" --strip-all &> /dev/null || true
 SCRIPT
-            find "$pkgdir" -print0 -type f | xargs --null strip --strip-all &> /dev/null || true
+                find "$pkgdir" -print0 -type f | xargs --null strip --strip-all &> /dev/null || true
+            fi
 
             section "Finalizing package $pkgname"
             # Show package contents
@@ -204,23 +206,32 @@ SCRIPT
             fi
 
             # Generate postinst
-            if [[ $(type -t configure) = function ]]; then
-                {
-                    maintainer-script-header
+            {
+                maintainer-script-header
+                if [[ $(type -t configure) = function ]]; then
                     declare -f configure
                     cat << 'SCRIPT'
 if [[ $1 = configure ]]; then
     configure
 fi
 SCRIPT
-                } >> "$ctldir"/postinst
-                chmod 755 "$ctldir"/postinst
-            fi
+                fi
+
+                if [ -d "$pkgdir"/opt/usr/share/applications ]; then
+                    cat << 'SCRIPT'
+if [[ $1 = configure ]]; then
+    reload-oxide-apps
+fi
+SCRIPT
+                fi
+            } >> "$ctldir"/postinst
+            chmod 755 "$ctldir"/postinst
 
             # Generate {pre,post}rm
             for step in pre post; do
                 if [[ $(type -t "$step"upgrade) = function ]] \
-                    || [[ $(type -t "$step"remove) = function ]]; then
+                    || [[ $(type -t "$step"remove) = function ]] \
+                    || [ -d "$pkgdir"/opt/usr/share/applications ] && [ $step = post ]; then
                     {
                         maintainer-script-header
 
@@ -238,6 +249,14 @@ SCRIPT
                             cat << SCRIPT
 if [[ \$1 = remove ]]; then
     "$step"remove "\$2"
+fi
+SCRIPT
+                        fi
+
+                        if [ $step = post ] && [ -d "$pkgdir"/opt/usr/share/applications ]; then
+                            cat << 'SCRIPT'
+if [[ $1 = remove ]] || [[ $1 = upgrade ]]; then
+    reload-oxide-apps
 fi
 SCRIPT
                         fi

--- a/scripts/package-lib
+++ b/scripts/package-lib
@@ -282,6 +282,7 @@ load-recipe-header() {
     check-field source array optional || source=()
     check-field noextract array optional || noextract=()
     check-field sha256sums array optional || sha256sums=()
+    check-field flags array optional || flags=()
 
     # Make fields read-only
     readonly \
@@ -293,6 +294,7 @@ load-recipe-header() {
         source \
         noextract \
         sha256sums \
+        flags \
         2> /dev/null || true
 
     # Make defined functions read-only
@@ -334,6 +336,7 @@ load-recipe-pkg() {
     check-field license string nonempty
     check-field depends array optional || depends=()
     check-field conflicts array optional || conflicts=()
+    check-field flags array optional || flags=()
 
     # Make fields read-only
     readonly \
@@ -344,6 +347,7 @@ load-recipe-pkg() {
         license \
         depends \
         conflicts \
+        flags \
         2> /dev/null || true
 
     # Check required functions
@@ -381,6 +385,7 @@ dump-fields() {
         source \
         noextract \
         sha256sums \
+        flags \
         2> /dev/null || true
 }
 

--- a/scripts/repo-build
+++ b/scripts/repo-build
@@ -15,16 +15,19 @@ gathered in REPODIR.  If REMOTEREPO is omitted,
 Options:
 
     -h              Show this help message.
+    -n              Only build new packages.
     -l              Only build packages locally, do not reuse existing packages
                     from the publishing server."
 
 helpflag=
 localflag=
+onlynew=
 
-while getopts hl name; do
+while getopts hln name; do
     case $name in
         h) helpflag=1 ;;
         l) localflag=1 ;;
+        n) onlynew=1 ;;
         *) error "Invalid option. Use the -h flag for more information." ;;
     esac
 done
@@ -92,6 +95,14 @@ for recipedir in "$recipesdir"/*; do
                 }
             ); then
                 missingpkgs+=("$pkgname")
+            else
+                (
+                    load-recipe-pkg "$pkgname"
+                    pkgid="$(package-id)"
+                    if [[ -n $onlynew ]]; then
+                        rm "$repodir/$pkgid.ipk"
+                    fi
+                )
             fi
         done
 

--- a/scripts/repo-build-web
+++ b/scripts/repo-build-web
@@ -169,7 +169,7 @@ WEBS
             <tr>
                 <td>$href</td>
                 <td>$pkgdesc</td>
-                <td>$pkgver</td>
+                <td><a href='./${pkgid}.ipk'>$pkgver</a></td>
                 <td><a href='https://spdx.org/licenses/$license.html'>$license</a></td>
             </tr>
 WEBS


### PR DESCRIPTION
New packages:

* decay 2.1\~beta-1

Updated packages:

* draft 0.2.0-16 → 0.2.0-17
    - Fix install script asking to disable shutdown.target
* erode 2.0.3\~beta-1 → 2.1\~beta-1
    - Add .oxide file
    - Automatically reload oxide on install
* fret 2.0.3\~beta-1 → 2.1\~beta-1
    - Add .oxide file
    - Automatically reload oxide on install
* oxide 2.0.3\~beta-1 → 2.1\~beta-1
    - Add .oxide file
    - Automatically reload oxide on install
* rot 1.0.0 → 2.1\~beta-1
    - Fix wrong version
* tarnish 2.0.3\~beta-1 → 2.1\~beta-1
    - Fix install script asking to disable shutdown.target
* koreader 2020.12-2 → 2020.12-3
    - Add .oxide file
    - Automatically reload oxide on install
    - Remove warning relative to Oxide
* plato 0.9.1-13 → 0.9.13-1
* genie 0.1.0-1 → 0.1.1-1
* simple 0.1.0-3 → 0.1.1-1
* remux 0.1.5-1 → 0.1.6-2
* toltec-bootstrap 0.0.1-2 → 0.0.1-3
    - Update wget to 1.21.1
* xochitl 0.0.0-2 → 0.0.0-3
    - Add .oxide file
    - Automatically reload oxide on install

Install:

* Update wget to 1.21.1
* Upgrade old opt.mount bind mount from remarkable_entware
* Keep branch from existing install if applicable

Documentation:

* Link to code of conduct and security policy.

Tooling:

* Add flag field to disable auto stripping of binaries
* Send Discord notifications on update