### PR TITLE
Create GitHub release on push to stable.

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -37,7 +37,7 @@ jobs:
                 remote-path: ${{ secrets.REMOTE_SSH }}:/srv/toltec/web
             - name: Create Github Release
               continue-on-error: true
-              run: hub release create -t ${{ github.sha }} -m "${{ github.event.commits[0].message }}" $(date +%Y-W%V)
+              run: hub release create -t ${{ github.sha }} -m "${{ github.event.commits[0].message }}" $(date +%Y-W%V-%u)
               env:
                 GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
             - name: Send notification to Discord

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -49,4 +49,4 @@ jobs:
                 title: New Toltec stable update available
                 link: https://toltec-dev.org/stable
                 color: 0x2ea043
-                message: ${{ github.event.head_commit.message }}
+                message: ${{ github.event.commits[0].message }}

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -35,6 +35,11 @@ jobs:
                 ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
                 ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
                 remote-path: ${{ secrets.REMOTE_SSH }}:/srv/toltec/web
+            - name: Create Github Release
+              continue-on-error: true
+              run: hub release create -t ${{ github.sha }} -m "${{ github.event.commits[0].message }}" ${{ github.run_number }} 
+              env:
+                GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
             - name: Send notification to Discord
               continue-on-error: true
               uses: ./.github/actions/discord-send

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -37,7 +37,7 @@ jobs:
                 remote-path: ${{ secrets.REMOTE_SSH }}:/srv/toltec/web
             - name: Create Github Release
               continue-on-error: true
-              run: hub release create -t ${{ github.sha }} -m "${{ github.event.commits[0].message }}" $(date +%Y-W%V-%u)
+              run: hub release create -t ${{ github.sha }} -m "${{ github.event.commits[0].message }}" $(date +%G-W%V-%u)
               env:
                 GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
             - name: Send notification to Discord

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -37,7 +37,7 @@ jobs:
                 remote-path: ${{ secrets.REMOTE_SSH }}:/srv/toltec/web
             - name: Create Github Release
               continue-on-error: true
-              run: hub release create -t ${{ github.sha }} -m "${{ github.event.commits[0].message }}" ${{ github.run_number }} 
+              run: hub release create -t ${{ github.sha }} -m "${{ github.event.commits[0].message }}" $(date +%Y-W%V)
               env:
                 GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
             - name: Send notification to Discord

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,4 +35,4 @@ jobs:
                 title: New Toltec testing update available
                 link: https://toltec-dev.org/testing
                 color: 0xe3b341
-                message: ${{ github.event.head_commit.message }}
+                message: ${{ github.event.commits[0].message }}


### PR DESCRIPTION
Resolves https://github.com/toltec-dev/toltec/issues/290

This adds a step to the stable workflow that will create a release.

The release will be named in accordance with the[ISO Week Date](https://en.wikipedia.org/wiki/ISO_week_date) format (e.g. 2021-W03-2 for a release made on the Tuesday in the third ISO Week of 2021).

The name of the release will be taken from the message of the commit that has been pushed to master - e.g. "Stable merge window for week XX of YYYY".

A proof of concept for this working can be seen in my fork: https://github.com/lambada/toltec/releases/tag/2021-W14-4

The `hub` cli tool this calls out to is https://github.com/github/hub and is preinstalled.

**Limitation: Only one release per day will be able to be created** but I feel that should be sufficient given the use case in the original issue - a notification mechanism to allow people to know that there are updates to install. As this step is marked with `continue_on_error` this is harmless in terms of continuing on to the next steps.

**This requires a new secret env var to be added to the repo configuration** This should be a Personal Access Token / API Key that has `repo` scope, and should be added with the name `RELEASE_TOKEN`. The default GITHUB_TOKEN that workflow has access to does not have permission to create a release.