### PR TITLE
Update KOReader to 2021.04

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,10 +5,10 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2021.03-1
-timestamp=2021-03-28T11:28:48Z
+pkgver=2021.04-1
+timestamp=2021-04-22T06:29:20Z
 section="readers"
-maintainer="raisjn <of.raisjn@gmail.com>"
+maintainer="Eeems <eeems@eeems.email>"
 license=AGPL-3.0-or-later
 installdepends=(fbink fbdepth display rm2fb-client)
 
@@ -20,7 +20,7 @@ source=(
     koreader
 )
 sha256sums=(
-    5120f0c9fc6c7f7f1f53a5f3b5b2aa29b63517ee3e9dc6f8d06f162db8b52501
+    b05d6b6d614b4eb6bc57c44a81c377947531981f2002a7b186b05b8b47956336
     SKIP
     SKIP
     SKIP

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -8,7 +8,7 @@ url=https://github.com/koreader/koreader
 pkgver=2021.04-1
 timestamp=2021-04-22T06:29:20Z
 section="readers"
-maintainer="Eeems <eeems@eeems.email>"
+maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
 installdepends=(fbink fbdepth display rm2fb-client)
 


### PR DESCRIPTION
Also change maintainer to Eeems

List of remarkable specific issues resolved in this release:

- https://github.com/koreader/koreader/issues/7519 'suspend', 'reboot' and 'poweroff' routines
  - https://github.com/koreader/koreader/pull/7563 remove extra refresh before poweroff
  - https://github.com/koreader/koreader/issues/7139 reMarkable 2 wakeup timing
- https://github.com/koreader/koreader/pull/7536 Fix for https://github.com/koreader/koreader/pull/7415 breaking reMarkable touch input
- https://github.com/koreader/koreader/issues/7508 Remarkable: "sync" command replaced as of FW 2.6
  - https://github.com/koreader/koreader/pull/7509 remarkable FW 2.6: Set absolute path for 'sync'