### PR TITLE
Fix missing prerm script in rm2fb

### DIFF
--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -8,7 +8,7 @@ maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 pkgdesc="Interface to the reMarkable 2 framebuffer"
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1.0.0-6
+pkgver=1.0.0-7
 section="devel"
 
 image=qt:v1.1


### PR DESCRIPTION
Due to a logic bug fixed in <https://github.com/toltec-dev/toltec/pull/222/files#diff-d7f7031a7af306332472a25649f7ebc8a7de7c7ce2eb421a30c8f76106f3b0fbR231>, prerm scripts were not generated for corresponding preremove functions.

rm2fb’s version was not increased since this fix was merged, therefore the current package (1.0.0-6) does not contain a prerm script.

This fix increments rm2fb’s version to trigger a rebuild of the package.