### PR TITLE
[TilEm][0.0.6] New Package

### DIFF
--- a/package/tilem/package
+++ b/package/tilem/package
@@ -12,8 +12,8 @@ license=GPL-3.0
 section="utils"
 image=base:v2.1
 
-source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.6.tar.gz)
-sha256sums=(ff3e5a903cb5e375a66eb0445ef107ce93823cad723b37b85ec39dff87f6c015)
+source=(https://github.com/timower/rM2-stuff/archive/8dc94a360358bf74da244beda74739663dd44741.tar.gz)
+sha256sums=(23192117d3e8bb3ddba5d909e80dea7354aa4c5e2936047ca2cb3d35e906ecc1)
 
 build() {
     mkdir build

--- a/package/tilem/package
+++ b/package/tilem/package
@@ -5,15 +5,15 @@
 pkgnames=(tilem)
 pkgdesc="TI-84+ calculator emulator"
 url=https://github.com/timower/rM2-stuff/tree/master/apps/tilem
-pkgver=0.0.6-1
+pkgver=0.0.7-1
 timestamp=2021-04-30T10:42Z
 maintainer="None <none@example.com>"
 license=GPL-3.0
 section="utils"
 image=base:v2.1
 
-source=(https://github.com/timower/rM2-stuff/archive/8dc94a360358bf74da244beda74739663dd44741.tar.gz)
-sha256sums=(23192117d3e8bb3ddba5d909e80dea7354aa4c5e2936047ca2cb3d35e906ecc1)
+source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.7.tar.gz)
+sha256sums=(ed2db5f1aa7c9e8b0bead53bd60cb8fd9eec24c028d789fdbdc4b1655d6c78ce)
 
 build() {
     mkdir build

--- a/package/tilem/package
+++ b/package/tilem/package
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(tilem)
+pkgdesc="TI-84+ calculator emulator"
+url=https://github.com/timower/rM2-stuff/tree/master/apps/tilem
+pkgver=0.0.6-1
+timestamp=2021-04-30T10:42Z
+maintainer="None <none@example.com>"
+license=GPL-3.0
+section="utils"
+image=base:v2.1
+
+source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.6.tar.gz)
+sha256sums=(ff3e5a903cb5e375a66eb0445ef107ce93823cad723b37b85ec39dff87f6c015)
+
+build() {
+    mkdir build
+    mkdir install
+    cd build
+    cmake -DCMAKE_TOOLCHAIN_FILE="/usr/share/cmake/$CHOST.cmake" \
+        -DCMAKE_INSTALL_PREFIX="../install" -DCMAKE_BUILD_TYPE=Release ..
+    cd apps/tilem
+    make
+    make install
+}
+
+package() {
+    cp -r "$srcdir/install/." "$pkgdir"
+}


### PR DESCRIPTION
Adds tilem, my port of the ti calculator emulator.
Currently only support ti84+. It should popup to download a ROM file if none is available.