### PR TITLE
[plato] Update to 0.9.17-1

### DIFF
--- a/package/plato/package
+++ b/package/plato/package
@@ -102,7 +102,7 @@ configure() {
             jq "$change_cmds | del($del_list)" < $metadata_file_old > $metadata_file
             echo 'Metadata file was updated! The old one was renamed to ".metadata-old.json".'
 
-        elif [ $max_key_len -gt 16 ] &&  [ -e $metadata_file_old ]; then
+        elif [ $max_key_len -gt 16 ] && [ -e $metadata_file_old ]; then
             echo 'MANUAL INTERVENTION REQUIRED!!!'
             echo 'Plato 0.9.14 changed the format of metadata files.'
             echo 'Your metadata file not found but may be outdated!'

--- a/package/plato/package
+++ b/package/plato/package
@@ -76,8 +76,9 @@ configure() {
         local metadata_file=$mediadir/.metadata.json
         local metadata_file_old=$mediadir/.metadata-old.json
 
-        local max_key_len=$(cat $metadata_file | jq --raw-output 'keys[]' | wc -L)
-        if [ $max_key_len -gt 16 ] && [ ! -e $metadata_file_old ]; then
+        local max_key_len
+        max_key_len=$(jq --raw-output 'keys[]' < $metadata_file | wc -L)
+        if [ "$max_key_len" -gt 16 ] && [ ! -e $metadata_file_old ]; then
 
             echo 'Plato 0.9.14 changed the format of metadata files.'
             echo 'Your metadata file was found and determined to be outdated!'
@@ -89,7 +90,7 @@ configure() {
             local change_cmds=""
             local del_list=""
             for key in $(jq --raw-output 'keys[]' < $metadata_file_old); do
-                hex_key=$(printf %016X $key)
+                hex_key=$(printf %016X "$key")
                 #echo "Key: $key --> $hex_key"
 
                 [ -z "$del_list" ] || del_list="${del_list}, "
@@ -102,7 +103,7 @@ configure() {
             jq "$change_cmds | del($del_list)" < $metadata_file_old > $metadata_file
             echo 'Metadata file was updated! The old one was renamed to ".metadata-old.json".'
 
-        elif [ $max_key_len -gt 16 ] && [ -e $metadata_file_old ]; then
+        elif [ "$max_key_len" -gt 16 ] && [ -e $metadata_file_old ]; then
             echo 'MANUAL INTERVENTION REQUIRED!!!'
             echo 'Plato 0.9.14 changed the format of metadata files.'
             echo 'Your metadata file not found but may be outdated!'

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,18 +5,18 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.13-2
-timestamp=2021-01-13T23:43Z
+pkgver=0.9.16-1
+timestamp=2021-04-19T23:53Z
 section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
-installdepends=(display)
+installdepends=(display jq)
 makedepends=(build:jq build:unzip build:wget)
 flags=(patch_rm2fb)
 
-image=rust:v1.4
-source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-7.zip")
-sha256sums=(17718d74066e5cbec043c98b52958a311eb793674751d6b7789b5baff2227f96)
+image=rust:v1.6
+source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-8.zip")
+sha256sums=(e741c18ed055bbaebdc06a32216784a59c8c976a8fa2b97dbe1ed6dc39bd8078)
 
 build() {
     # Fall back to system-wide config
@@ -62,12 +62,57 @@ package() {
 configure() {
     local mediadir=/home/root/plato-media
 
-    # This directory should not be tracked by opkg
-    # so that its contents are kept after removing
     if [ ! -d $mediadir ]; then
+        # This directory should not be tracked by opkg
+        # so that its contents are kept after removing
         mkdir $mediadir
         echo ""
         echo "Place your media files for plato in '$mediadir'"
         echo ""
+    else
+        # Fix breaking change introduced in version 0.9.14
+        # https://github.com/baskerville/plato/releases/tag/0.9.14
+
+        local metadata_file=$mediadir/.metadata.json
+        local metadata_file_old=$mediadir/.metadata-old.json
+
+        local max_key_len=$(cat $metadata_file | jq --raw-output 'keys[]' | wc -L)
+        if [ $max_key_len -gt 16 ] && [ ! -e $metadata_file_old ]; then
+
+            echo 'Plato 0.9.14 changed the format of metadata files.'
+            echo 'Your metadata file was found and determined to be outdated!'
+            echo 'Automatically updating the file...'
+
+            # Routine is based on baskerville's migrate-hex_keys.py (from the release page)
+            # Rewritten in bash to only require jq rather than python.
+            mv $metadata_file $metadata_file_old
+            local change_cmds=""
+            local del_list=""
+            for key in $(jq --raw-output 'keys[]' < $metadata_file_old); do
+                hex_key=$(printf %016X $key)
+                #echo "Key: $key --> $hex_key"
+
+                [ -z "$del_list" ] || del_list="${del_list}, "
+                [ -z "$change_cmds" ] || change_cmds="${change_cmds} | "
+                del_list="${del_list}.[\"${key}\"]"
+                change_cmds="${change_cmds}.[\"$hex_key\"] = .[\"$key\"]"
+            done
+
+            # Create updated json file
+            jq "$change_cmds | del($del_list)" < $metadata_file_old > $metadata_file
+            echo 'Metadata file was updated! The old one was renamed to ".metadata-old.json".'
+
+        elif [ $max_key_len -gt 16 ] &&  [ -e $metadata_file_old ]; then
+            echo 'MANUAL INTERVENTION REQUIRED!!!'
+            echo 'Plato 0.9.14 changed the format of metadata files.'
+            echo 'Your metadata file not found but may be outdated!'
+            echo 'Since the file could not be found, you should update it yourself!'
+            echo 'Please launch plato only after this was done! See'
+            echo 'https://github.com/baskerville/plato/releases/tag/0.9.14 for how to do it.'
+        elif [ ! -e $metadata_file ]; then
+            echo 'Plato 0.9.14 changed the format of metadata files!'
+            echo 'If you already have a library in some non-standard location, please migrate it! See'
+            echo 'https://github.com/baskerville/plato/releases/tag/0.9.14 for more.'
+        fi
     fi
 }

--- a/package/plato/package
+++ b/package/plato/package
@@ -62,55 +62,46 @@ package() {
 configure() {
     local mediadir=/home/root/plato-media
 
-    if [ ! -d $mediadir ]; then
+    if [[ ! -d $mediadir ]]; then
         # This directory should not be tracked by opkg
         # so that its contents are kept after removing
-        mkdir $mediadir
+        mkdir "$mediadir"
         echo ""
         echo "Place your media files for plato in '$mediadir'"
         echo ""
     else
-        # Fix breaking change introduced in version 0.9.14
-        # https://github.com/baskerville/plato/releases/tag/0.9.14
+        # Convert old library metadata format for version 0.9.14
+        # (see <https://github.com/baskerville/plato/releases/tag/0.9.14>)
+        local metadata_file="$mediadir"/.metadata.json
+        local key_len
+        [[ -f $metadata_file ]] && key_len="$(jq --raw-output 'keys[]' "$metadata_file" | wc -L)" || key_len=-1
 
-        local metadata_file=$mediadir/.metadata.json
-        local metadata_file_old=$mediadir/.metadata-old.json
-
-        local max_key_len
-        [ -e $metadata_file ] && max_key_len=$(jq --raw-output 'keys[]' < $metadata_file | wc -L) || max_key_len=-1
-        if [ "$max_key_len" -gt 16 ] && [ ! -e $metadata_file_old ]; then
+        if [[ "$key_len" -gt 16 ]]; then
+            local metadata_file_bak
+            metadata_file_bak="$(mktemp "$metadata_file".bak.XXXXXXXX)"
 
             echo ""
             echo "In Plato 0.9.14 the metadata format for libraries changed."
-            echo "Found your outdated metadata file. Will update it automatically..."
+            echo "Found existing metadata file in '$metadata_file'. Will update it automatically..."
 
             # Routine is based on baskerville's migrate-hex_keys.py (from the release page)
             # Rewritten in bash to only require jq rather than python.
-            mv $metadata_file $metadata_file_old
+            mv "$metadata_file" "$metadata_file_bak"
             local change_cmds=""
             local del_list=""
-            for key in $(jq --raw-output 'keys[]' < $metadata_file_old); do
-                hex_key=$(printf %016X "$key")
-                #echo "Key: $key --> $hex_key"
 
-                [ -z "$del_list" ] || del_list="${del_list}, "
-                [ -z "$change_cmds" ] || change_cmds="${change_cmds} | "
-                del_list="${del_list}.[\"${key}\"]"
-                change_cmds="${change_cmds}.[\"$hex_key\"] = .[\"$key\"]"
-            done
+            while read -r key; do
+                hex_key="$(printf %016X "$key")"
+                [[ -z "$del_list" ]] || del_list="$del_list, "
+                del_list="$del_list.[\"$key\"]"
+                [[ -z "$change_cmds" ]] || change_cmds="$change_cmds | "
+                change_cmds="$change_cmds.[\"$hex_key\"] = .[\"$key\"]"
+            done <<< "$(jq --raw-output 'keys[]' "$metadata_file_bak")"
 
             # Create updated json file
-            jq "$change_cmds | del($del_list)" < $metadata_file_old > $metadata_file
-            echo "Update complete. The old file was renamed to '.metadata-old.json'."
-            echo ""
+            jq "$change_cmds | del($del_list)" "$metadata_file_bak" > "$metadata_file"
 
-        elif [ "$max_key_len" -gt 16 ] && [ -e $metadata_file_old ] || [ ! -e $metadata_file ]; then
-            echo ""
-            echo "In Plato 0.9.14 the metadata format for libraries changed."
-            echo "MANUAL INTERVENTION REQUIRED\!\!\!"
-            echo "Please follow the following guide to update your library metadata manually:"
-            echo "https://github.com/baskerville/plato/releases/tag/0.9.14"
-            echo "Please LAUNCH plato ONLY AFTER this was done\!"
+            echo "Update complete. Backup of previous version created in '$metadata_file_bak'."
             echo ""
         fi
     fi

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,8 +5,8 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.16-1
-timestamp=2021-04-19T23:53Z
+pkgver=0.9.17-1
+timestamp=2021-05-02T14:39Z
 section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
@@ -15,8 +15,8 @@ makedepends=(build:jq build:unzip build:wget)
 flags=(patch_rm2fb)
 
 image=rust:v1.6
-source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-8.zip")
-sha256sums=(e741c18ed055bbaebdc06a32216784a59c8c976a8fa2b97dbe1ed6dc39bd8078)
+source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-10.zip")
+sha256sums=(25aae17979d9e259d228617eb26a0cc89a6251968b8fc355b8cde36fd6b26773)
 
 build() {
     # Fall back to system-wide config

--- a/package/plato/package
+++ b/package/plato/package
@@ -77,12 +77,12 @@ configure() {
         local metadata_file_old=$mediadir/.metadata-old.json
 
         local max_key_len
-        max_key_len=$(jq --raw-output 'keys[]' < $metadata_file | wc -L)
+        [ -e $metadata_file ] && max_key_len=$(jq --raw-output 'keys[]' < $metadata_file | wc -L) || max_key_len=-1
         if [ "$max_key_len" -gt 16 ] && [ ! -e $metadata_file_old ]; then
 
-            echo 'Plato 0.9.14 changed the format of metadata files.'
-            echo 'Your metadata file was found and determined to be outdated!'
-            echo 'Automatically updating the file...'
+            echo ""
+            echo "In Plato 0.9.14 the metadata format for libraries changed."
+            echo "Found your outdated metadata file. Will update it automatically..."
 
             # Routine is based on baskerville's migrate-hex_keys.py (from the release page)
             # Rewritten in bash to only require jq rather than python.
@@ -101,19 +101,17 @@ configure() {
 
             # Create updated json file
             jq "$change_cmds | del($del_list)" < $metadata_file_old > $metadata_file
-            echo 'Metadata file was updated! The old one was renamed to ".metadata-old.json".'
+            echo "Update complete. The old file was renamed to '.metadata-old.json'."
+            echo ""
 
-        elif [ "$max_key_len" -gt 16 ] && [ -e $metadata_file_old ]; then
-            echo 'MANUAL INTERVENTION REQUIRED!!!'
-            echo 'Plato 0.9.14 changed the format of metadata files.'
-            echo 'Your metadata file not found but may be outdated!'
-            echo 'Since the file could not be found, you should update it yourself!'
-            echo 'Please launch plato only after this was done! See'
-            echo 'https://github.com/baskerville/plato/releases/tag/0.9.14 for how to do it.'
-        elif [ ! -e $metadata_file ]; then
-            echo 'Plato 0.9.14 changed the format of metadata files!'
-            echo 'If you already have a library in some non-standard location, please migrate it! See'
-            echo 'https://github.com/baskerville/plato/releases/tag/0.9.14 for more.'
+        elif [ "$max_key_len" -gt 16 ] && [ -e $metadata_file_old ] || [ ! -e $metadata_file ]; then
+            echo ""
+            echo "In Plato 0.9.14 the metadata format for libraries changed."
+            echo "MANUAL INTERVENTION REQUIRED\!\!\!"
+            echo "Please follow the following guide to update your library metadata manually:"
+            echo "https://github.com/baskerville/plato/releases/tag/0.9.14"
+            echo "Please LAUNCH plato ONLY AFTER this was done\!"
+            echo ""
         fi
     fi
 }


### PR DESCRIPTION
This update doesn't add any custom reMarkable functionality.

It does however handle a breaking change that happened with [release 0.9.14](https://github.com/baskerville/plato/releases/tag/0.9.14) of the upstream plato. I ported the migration script from python to baseh (with jq as new dependency) but only support the default library location. In any case the user should get a warning anyway.

The migration messages may need some refinement. I'll probably do those tomorrow.

Tested it on the rM 1 and 2 (both with firmware 2.5.X). Is a 2.X toolchain required for the 2.6.X firmware? The other doesn't seem to work at least (using the package with 2.1 toolchain on a 2.5.X device) gives the following error:

```shell
reMarkable: ~/ rm2fb-client plato
./plato: /lib/libc.so.6: version `GLIBC_2.28' not found (required by ./plato)
```

If the 1.6 toolchain works on the 2.6.X firmware in that regard, I don't see a reason to update it yet since plato doesn't use QT.

Steps for testing:
 - Have 0.9.13 or earlier installed
 - Have some document in ~/plato-media that e.g. has some other last opened page
 - Update to this version
 - The update should automatically migrate the metadata and thus e.g. keep the last opened page
 - (It should not attempt to migrate an already up-to-date metadata file and warn if an "-old" variation was already created.)

(Some more info about this release can be found on [my release page](https://github.com/LinusCDE/plato/releases/tag/0.9.16-rm-release-8).)

---

P.S.: I'll hopefully be able to do more again in the coming days.