### PR TITLE
Pin the Ubuntu version used in workflows to 20.04

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -5,7 +5,7 @@ on:
 jobs:
     check-labels:
         name: Check that PRs against the stable branch are labelled correctly
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - name: Check labels
               run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,7 +4,7 @@ on:
 jobs:
     lint:
         name: Check that it conforms to the style guide
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - name: Checkout the Git repository
               uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
               run: make lint
     pr:
         name: Check that it builds without error
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         needs: lint
         steps:
             - name: Checkout the Git repository

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     stable:
         name: Build and publish the stable channel
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - name: Checkout the Git repository
               uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     testing:
         name: Build and publish the testing channel
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         steps:
             - name: Checkout the Git repository
               uses: actions/checkout@v2


### PR DESCRIPTION
GitHub recently transitioned the `ubuntu-latest` label from Ubuntu 18.04 to Ubuntu 20.04 (see <https://github.com/actions/virtual-environments/issues/1816>). This caused our workflows to fail because the bsdtar binary was moved to a different package in 20.04.

To prevent this kind of failure in the future, we should specify a fixed Ubuntu version in our workflows. This PR implements that change.