### PR TITLE
Update fingerterm

### DIFF
--- a/package/fingerterm/package
+++ b/package/fingerterm/package
@@ -11,7 +11,7 @@ section="admin"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-2.0-or-later
 
-image=qt:v1.1
+image=qt:v1.2.2
 source=(
     https://github.com/dixonary/fingerterm-reMarkable/archive/02c17b5b485743c698e005ca89366c32b66aa044.zip
     fingerterm.png

--- a/package/fingerterm/package
+++ b/package/fingerterm/package
@@ -5,20 +5,20 @@
 pkgnames=(fingerterm)
 pkgdesc="Terminal emulator with an on-screen touch keyboard"
 url=https://github.com/dixonary/fingerterm-reMarkable
-pkgver=1.3.5-11
-timestamp=2017-12-08T15:40Z
+pkgver=1.3.5-12
+timestamp=2020-10-27T12:02Z
 section="admin"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-2.0-or-later
 
 image=qt:v1.1
 source=(
-    https://github.com/dixonary/fingerterm-reMarkable/archive/bd97bfb34b7ebebeed029fca0d72a10af0258884.zip
+    https://github.com/dixonary/fingerterm-reMarkable/archive/02c17b5b485743c698e005ca89366c32b66aa044.zip
     fingerterm.png
     fingerterm.draft
 )
 sha256sums=(
-    ff4fa704d6199213ccfacb34477c5b0869910b9f7f476f334bf31c192456c1b5
+    1e2290f876ca97dceda5b25e04517d793ac0a040fa4d6004dd34e5b507de534c
     SKIP
     SKIP
 )


### PR DESCRIPTION
(Fixes #242)

This adds commit <https://github.com/dixonary/fingerterm-reMarkable/commit/02c17b5b485743c698e005ca89366c32b66aa044> which provides a new setting called 'showVisualKeyPressFeedback' for disabling the flash that happens after each tap on a key of the terminal keyboard.