### PR TITLE
Fix partial repository builds

### DIFF
--- a/scripts/toltec/repo.py
+++ b/scripts/toltec/repo.py
@@ -137,6 +137,8 @@ class Repo:
         if req.status_code != 200:
             return PackageStatus.Missing
 
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+
         with open(local_path, "wb") as local:
             for chunk in req.iter_content(chunk_size=1024):
                 local.write(chunk)


### PR DESCRIPTION
In PR #310, a regression was introduced that makes `make repo` fail. This slipped through the testing because we only did full repo builds (i.e., `make repo-local`). This regression makes CI builds fail, as they only rebuild packages that have changed (see the failing build in #328).

The failure comes from `Repo.fetch_package`: when fetching an existing packages from the remote server, the method should first make sure that the parent architecture directory (e.g. `build/repo/rmall`) exists.

To test, you only need to run `make clean && make repo` and observe that the fetching process completes successfully.