### PR TITLE
Make bootstrap execution conditional on hash verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "5b494f5b98c4cb5f1d9836f966075026abf48a0cd320a99c026c4b18d76c8a0b  bootstrap" | sha256sum -c
-$ bash bootstrap
+$ echo "5b494f5b98c4cb5f1d9836f966075026abf48a0cd320a99c026c4b18d76c8a0b  bootstrap" | sha256sum -c && bash bootstrap
 ```
 
 > **Warning:**

--- a/web/index.rst
+++ b/web/index.rst
@@ -23,8 +23,7 @@ This will install the Toltec package repository and related tools.
 .. parsed-literal::
 
     $ wget \http://toltec-dev.org/bootstrap
-    $ echo "|bootstrap-hash|  bootstrap" | sha256sum -c
-    $ bash bootstrap
+    $ echo "|bootstrap-hash|  bootstrap" | sha256sum -c && bash bootstrap
 
 
 What Does Toltec Do?


### PR DESCRIPTION
This should keep users from copy and pasting all three commands and running a bootstrap script even if the hash check fails.