### PR TITLE
Update the bootstrap script to install wget-ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "c930e94a4145c31e63ac8c66b1b0f5a192a91f31946d758bfc1470338cb64bae  bootstrap" | sha256sum -c && bash bootstrap
+$ echo "edf2fc05cf0777731b2c4a73b64ea5880f5aa1d3a1617749ce03e6219194e3c0  bootstrap" | sha256sum -c && bash bootstrap
 ```
 
 > **Warning:**

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,8 +5,8 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Manage your Toltec install"
 url=https://toltec-dev.org/
-pkgver=0.0.7-1
-timestamp=2021-06-20T20:46Z
+pkgver=0.0.8-1
+timestamp=2021-06-22T08:38Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -292,7 +292,7 @@ toltec-install() {
     local additional_packages=()
 
     [[ ! -d /opt/etc/ssl/certs ]] && additional_packages+=(ca-certificates)
-    [[ ! -f /opt/bin/wget ]] && additional_packages+=(wget)
+    [[ ! -f /opt/bin/wget ]] && additional_packages+=(wget-ssl)
 
     if [[ ${#additional_packages[@]} -gt 0 ]]; then
         /opt/bin/opkg install "${additional_packages[@]}"


### PR DESCRIPTION
Entware recently renamed its `wget` package to `wget-ssl`, and made `wget` a virtual package provided both by `wget-ssl` and `wget-nossl` (see <https://github.com/openwrt/packages/pull/13613>). The latter seems to be favored by the package manager, so doing `opkg install wget` will actually install the version of wget that does not support TLS.

This PR changes the bootstrap script to ensure that the TLS-enabled version of wget gets installed. To test it, run the new bootstrap script on a clean system and make sure that no message saying “TLS certificate validation not implemented” is ever printed out.