### PR TITLE
Use the Bash binary in PATH for parsing recipes

### DIFF
--- a/scripts/toltec/bash.py
+++ b/scripts/toltec/bash.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Bridge Bash with Python."""
 
+import os
 import shlex
 import subprocess
 from typing import Dict, Generator, List, Optional, Tuple, Union
@@ -94,7 +95,9 @@ def get_declarations(src: str) -> Tuple[Variables, Functions]:
 declare -f
 declare -p
 """
-    env: Dict[str, str] = {}
+    env: Dict[str, str] = {
+        "PATH": os.environ["PATH"],
+    }
 
     declarations_subshell = (
         subprocess.run(  # pylint:disable=subprocess-run-check


### PR DESCRIPTION
Our current Python code spawns a Bash process as part of the recipe parsing process. To make sure the calling environment does not influence how the recipe is parsed, the subprocess is created with a clean environment. Unfortunately, this means the PATH variable is cleared and therefore that the subprocess may use a Bash binary different from the one in the user’s PATH. This PR changes that behavior and forwards the PATH value to the subprocess.

See the following comment and its follow-ups for more context: <https://github.com/toltec-dev/toltec/issues/324#issuecomment-813731157>

Test plan: Added a dummy `bash` binary (a file containing only `#!/usr/bin/env false`) to my PATH and checked that the recipe parsing fails (indicating that it invokes the dummy Bash and not the system one). Without the current PR, the parsing succeeds even if the parent PATH points to the dummy Bash.