### PR TITLE
Fix link in docs/package.md

### DIFF
--- a/docs/package.md
+++ b/docs/package.md
@@ -308,7 +308,7 @@ The install section can contain additional functions to customize the behavior o
 Those functions are `preinstall()`, `configure()`, `preremove()`, `postremove()`, `preupgrade()` and `postupgrade()`.
 Unlike the previous functions, all the install functions **run in the context of the target device.**
 They have access to all the metadata fields, but not to other functions.
-They can also use functions from the [install library](scripts/install-lib).
+They can also use functions from the [install library](../scripts/install-lib).
 
 When installing a new package, the following happens:
 


### PR DESCRIPTION
The link was to `scripts/install-lib`, but because `package.md` isn't in the root of the repo, it pointed to the wrong place. It should point to the correct file now.