### PR TITLE
Hotfix: Fix local wget download issue in stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "46f556b06f5624b48e974ae040b6213828eff6aa2cc78618a4d8961a27cdc8b3  bootstrap" | sha256sum -c && bash bootstrap
+$ echo "5f826348764f664e577700c4d9d97e36f250ac27b616f7c09ba4a80e604a3012  bootstrap" | sha256sum -c && bash bootstrap
 ```
 
 > **Warning:**

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,8 +5,8 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Toltec installation script"
 url=https://toltec-dev.org/
-pkgver=0.0.1-3
-timestamp=2021-01-15T20:15Z
+pkgver=0.0.1-4
+timestamp=2021-06-18T11:59Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -95,9 +95,6 @@ wget-bootstrap() {
 
         # Download and compare to hash
         mkdir -p "$(dirname "$wget_path")"
-        touch "$wget_path"
-        chmod +x "$wget_path"
-
         wget "$wget_remote" --output-document "$wget_path" 2> /dev/null
 
         if ! sha256sum -c <(echo "$wget_checksum  $wget_path") > /dev/null 2>&1; then
@@ -105,6 +102,8 @@ wget-bootstrap() {
             error-cleanup
             exit 1
         fi
+
+        chmod +x "$wget_path"
     fi
 
     # Ensure the local binary is used


### PR DESCRIPTION
The bootstrap script that’s currently in stable creates an empty `/home/root/.local/bin/wget` file before downloading its contents using `wget`. If a user happens to have `/home/root/.local/bin` in their PATH before the `/usr/bin` folder, then the script will try to use the empty `/home/root/.local/bin/wget` binary to download itself! (See #368.)

This issue is already fixed in testing, so this PR is just a backport of this fix to the stable branch.

Test plan: From a clean system, with no file in `/home/root/.local/bin/wget`, set your `PATH` to include the `/home/root/.local/bin` folder before the `/usr/bin` folder. With the old bootstrap script, this should result in a checksum mismatch error. With this PR’s bootstrap script, the install should complete successfully.

I tested this on my rM2.