### PR TITLE
Print msgs on error

### DIFF
--- a/scripts/toltec/bash.py
+++ b/scripts/toltec/bash.py
@@ -9,6 +9,7 @@ from docker.client import DockerClient
 
 AssociativeArray = Dict[str, str]
 IndexedArray = List[Optional[str]]
+LogGenerator = Generator[str, None, None]
 Any = Union[str, AssociativeArray, IndexedArray]
 Variables = Dict[str, Optional[Any]]
 Functions = Dict[str, str]
@@ -321,7 +322,7 @@ def _parse_func(lexer: shlex.shlex) -> Tuple[int, int]:
     return start_byte, end_byte
 
 
-def run_script(variables: Variables, script: str) -> Generator[str, None, None]:
+def run_script(variables: Variables, script: str) -> LogGenerator:
     """
     Run a Bash script and stream its output.
 
@@ -368,7 +369,7 @@ def run_script_in_container(
     mounts: List,
     variables: Variables,
     script: str,
-) -> Generator[str, None, None]:
+) -> LogGenerator:
     """
     Run a Bash script inside a Docker container and stream its output.
 

--- a/scripts/toltec/builder.py
+++ b/scripts/toltec/builder.py
@@ -448,7 +448,7 @@ source file '{source.url}', got {req.status_code}"
         logs: bash.LogGenerator,
         adapter: BuildContextAdapter,
         function_name: str = None,
-        max_lines_on_fail: int = 200,
+        max_lines_on_fail: int = 50,
     ) -> None:
         """
         Print logs to the debug output or buffer and print the last n log lines


### PR DESCRIPTION
Here is the change to print the last 200 lines when a bash script fails, @matteodelabre .

Might want to refactor it a bit to fit better into the toolchain. I hope this is somewhat similar to the current coding style already.

(I didn't put it in utils.py since the function refers to `bash.ScriptError` and utils seems to be more general with not imports from the own application at all.)