### PR TITLE
util.auto_extract: Extract broken symlinks

### DIFF
--- a/scripts/toltec/util.py
+++ b/scripts/toltec/util.py
@@ -129,6 +129,7 @@ def auto_extract(archive_path: str, dest_path: str) -> bool:
                 zip_archive.getinfo,
                 zip_archive.open,
                 lambda member: member.is_dir(),
+                lambda member: False,
                 lambda member: member.external_attr >> 16 & 0x1FF,
                 dest_path,
             )
@@ -145,6 +146,7 @@ def auto_extract(archive_path: str, dest_path: str) -> bool:
                 tar_archive.getmember,
                 tar_archive.extractfile,
                 lambda member: member.isdir(),
+                lambda member: member.issym(),
                 lambda member: member.mode,
                 dest_path,
             )
@@ -153,11 +155,12 @@ def auto_extract(archive_path: str, dest_path: str) -> bool:
     return False
 
 
-def _auto_extract(  # pylint:disable=too-many-arguments
+def _auto_extract(  # pylint:disable=too-many-arguments,disable=too-many-locals
     members: List[str],
     getinfo: Callable[[str], Any],
     extract: Callable[[Any], Optional[IO[bytes]]],
     isdir: Callable[[Any], bool],
+    issym: Callable[[Any], bool],
     getmode: Callable[[Any], int],
     dest_path: str,
 ) -> None:
@@ -168,6 +171,7 @@ def _auto_extract(  # pylint:disable=too-many-arguments
     :param getinfo: get an entry object from an entry name in the archive
     :param extract: get a reading stream corresponding to an archive entry
     :param isdir: get whether an entry is a directory or not
+    :param issym: get whether an entry is a symbolic link or not
     :param getmode: get the permission bits for an entry
     :param destpath: destinatio folder for the archive contents
     """
@@ -180,9 +184,13 @@ def _auto_extract(  # pylint:disable=too-many-arguments
         if isdir(member):
             os.makedirs(file_path, exist_ok=True)
         else:
-            if hasattr(member, "issym") and member.issym():
+            if issym(member):
                 os.symlink(member.linkname, file_path)
             else:
+                basedir = os.path.dirname(file_path)
+                if not os.path.exists(basedir):
+                    os.makedirs(basedir, exist_ok=True)
+
                 source = extract(member)
                 assert source is not None
 

--- a/scripts/toltec/util.py
+++ b/scripts/toltec/util.py
@@ -180,15 +180,18 @@ def _auto_extract(  # pylint:disable=too-many-arguments
         if isdir(member):
             os.makedirs(file_path, exist_ok=True)
         else:
-            source = extract(member)
-            assert source is not None
+            if hasattr(member, 'issym') and member.issym():
+                os.symlink(member.linkname, file_path)
+            else:
+                source = extract(member)
+                assert source is not None
 
-            with source, open(file_path, "wb") as target:
-                shutil.copyfileobj(source, target)
+                with source, open(file_path, "wb") as target:
+                    shutil.copyfileobj(source, target)
 
-            mode = getmode(member)
-            if mode != 0:
-                os.chmod(file_path, mode)
+                mode = getmode(member)
+                if mode != 0:
+                    os.chmod(file_path, mode)
 
 
 def query_user(

--- a/scripts/toltec/util.py
+++ b/scripts/toltec/util.py
@@ -180,7 +180,7 @@ def _auto_extract(  # pylint:disable=too-many-arguments
         if isdir(member):
             os.makedirs(file_path, exist_ok=True)
         else:
-            if hasattr(member, 'issym') and member.issym():
+            if hasattr(member, "issym") and member.issym():
                 os.symlink(member.linkname, file_path)
             else:
                 source = extract(member)


### PR DESCRIPTION
Fixes #291.

Broken symlinks in source archives previously triggered build errors when auto-extracted. This PR changes this behavior to always create symlinks even if their destination does not (yet) exist.

Test plan:

* Make sure all other recipes still build (`make repo-local`)
* Build the following recipe:

```sh
pkgnames=(test-symlinks)
pkgdesc=""
url=""
pkgver=0.0.0-1
timestamp=1970-01-01T00:00Z
section="devel"
maintainer="Nobody <nobody@example.com>"
license=MIT
source=("https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20200827.tar.xz")
sha256sums=(51bc85e33a5b3cf353786ae64b0f1216d7a871447f058b6137f793eb0f53b7fd)

package() {
    return
}
```

* Make sure the `src/src/wg-quick/wg` symlink gets created in the build folder and points to `../wg`