### PR TITLE
Use xochitl instead of remarkable-shutdown in rm2fb-server

### DIFF
--- a/package/rm2fb/overwrite-server-argv0.patch
+++ b/package/rm2fb/overwrite-server-argv0.patch
@@ -1,0 +1,15 @@
+diff --git a/src/server/main.cpp b/src/server/main.cpp
+index 755be17..4186060 100755
+--- a/src/server/main.cpp
++++ b/src/server/main.cpp
+@@ -173,6 +173,10 @@ int __libc_start_main(int (*_main)(int, char **, char **), int argc,
+   swtfb::SDK_BIN = argv[0];
+   fprintf(stderr, "BIN FILE: %s\n", argv[0]);
+ 
++  size_t argv0_len = strlen(argv[0]);
++  strncpy(argv[0], "rm2fb-server", argv0_len);
++  argv[0][argv0_len] = 0;
++
+   return func_main(server_main, argc, argv, init, fini, rtld_fini, stack_end);
+ };
+ };

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -8,7 +8,7 @@ maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 pkgdesc="Interface to the reMarkable 2 framebuffer"
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1.0.1-1
+pkgver=1.0.1-2
 section="devel"
 
 image=qt:v1.1

--- a/package/rm2fb/package
+++ b/package/rm2fb/package
@@ -18,9 +18,11 @@ source=(
     rm2fb.service
     rm2fb-server
     rm2fb-client
+    overwrite-server-argv0.patch
 )
 sha256sums=(
     76f1c0b72260a9743f3e008100ffddf1f89cd44c6f0376d906e98ae66eaea716
+    SKIP
     SKIP
     SKIP
     SKIP
@@ -30,6 +32,11 @@ sha256sums=(
 build() {
     qmake
     make
+}
+
+prepare() {
+    patch -p1 -d"$srcdir" < "$srcdir"/overwrite-server-argv0.patch
+    rm "$srcdir"/overwrite-server-argv0.patch
 }
 
 package() {

--- a/package/rm2fb/rm2fb-server
+++ b/package/rm2fb/rm2fb-server
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-LD_PRELOAD=/opt/lib/librm2fb_server.so.1 exec "$(command -v remarkable-shutdown)"
+LD_PRELOAD=/opt/lib/librm2fb_server.so.1 exec "$(command -v xochitl)"

--- a/package/rm2fb/rm2fb.service
+++ b/package/rm2fb/rm2fb.service
@@ -8,9 +8,10 @@ After=opt.mount
 StartLimitInterval=30
 StartLimitBurst=5
 Conflicts=
+ConditionFileNotEmpty=/opt/lib/librm2fb_server.so.1
 
 [Service]
-ExecStart=/usr/bin/remarkable-shutdown
+ExecStart=/usr/bin/xochitl
 Restart=on-failure
 RestartSec=5
 Environment="HOME=/home/root"


### PR DESCRIPTION
In the last software relase (2.6), new waveform modes were added to xochitl to make the pinch-to-zoom feature work. Unfortunately, the remarkable-shutdown binary was not updated to support those new waveforms. As a consequence, using pinch-to-zoom with rm2fb results in a less smooth experience than without rm2fb, since the screen gets refreshed less frequently during the gesture.

See:

* <https://github.com/toltec-dev/toltec/issues/322#issuecomment-808235577>
* <https://github.com/ddvk/remarkable2-framebuffer/issues/56>

To address this issue, this PR changes the rm2fb-server to preload the `/usr/bin/xochitl` binary instead of `/usr/bin/remarkable-shutdown` in both the `rm2fb-server` command and `rm2fb.service`.

A start condition is added to `rm2fb.service` to only start if the librm2fb_server library actually exists on the filesystem. This is to
avoid having two concurrent xochitl processes running, as the loader ignores non-existent files provided in LD_PRELOAD.

Test plan:

* Manually run `rm2fb-server` and `rm2fb-client xochitl`, make use of the pinch-to-zoom gesture, and make sure no message of the form `Unable to complete update: invalid waveform ( 6 )` appears in the server process.
* Check that the display continuously updates when using the pinch-to-zoom gesture, even if the `rm2fb.service` service is running and xochitl is started with `rm2fb-client xochitl`.
* Remove the `/opt/lib/librm2fb_server.so.1` symlink and restart `rm2fb.service`. The service should not start. Make sure that there’s no duplicate `xochitl` process in this case.