### PR TITLE
Add libcurl package

### DIFF
--- a/package/libcurl/package
+++ b/package/libcurl/package
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(libcurl-dev)
+pkgdesc="Client-side URL transfer library"
+url=https://curl.se/libcurl
+pkgver=7.75.0-1
+timestamp=2021-04-14T00:00:00Z
+section="devel"
+maintainer="TBD"
+license=MIT
+
+image=base:v1.5
+source=("https://curl.se/download/curl-${pkgver%-*}.tar.gz")
+sha256sums=(4d51346fe621624c3e4b9f86a8fd6f122a143820e17889f59c18f245d2d8e7a6)
+
+build() {
+    ./configure --prefix=/opt --host="$CHOST"
+    make
+    DESTDIR="$srcdir"/install make install
+}
+
+package() {
+    install -d "$pkgdir"/opt/lib/pkgconfig
+    install -m 644 "$srcdir"/install/opt/lib/libcurl.a "$pkgdir"/opt/lib/
+    install -m 644 "$srcdir"/install/opt/lib/libcurl.la "$pkgdir"/opt/lib/
+    install -m 644 "$srcdir"/install/opt/lib/libcurl.so "$pkgdir"/opt/lib/
+    install -m 644 "$srcdir"/install/opt/lib/pkgconfig/libcurl.pc "$pkgdir"/opt/lib/pkgconfig/
+
+    install -d "$pkgdir"/opt/share/aclocal/
+    install -m 644 "$srcdir"/install/opt/share/aclocal/libcurl.m4 "$pkgdir"/opt/share/aclocal/
+
+    install -d "$pkgdir"/opt/bin/
+    install -m 755 "$srcdir"/install/opt/bin/curl-config "$pkgdir"/opt/bin/
+
+    install -d "$pkgdir"/opt/include/curl
+    for file in "$srcdir"/install/opt/include/curl/*; do
+        install -m 644 "$file" "$pkgdir"/opt/include/curl/
+    done
+}

--- a/package/libcurl/package
+++ b/package/libcurl/package
@@ -22,20 +22,14 @@ build() {
 }
 
 package() {
-    install -d "$pkgdir"/opt/lib/pkgconfig
-    install -m 644 "$srcdir"/install/opt/lib/libcurl.a "$pkgdir"/opt/lib/
-    install -m 644 "$srcdir"/install/opt/lib/libcurl.la "$pkgdir"/opt/lib/
-    install -m 644 "$srcdir"/install/opt/lib/libcurl.so "$pkgdir"/opt/lib/
-    install -m 644 "$srcdir"/install/opt/lib/pkgconfig/libcurl.pc "$pkgdir"/opt/lib/pkgconfig/
+    install -D -m 644 -t "$pkgdir"/opt/lib/ \
+        "$srcdir"/install/opt/lib/libcurl.a "$srcdir"/install/opt/lib/libcurl.la "$srcdir"/install/opt/lib/libcurl.so
+    install -D -m 644 -t "$pkgdir"/opt/lib/pkgconfig "$srcdir"/install/opt/lib/pkgconfig/libcurl.pc
+    install -D -m 644 -t "$pkgdir"/opt/share/aclocal/ "$srcdir"/install/opt/share/aclocal/libcurl.m4
 
-    install -d "$pkgdir"/opt/share/aclocal/
-    install -m 644 "$srcdir"/install/opt/share/aclocal/libcurl.m4 "$pkgdir"/opt/share/aclocal/
+    install -D -m 755 -t "$pkgdir"/opt/bin/ "$srcdir"/install/opt/bin/curl-config
 
-    install -d "$pkgdir"/opt/bin/
-    install -m 755 "$srcdir"/install/opt/bin/curl-config "$pkgdir"/opt/bin/
-
-    install -d "$pkgdir"/opt/include/curl
     for file in "$srcdir"/install/opt/include/curl/*; do
-        install -m 644 "$file" "$pkgdir"/opt/include/curl/
+        install -D -m 644 -t "$pkgdir"/opt/include/curl "$file"
     done
 }


### PR DESCRIPTION
This will produce a bare-bones build of curl:
```
[   DEBUG] toltec.builder: libcurl [rmall]: SSL:              no      (--with-{ssl,gnutls,nss,mbedtls,wolfssl,schannel,secure-transport,mesalink,amissl,bearssl} )
[   DEBUG] toltec.builder: libcurl [rmall]: SSH:              no      (--with-{libssh,libssh2})
[   DEBUG] toltec.builder: libcurl [rmall]: zlib:             enabled
[   DEBUG] toltec.builder: libcurl [rmall]: brotli:           no      (--with-brotli)
[   DEBUG] toltec.builder: libcurl [rmall]: zstd:             no      (--with-zstd)
[   DEBUG] toltec.builder: libcurl [rmall]: GSS-API:          no      (--with-gssapi)
[   DEBUG] toltec.builder: libcurl [rmall]: TLS-SRP:          no      (--enable-tls-srp)
[   DEBUG] toltec.builder: libcurl [rmall]: resolver:         POSIX threaded
[   DEBUG] toltec.builder: libcurl [rmall]: IPv6:             enabled
[   DEBUG] toltec.builder: libcurl [rmall]: Unix sockets:     enabled
[   DEBUG] toltec.builder: libcurl [rmall]: IDN:              no      (--with-{libidn2,winidn})
[   DEBUG] toltec.builder: libcurl [rmall]: Build libcurl:    Shared=yes, Static=yes
[   DEBUG] toltec.builder: libcurl [rmall]: Built-in manual:  no      (--enable-manual)
[   DEBUG] toltec.builder: libcurl [rmall]: --libcurl option: enabled (--disable-libcurl-option)
[   DEBUG] toltec.builder: libcurl [rmall]: Verbose errors:   enabled (--disable-verbose)
[   DEBUG] toltec.builder: libcurl [rmall]: Code coverage:    disabled
[   DEBUG] toltec.builder: libcurl [rmall]: SSPI:             no      (--enable-sspi)
[   DEBUG] toltec.builder: libcurl [rmall]: ca cert bundle:   no
[   DEBUG] toltec.builder: libcurl [rmall]: ca cert path:
[   DEBUG] toltec.builder: libcurl [rmall]: ca fallback:
[   DEBUG] toltec.builder: libcurl [rmall]: LDAP:             no      (--enable-ldap / --with-ldap-lib / --with-lber-lib)
[   DEBUG] toltec.builder: libcurl [rmall]: LDAPS:            no      (--enable-ldaps)
[   DEBUG] toltec.builder: libcurl [rmall]: RTSP:             enabled
[   DEBUG] toltec.builder: libcurl [rmall]: RTMP:             no      (--with-librtmp)
[   DEBUG] toltec.builder: libcurl [rmall]: Metalink:         no      (--with-libmetalink)
[   DEBUG] toltec.builder: libcurl [rmall]: PSL:              no      (libpsl not found)
[   DEBUG] toltec.builder: libcurl [rmall]: Alt-svc:          enabled
[   DEBUG] toltec.builder: libcurl [rmall]: HTTP1:            enabled (--with-hyper)
[   DEBUG] toltec.builder: libcurl [rmall]: HTTP2:            no      (--with-nghttp2)
[   DEBUG] toltec.builder: libcurl [rmall]: HTTP3:            no      (--with-ngtcp2, --with-quiche)
[   DEBUG] toltec.builder: libcurl [rmall]: ECH:              no      (--enable-ech)
[   DEBUG] toltec.builder: libcurl [rmall]: Protocols:        DICT FILE FTP GOPHER HTTP IMAP MQTT POP3 RTSP SMTP TELNET TFTP
[   DEBUG] toltec.builder: libcurl [rmall]: Features:         AsynchDNS IPv6 UnixSockets alt-svc libz
```