### PR TITLE
[rmkit] patch genie to fix crash in testing

### DIFF
--- a/package/rmkit/2021_03_05_genie.diff
+++ b/package/rmkit/2021_03_05_genie.diff
@@ -1,0 +1,29 @@
+diff --git a/src/genie/gesture_parser.cpy b/src/genie/gesture_parser.cpy
+index fa82b67..c94fd59 100644
+--- a/src/genie/gesture_parser.cpy
++++ b/src/genie/gesture_parser.cpy
+@@ -16,17 +16,18 @@ namespace genie:
+   ;
+ 
+   void run_command(string command):
++    debug "RUNNING COMMAND", command
++    string cmd = command + "&"
++    c_str := cmd.c_str()
++    _ := system(c_str)
++
+     ui::TaskQueue::add_task([=]() {
+       usleep(1e3 * 50)
+-
+-      debug "RUNNING COMMAND", command
+-      string cmd = command
+-      c_str := cmd.c_str()
+-      _ := system(c_str)
+-
+       ui::MainLoop::reset_gestures()
+     })
+ 
++
++
+   input::SwipeGesture* build_swipe_gesture(GestureConfigData gcd):
+     fb := framebuffer::get()
+     fw, fh := fb->get_display_size()

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -12,15 +12,18 @@ source=(
     https://github.com/rmkit-dev/rmkit/archive/681354803a158eca9c267b1f1976affda391bdff.zip
     remux.service
     genie.service
+    2021_03_05_genie.diff
 )
 sha256sums=(
     6e2b1fb7fa52f6412268b1d063e9dd117d1913411fe26627c34cf3d02a836de5
+    SKIP
     SKIP
     SKIP
 )
 
 build() {
     pip3 install okp
+    patch -p1 < 2021_03_05_genie.diff
     make
 }
 
@@ -38,7 +41,7 @@ bufshot() {
 genie() {
     pkgdesc="Gesture engine that connects commands to gestures"
     url="https://rmkit.dev/apps/genie"
-    pkgver=0.1.4-1
+    pkgver=0.1.4-2
     section="utils"
 
     package() {


### PR DESCRIPTION
from discussion with matteo, there is a crash in genie on testing (see test plan) when using the example genie config. i tested this patch and verified it fixes the crash. 

test plan:

* use 3 finger tap on rM2 with example genie config (/opt/etc/genie.example.conf). watch genie output and verify that it recognizes the gesture. gesture several times, trying to trigger crash. it's useful to verify that genie in testing crashes for you and that this version does not