### PR TITLE
Update packages for release 2.6 and onwards

### DIFF
--- a/package/appmarkable/package
+++ b/package/appmarkable/package
@@ -5,7 +5,7 @@
 pkgnames=(appmarkable)
 pkgdesc="Front-end for apps that do not have a graphical user interface"
 url="https://github.com/LinusCDE/appmarkable"
-pkgver=0.0.0-10
+pkgver=0.0.0-11
 timestamp=2021-03-10T18:36Z
 section="devel"
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=rust:v1.4
+image=rust:v2.1
 source=(https://github.com/LinusCDE/appmarkable/archive/c44ee87ea2b1f1e41c9592476c076150c9a1acf4.zip)
 sha256sums=(76e151aeae0f18b206dd3c6258bf74bcb5256ee2f803e1ed2073278831158f60)
 

--- a/package/bash-completion/package
+++ b/package/bash-completion/package
@@ -5,7 +5,7 @@
 pkgnames=(bash-completion)
 pkgdesc="Programmable completion functions for bash"
 url=https://github.com/scop/bash-completion
-pkgver=2.11-1
+pkgver=2.11-2
 timestamp=2020-07-25T00:00Z
 section="utils"
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -14,7 +14,7 @@ license=GPL-2.0-only
 # Based on the ArchLinux PKGBUILD file:
 # https://github.com/archlinux/svntogit-packages/blob/packages/bash-completion/trunk/PKGBUILD
 
-image=base:v1.3.2
+image=base:v2.1
 source=(https://github.com/scop/bash-completion/releases/download/2.11/bash-completion-2.11.tar.xz)
 sha256sums=(73a8894bad94dee83ab468fa09f628daffd567e8bef1a24277f1e9a0daf911ac)
 

--- a/package/bash-completion/package
+++ b/package/bash-completion/package
@@ -5,7 +5,7 @@
 pkgnames=(bash-completion)
 pkgdesc="Programmable completion functions for bash"
 url=https://github.com/scop/bash-completion
-pkgver=2.11-2
+pkgver=2.11-3
 timestamp=2020-07-25T00:00Z
 section="utils"
 maintainer="Linus K. <linus@cosmos-ink.net>"

--- a/package/calculator/package
+++ b/package/calculator/package
@@ -5,7 +5,7 @@
 pkgnames=(calculator)
 pkgdesc="Touch-based calculator"
 url=https://github.com/reHackable/Calculator
-pkgver=0.0.0-14
+pkgver=0.0.0-15
 timestamp=2020-08-20T12:28Z
 section="math"
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -14,7 +14,7 @@ installdepends=(display)
 makedepends=(build:imagemagick build:librsvg2-bin)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=(
     https://github.com/reHackable/Calculator/archive/7b8be5de12f1536bc04b6216abbf26f998097bf4.zip
     calculator.draft

--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -5,7 +5,7 @@
 pkgnames=(chessmarkable)
 pkgdesc="Chess game"
 url=https://github.com/LinusCDE/chessmarkable
-pkgver=0.7.0-1
+pkgver=0.7.0-2
 timestamp=2021-06-03T10:47Z
 section="games"
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=rust:v1.6
+image=rust:v2.1
 source=(https://github.com/LinusCDE/chessmarkable/archive/0.7.0-1.zip)
 sha256sums=(34d388f094863d849b23a9dd0e069575ff6a5dec547da3920d59308f2e369c9a)
 

--- a/package/display/package
+++ b/package/display/package
@@ -8,10 +8,10 @@ timestamp=2021-02-21T01:41+00:00
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1.0.1-4
+pkgver=1.0.1-5
 section="devel"
 
-image=qt:v1.4
+image=qt:v2.1
 source=(
     https://github.com/ddvk/remarkable2-framebuffer/archive/v0.0.4.zip
     rm2fb.service

--- a/package/display/package
+++ b/package/display/package
@@ -8,7 +8,7 @@ timestamp=2021-02-21T01:41+00:00
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1.0.1-5
+pkgver=1.0.1-6
 section="devel"
 
 image=qt:v2.1

--- a/package/draft/package
+++ b/package/draft/package
@@ -5,7 +5,7 @@
 pkgnames=(draft)
 pkgdesc="Launcher which wraps around the standard interface"
 url=https://github.com/dixonary/draft-reMarkable
-pkgver=0.2.0-19
+pkgver=0.2.0-20
 timestamp=2020-07-20T10:23Z
 section="launchers"
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -13,7 +13,7 @@ license=Apache-2.0
 installdepends=(xochitl display)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=(
     https://github.com/dixonary/draft-reMarkable/archive/5bd660a2fd07eba166c6110d2b48cfc58ee67e58.zip
     draft.service

--- a/package/evtest/package
+++ b/package/evtest/package
@@ -5,14 +5,14 @@
 pkgnames=(evtest)
 pkgdesc="Kernel evdev device information and monitor"
 url=https://gitlab.freedesktop.org/libevdev/evtest
-pkgver=1.34-2
+pkgver=1.34-3
 timestamp=2020-12-30T02:52Z
 section="utils"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=GPL-2.0-only
 makedepends=(build:automake)
 
-image=base:v1.2.1
+image=base:v2.1
 source=("https://gitlab.freedesktop.org/libevdev/evtest/-/archive/evtest-${pkgver%-*}/evtest-evtest-${pkgver%-*}.zip")
 sha256sums=(62f7e34c5bab91b5015de5b056d79051c677c5bd5702facb2885f8e4ba0df84c)
 

--- a/package/fbink/package
+++ b/package/fbink/package
@@ -4,12 +4,12 @@
 
 pkgnames=(fbink fbdepth fbink-doom)
 url=https://github.com/NiLuJe/FBInk
-pkgver=1.23.1-3
+pkgver=1.23.1-4
 timestamp=2020-12-14T12:30Z
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 
-image=base:v1.2.1
+image=base:v2.1
 source=()
 sha256sums=()
 

--- a/package/fingerterm/package
+++ b/package/fingerterm/package
@@ -5,7 +5,7 @@
 pkgnames=(fingerterm)
 pkgdesc="Terminal emulator with an on-screen touch keyboard"
 url=https://github.com/dixonary/fingerterm-reMarkable
-pkgver=1.3.5-13
+pkgver=1.3.5-14
 timestamp=2020-10-27T12:02Z
 section="admin"
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -13,7 +13,7 @@ license=GPL-2.0-or-later
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=(
     https://github.com/dixonary/fingerterm-reMarkable/archive/02c17b5b485743c698e005ca89366c32b66aa044.zip
     fingerterm.png

--- a/package/fuse/fix-multiple-yylloc-definitions.patch
+++ b/package/fuse/fix-multiple-yylloc-definitions.patch
@@ -1,0 +1,26 @@
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 790fbf6c..e7eab4d7 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index ba525c2f..a2fe8dbc 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -637,7 +637,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/package/fuse/package
+++ b/package/fuse/package
@@ -6,7 +6,7 @@ archs=(rm1 rm2)
 pkgnames=(fuse)
 pkgdesc="FUSE (Filesystem in Userspace) Kernel Module"
 url=https://github.com/libfuse/libfuse
-pkgver=1.0.0-1
+pkgver=1.0.0-2
 timestamp=2021-04-06T22:16Z
 section=utils
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"
@@ -14,19 +14,27 @@ license=GPL-2.0-only
 makedepends=(build:bc build:lzop build:git)
 flags=(nostrip)
 
+image=base:v2.1
+source=(fix-multiple-yylloc-definitions.patch)
+sha256sums=(SKIP)
+
 _kernelrepo=https://github.com/remarkable/linux
 _kernelrev=1774e2a6a091fdc081324e966d3db0aa9df75c0b
 _defconfig=arch/arm/configs/zero-gravitas_defconfig
 
-image=base:v1.3.2
-
-build() {
+prepare() {
+    cd "$srcdir"
     mkdir pkg
     git init linux
+    cd linux
+    git fetch --depth=1 "$_kernelrepo" "$_kernelrev"
+    git checkout -f "$_kernelrev"
+    git apply "$srcdir"/fix-multiple-yylloc-definitions.patch
+}
+
+build() {
     (
         cd linux
-        git fetch --depth=1 "$_kernelrepo" "$_kernelrev"
-        git checkout -f "$_kernelrev"
         make mrproper
         touch .scmversion
         cp "$_defconfig" .config

--- a/package/gocryptfs/package
+++ b/package/gocryptfs/package
@@ -6,24 +6,16 @@ pkgnames=(gocryptfs)
 pkgdesc="An encrypted overlay filesystem written in Go."
 url="https://nuetzlich.net/gocryptfs/"
 _srcver=2.0-beta2
-pkgver="$_srcver"-1
+pkgver="$_srcver"-2
 timestamp=2021-03-22
 section=utils
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"
 license=MIT
-
-makedepends=()
 installdepends=(fuse fuse-utils)
 
-image=golang:v1.5
-
-source=(
-    https://github.com/rfjakob/gocryptfs/archive/v"$_srcver".zip
-)
-
-sha256sums=(
-    3d66368cfc79a300de5a22fe01788d0c702f9107731db63fcd8850157d105cc0
-)
+image=golang:v2.1
+source=(https://github.com/rfjakob/gocryptfs/archive/v"$_srcver".zip)
+sha256sums=(3d66368cfc79a300de5a22fe01788d0c702f9107731db63fcd8850157d105cc0)
 
 prepare() {
     # Official build script runs compiled binary to show version.

--- a/package/innernet/package
+++ b/package/innernet/package
@@ -5,7 +5,7 @@
 pkgnames=(innernet-client)
 pkgdesc="A private network system that uses WireGuard under the hood."
 url="https://github.com/tonarino/innernet"
-pkgver=1.3.1-1
+pkgver=1.3.1-2
 timestamp=2021-06-01T12:50:04Z
 section="utils"
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"

--- a/package/innernet/package
+++ b/package/innernet/package
@@ -5,7 +5,7 @@
 pkgnames=(innernet-client)
 pkgdesc="A private network system that uses WireGuard under the hood."
 url="https://github.com/tonarino/innernet"
-pkgver=1.3.0-1
+pkgver=1.3.0-2
 timestamp=2021-05-19T08:17:04Z
 section="utils"
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(wireguard)
 makedepends=(build:librust-clang-sys-dev build:libclang-dev build:libc6 build:libc6-dev build:clang build:gcc-multilib build:g++-multilib)
 
-image=rust:v1.4
+image=rust:v2.1
 source=(https://github.com/tonarino/innernet/archive/refs/tags/v1.3.0.zip)
 sha256sums=(de3feb881c64ff91aa626aaa5b16e24c2a2c37688c4989b8394e1e15a175112e)
 

--- a/package/keywriter/package
+++ b/package/keywriter/package
@@ -5,7 +5,7 @@
 pkgnames=(keywriter)
 pkgdesc="Markdown-enabled free writing app"
 url=https://github.com/dps/remarkable-keywriter
-pkgver=0.1.0-2
+pkgver=0.1.0-3
 timestamp=2019-07-13T06:27Z
 section="writing"
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 _sundown=37728fb2d7137ff7c37d0a474cb827a8d6d846d8
 source=(
     https://github.com/dps/remarkable-keywriter/archive/c77ec3f65d9ff769f3f5dc85cc91abbf05aa163f.zip

--- a/package/libdlib/package
+++ b/package/libdlib/package
@@ -5,13 +5,13 @@
 pkgnames=(libdlib libdlib-dev)
 pkgdesc="Toolkit for making machine learning and data analysis applications in C++"
 url=http://dlib.net
-pkgver=19.21-1
+pkgver=19.21-2
 timestamp=2020-08-08T19:41:07Z
 section="devel"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=BSL-1.0
 
-image=base:v1.3.1
+image=base:v2.1
 source=("https://github.com/davisking/dlib/archive/v${pkgver%-*}.tar.gz")
 sha256sums=(116f52e58be04b47dab52057eaad4b5c4d5c3032d927fe23d55b0741fc4107a0)
 

--- a/package/libvncserver/package
+++ b/package/libvncserver/package
@@ -5,13 +5,13 @@
 pkgnames=(libvncserver libvncclient libvncserver-dev)
 pkgdesc="C libraries for implementing VNC servers or clients"
 url=https://libvnc.github.io
-pkgver=0.9.13-1
+pkgver=0.9.13-2
 timestamp=2020-06-13T19:19:11Z
 section="devel"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-2.0-or-later
 
-image=base:v1.3.1
+image=base:v2.1
 source=("https://github.com/LibVNC/libvncserver/archive/LibVNCServer-${pkgver%-*}.zip")
 sha256sums=(d209d70998a9b98f9120eeb82df7a17767796c477eaa8297e0a55856a977c54f)
 

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -10,8 +10,18 @@ license=MIT
 flags=(patch_rm2fb)
 
 image=qt:v2.1
-source=("https://github.com/Eeems/oxide/archive/30aab3456b9f8b37ffb667cbc8b5e2a686f3e98e.tar.gz")
-sha256sums=(1ddd7bcd71aa12855348bde72bd0d0e7f91f1b958b054614c02eaa4b99168644)
+source=(
+    "https://github.com/Eeems/oxide/archive/30aab3456b9f8b37ffb667cbc8b5e2a686f3e98e.tar.gz"
+    support-2.6.patch
+)
+sha256sums=(
+    1ddd7bcd71aa12855348bde72bd0d0e7f91f1b958b054614c02eaa4b99168644
+    SKIP
+)
+
+prepare() {
+    patch -d "$srcdir" -p1 < "$srcdir"/support-2.6.patch
+}
 
 build() {
     find . -name "*.pro" -type f -print0 \

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish decay)
-pkgver=2.1.2-2
+pkgver=2.1.2-3
 timestamp=2021-01-07T03:28Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=("https://github.com/Eeems/oxide/archive/30aab3456b9f8b37ffb667cbc8b5e2a686f3e98e.tar.gz")
 sha256sums=(1ddd7bcd71aa12855348bde72bd0d0e7f91f1b958b054614c02eaa4b99168644)
 

--- a/package/oxide/support-2.6.patch
+++ b/package/oxide/support-2.6.patch
@@ -1,0 +1,35 @@
+diff --git a/applications/launcher/main.qml b/applications/launcher/main.qml
+index a54f2b8..ada050e 100755
+--- a/applications/launcher/main.qml
++++ b/applications/launcher/main.qml
+@@ -34,7 +34,7 @@ ApplicationWindow {
+                 CustomMenu {
+                     BetterMenu {
+                         id: optionsMenu
+-                        title: "";
++                        title: qsTr("")
+                         font: iconFont.name
+                         width: 310
+                         Action { text: qsTr(" Reload"); onTriggered: appsView.model = controller.getApps() }
+@@ -142,7 +142,7 @@ ApplicationWindow {
+                 CustomMenu {
+                     BetterMenu {
+                         id: powerMenu
+-                        title: "";
++                        title: qsTr("")
+                         font: iconFont.name
+                         width: 260
+                         Action {
+diff --git a/applications/lockscreen/main.qml b/applications/lockscreen/main.qml
+index e835268..3fd18c1 100644
+--- a/applications/lockscreen/main.qml
++++ b/applications/lockscreen/main.qml
+@@ -94,7 +94,7 @@ ApplicationWindow {
+                 CustomMenu {
+                     BetterMenu {
+                         id: powerMenu
+-                        title: "";
++                        title: qsTr("");
+                         font: iconFont.name
+                         width: 260
+                         Action {

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,7 +5,7 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.17-1
+pkgver=0.9.17-2
 timestamp=2021-05-02T14:39Z
 section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -14,7 +14,7 @@ installdepends=(display jq)
 makedepends=(build:jq build:unzip build:wget)
 flags=(patch_rm2fb)
 
-image=rust:v1.6
+image=rust:v2.1
 source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-10.zip")
 sha256sums=(25aae17979d9e259d228617eb26a0cc89a6251968b8fc355b8cde36fd6b26773)
 

--- a/package/puzzles/package
+++ b/package/puzzles/package
@@ -5,14 +5,14 @@
 pkgnames=(puzzles)
 timestamp=2021-03-04T14:03-08:00
 maintainer="NONE"
-pkgver=0.2.2-1
+pkgver=0.2.2-2
 license=MIT
 pkgdesc="Simon Tatham's Puzzle Package"
 url="https://github.com/mrichards42/remarkable_puzzles"
 section="games"
 flags=(patch_rm2fb)
 
-image=python:v1.4
+image=python:v2.1
 source=(
     https://github.com/mrichards42/remarkable_puzzles/releases/download/v0.2.2/puzzles-source.tar.gz
     puzzles.draft

--- a/package/quickjs/package
+++ b/package/quickjs/package
@@ -5,13 +5,13 @@
 pkgnames=(quickjs)
 pkgdesc="A small and embeddable Javascript engine"
 url=https://bellard.org/quickjs/
-pkgver=2020.11.08-1
+pkgver=2020.11.08-2
 section="devel"
 timestamp=2020-11-08T13:44Z
 maintainer="khanhas <xuankhanh963@gmail.com>"
 license=MIT
 
-image=base:v1.3.2
+image=base:v2.1
 source=(
     https://bellard.org/quickjs/quickjs-2020-11-08.tar.xz
     quickjs.patch

--- a/package/recrossable/package
+++ b/package/recrossable/package
@@ -5,7 +5,7 @@
 pkgnames=(recrossable)
 pkgdesc="Solve crossword puzzles"
 url=https://github.com/sandsmark/recrossable
-pkgver=0.0.0-6
+pkgver=0.0.0-7
 timestamp=2021-01-15T12:58:22Z
 section="games"
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -14,7 +14,7 @@ installdepends=(libdlib display)
 makedepends=(build:imagemagick build:librsvg2-bin host:libdlib host:libdlib-dev)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=(
     https://github.com/sandsmark/recrossable/archive/234d5744c0b20087a588d0ecead0a9f58c1f323d.zip
     recrossable.draft

--- a/package/remarkable-splash/package
+++ b/package/remarkable-splash/package
@@ -5,7 +5,7 @@
 pkgnames=(remarkable-splash)
 pkgdesc="Show splashscreens + remarkable-shutdown replacement that does not clear the screen"
 url=https://github.com/ddvk/remarkable-splash
-pkgver=1.0-4
+pkgver=1.0-5
 timestamp=2019-12-31T10:07Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=(https://github.com/ddvk/remarkable-splash/archive/e6e0b1e1f3604ab99fb7b476cd290b19c5644025.zip)
 sha256sums=(4aa3988707f9b66752ec9ec2f407cce2ac6e433ae7f06affea9f26957d206b4a)
 

--- a/package/restream/package
+++ b/package/restream/package
@@ -5,12 +5,13 @@
 pkgnames=(restream)
 pkgdesc="Binary framebuffer capture tool for the reStream script"
 url=https://github.com/rien/reStream
-pkgver=1.1-1
+pkgver=1.1-2
 timestamp=2021-01-28T23:25:40Z
 section="screensharing"
 maintainer="Dan Shick <dan.shick@gmail.com>"
 license=MIT
-image=rust:v1.3
+
+image=rust:v2.1
 source=("https://github.com/rien/reStream/archive/${pkgver%-*}.tar.gz")
 sha256sums=(89fa4c8adfcdfb5266e11d1f8ed4c5d8dac12a68a7ee5622cf21f833bca1704f)
 

--- a/package/retris/package
+++ b/package/retris/package
@@ -5,7 +5,7 @@
 pkgnames=(retris)
 pkgdesc="Tetris game"
 url=https://github.com/LinusCDE/retris
-pkgver=0.6.3-2
+pkgver=0.6.3-3
 timestamp=2021-01-30T02:41Z
 section="games"
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=rust:v1.4
+image=rust:v2.1
 source=(https://github.com/LinusCDE/retris/archive/0.6.3-1.zip)
 sha256sums=(ecc7215098c03e79cd92b1835626e6739a5a932d5aa709899d183347e2a4108e)
 

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -9,7 +9,7 @@ license=MIT
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=python:v1.1
+image=python:v2.1
 source=(
     https://github.com/rmkit-dev/rmkit/archive/a99b2f70c72539bedc1d201e3899da6e19c197da.zip
     patch-remux-duplicate-xochitl.diff
@@ -36,7 +36,7 @@ build() {
 bufshot() {
     pkgdesc="program for saving the framebuffer as a png"
     url="https://github.com/rmkit-dev/rmkit/tree/master/src/bufshot"
-    pkgver=0.1.0-4
+    pkgver=0.1.0-5
     section="utils"
 
     package() {
@@ -47,7 +47,7 @@ bufshot() {
 genie() {
     pkgdesc="Gesture engine that connects commands to gestures"
     url="https://rmkit.dev/apps/genie"
-    pkgver=0.1.5-2
+    pkgver=0.1.5-3
     section="utils"
 
     package() {
@@ -74,7 +74,7 @@ genie() {
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.1.3-2
+    pkgver=0.1.3-3
     section="drawing"
 
     package() {
@@ -91,7 +91,7 @@ harmony() {
 iago() {
     pkgdesc="overlay for drawing shapes via stroke injection"
     url="https://rmkit.dev/apps/iago"
-    pkgver=0.1.0-3
+    pkgver=0.1.0-4
     section="utils"
     installdepends+=("lamp")
 
@@ -103,7 +103,7 @@ iago() {
 lamp() {
     pkgdesc="config based stroke injection utility"
     url="https://rmkit.dev/apps/lamp"
-    pkgver=0.1.0-3
+    pkgver=0.1.0-4
     section="utils"
 
     package() {
@@ -114,7 +114,7 @@ lamp() {
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.1.2-3
+    pkgver=0.1.2-4
     section="games"
 
     package() {
@@ -127,7 +127,7 @@ mines() {
 nao() {
     pkgdesc="Nao Package Manager: opkg UI built with SAS"
     url="https://rmkit.dev/apps/nao"
-    pkgver=0.1.2-2
+    pkgver=0.1.2-3
     section="admin"
     installdepends+=(simple)
 
@@ -141,7 +141,7 @@ nao() {
 remux() {
     pkgdesc="Launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.9-2
+    pkgver=0.1.9-3
     section="launchers"
 
     package() {
@@ -173,7 +173,7 @@ remux() {
 simple() {
     pkgdesc="Simple app script for writing scripted applications"
     url="https://rmkit.dev/apps/sas"
-    pkgver=0.1.4-2
+    pkgver=0.1.4-3
     section="devel"
 
     package() {

--- a/package/rmservewacominput/package
+++ b/package/rmservewacominput/package
@@ -5,14 +5,14 @@
 pkgnames=(rmservewacominput)
 pkgdesc="Serve pen input on port 33333"
 url=https://github.com/LinusCDE/rmWacomToMouse
-pkgver=0.3.0-1
+pkgver=0.3.0-2
 timestamp=2021-03-10T18:36Z
 section="utils"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
 installdepends=(appmarkable)
 
-image=base:v1.4
+image=base:v2.1
 source=(
     https://github.com/LinusCDE/rmWacomToMouse/archive/fd1c5454b65f456f6e890b99109e50a8f576dad1.zip
     rmservewacominput.draft

--- a/package/templatectl/package
+++ b/package/templatectl/package
@@ -5,13 +5,13 @@
 pkgnames=(templatectl)
 pkgdesc="Tool to add/remove templates for xochitl"
 url=https://github.com/PeterGrace/templatectl
-pkgver=0.1.3-2
+pkgver=0.1.3-3
 timestamp=2021-01-15T01:23Z
 section="templates"
 maintainer="Peter Grace <pete.grace@gmail.com>"
 license=MIT
 
-image=rust:v1.2.2
+image=rust:v2.1
 source=("https://github.com/PeterGrace/templatectl/archive/v${pkgver%-*}.zip")
 sha256sums=(1ac1049c7db4f87c113dbc96372f8f4e2b8bd4c60252e3c4f7c1fafb5ee61ae4)
 

--- a/package/toltec-completion/package
+++ b/package/toltec-completion/package
@@ -5,7 +5,7 @@
 pkgnames=(toltec-completion)
 pkgdesc="Expands bash-completion with functions for toltec-specific commands"
 url=https://github.com/toltec-dev/toltec
-pkgver=0.1.0-2
+pkgver=0.1.0-3
 timestamp=2021-02-07T13:47Z
 section="utils"
 maintainer="Linus K. <linus@cosmos-ink.net>"

--- a/package/vnsee/package
+++ b/package/vnsee/package
@@ -5,7 +5,7 @@
 pkgnames=(vnsee)
 pkgdesc="VNC client allowing you to use the device as a second screen"
 url=https://github.com/matteodelabre/vnsee
-pkgver=0.4.0-1
+pkgver=0.4.0-2
 timestamp=2021-04-24T20:36:31Z
 section="screensharing"
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -13,7 +13,7 @@ license=GPL-3.0-only
 installdepends=(display libvncclient nmap simple)
 makedepends=(host:libvncclient host:libvncserver-dev)
 
-image=base:v1.4
+image=base:v2.1
 _boost_pp_ver=5e17804af2496e13ca0cc03d892b5351b637ea43
 source=(
     "https://github.com/matteodelabre/vnsee/archive/v${pkgver%-*}.zip"

--- a/package/wikipedia/package
+++ b/package/wikipedia/package
@@ -5,7 +5,7 @@
 pkgnames=(wikipedia)
 pkgdesc="The free encyclopedia"
 url=https://github.com/dps/remarkable-wikipedia
-pkgver=0.1.0-2
+pkgver=0.1.0-3
 timestamp=2021-03-11T04:50Z
 section="readers"
 maintainer="David Singleton <david@singleton.io>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=(
     https://github.com/dps/remarkable-wikipedia/archive/eb00876ef49e7deedc127bc6c1486e3ed13aedcc.zip
     wikipedia.draft

--- a/package/wireguard/fix-multiple-yylloc-definitions.patch
+++ b/package/wireguard/fix-multiple-yylloc-definitions.patch
@@ -1,0 +1,26 @@
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 790fbf6c..e7eab4d7 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,7 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index ba525c2f..a2fe8dbc 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -637,7 +637,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */

--- a/package/wireguard/package
+++ b/package/wireguard/package
@@ -5,7 +5,7 @@
 pkgnames=(wireguard)
 pkgdesc="Fast, modern, secure VPN tunnel"
 url=https://www.wireguard.com
-pkgver=1.0.20210219-1
+pkgver=1.0.20210219-2
 _wireguardtoolsver=1.0.20210223
 timestamp=2021-02-19T14:08Z
 section=utils
@@ -24,15 +24,17 @@ _defconfigs=(
     arch/arm/configs/zero-sugar_defconfig
 )
 
-image=base:v1.3.2
+image=base:v2.1
 source=(
     "https://git.zx2c4.com/wireguard-linux-compat/snapshot/wireguard-linux-compat-${pkgver%-*}.tar.xz"
     "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-${_wireguardtoolsver}.tar.xz"
+    fix-multiple-yylloc-definitions.patch
 )
 noextract=("wireguard-tools-${_wireguardtoolsver}.tar.xz")
 sha256sums=(
     99d35296b8d847a0d4db97a4dda96b464311a6354e75fe0bef6e7c4578690f00
     1f72da217044622d79e0bab57779e136a3df795e3761a3fc1dc0941a9055877c
+    SKIP
 )
 
 prepare() {
@@ -54,6 +56,7 @@ build() {
             cd linux
             git fetch --depth=1 "$_kernelrepo" "${_kernelrevs[$i]}"
             git checkout -f "${_kernelrevs[$i]}"
+            git apply "$srcdir"/fix-multiple-yylloc-definitions.patch || true
             make mrproper
             touch .scmversion
             cp "${_defconfigs[$i]}" .config

--- a/package/yaft/package
+++ b/package/yaft/package
@@ -5,12 +5,12 @@
 pkgnames=(yaft)
 pkgdesc="Yet another framebuffer terminal"
 url=https://github.com/timower/rM2-stuff/tree/master/apps/yaft
-pkgver=0.0.4-2
+pkgver=0.0.4-3
 timestamp=2021-04-30T10:42Z
 maintainer="None <none@example.com>"
 license=GPL-3.0
 section="admin"
-image=base:v1.6
+image=base:v2.1
 
 source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.4.tar.gz)
 sha256sums=(dee471ac19ea43ba741f826c9a0a17d7a01bda6472043d400fbcab6fad1931fe)

--- a/package/zoneinfo-utils/package
+++ b/package/zoneinfo-utils/package
@@ -8,15 +8,15 @@ pkgnames=(zoneinfo-utils)
 pkgdesc="Utilities for interacting with zoneinfo files"
 url=https://www.iana.org/time-zones
 _tzver=2021a
-pkgver="$_tzver"-1
+pkgver="$_tzver"-2
 timestamp=2020-05-04T06:16Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license="custom: public domain"
 installdepends=(zoneinfo-core)
 makedepends=(build:gawk)
-image=base:v1.3.2
 
+image=base:v2.1
 source=(
     "https://www.iana.org/time-zones/repository/releases/tzcode${_tzver}.tar.gz"
     "https://www.iana.org/time-zones/repository/releases/tzdata${_tzver}.tar.gz"

--- a/package/zshelf/package
+++ b/package/zshelf/package
@@ -5,7 +5,7 @@
 pkgnames=(zshelf)
 pkgdesc="Z-Library browser and downloader"
 url=https://github.com/khanhas/zshelf
-pkgver=0.3.1-2
+pkgver=0.3.1-3
 section=utils
 timestamp=2021-02-20T01:45Z
 maintainer="khanhas <xuankhanh963@gmail.com>"
@@ -14,7 +14,7 @@ installdepends=(node display)
 makedepends=(build:imagemagick build:librsvg2-bin)
 flags=(patch_rm2fb)
 
-image=qt:v1.4
+image=qt:v2.1
 source=(
     https://github.com/khanhas/zshelf/archive/v0.3.1.zip
     zshelf.draft


### PR DESCRIPTION
With release 2.6 having reached most users, I think it makes sense to rebuild our packages to use the 2.x toolchain. This will make Toltec work with updates 2.6 and onwards (fixes #322), at the price of **breaking compatibility with system updates 2.5 and earlier.**

Testing plan: Having update 2.7.1 installed, I went through basic checks for each package on rM2 to make sure that each app at least starts up and seems to react to user input.