### PR TITLE
Hardcode REMOTE_HTTP secret in PR workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
             - name: Setup Toltec dependencies
               uses: ./.github/actions/setup
             - name: Build packages
-              run: make repo-new FLAGS='--remote-repo ${{ secrets.REMOTE_HTTP }}/${{ github.base_ref }}'
+              run: make repo-new FLAGS='--remote-repo https://toltec-dev.org/${{ github.base_ref }}'
             - name: Save the build output
               uses: actions/upload-artifact@v2
               with:


### PR DESCRIPTION
The REMOTE_HTTP secret was introduced to make the remote server
configurable without changing the workflow code in #218. For security
reasons, PR workflows do not have access to secret variables (this is an
oversight of the aforementioned PR).

We could switch the PR workflow to trigger on the `pull_request_target`
event which allows access to secrets, but that would enable external
attackers to exfiltrate our secrets (see
<https://securitylab.github.com/research/github-actions-preventing-pwn-requests>).

The correct solution would be for GitHub to provide a mechanism for
marking secrets as non-sensitive (which is the case of REMOTE_HTTP). For
now, let’s just hardcode that secret in PR workflows.