### PR TITLE
display: Add support for release 2.8

### DIFF
--- a/package/display/package
+++ b/package/display/package
@@ -8,18 +8,18 @@ timestamp=2021-02-21T01:41+00:00
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1.0.1-4
+pkgver=1.0.1-5
 section="devel"
 
 image=qt:v1.4
 source=(
-    https://github.com/ddvk/remarkable2-framebuffer/archive/v0.0.4.zip
+    https://github.com/ddvk/remarkable2-framebuffer/archive/v0.0.5.zip
     rm2fb.service
     rm2fb-client
     rm2fb-preload.conf
 )
 sha256sums=(
-    945db410c233be0241c7bfa57c10cb5dd9fcddee17962090d8352a5b7b89f94a
+    002a4f819077194ca497a8d23da8a83c6f6fed7882fba7a5bdba93559394c96b
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
This PR updates the display package to use rm2fb’s 0.0.5 release. This release fixes support for the 2.8 system update.

Test plan: On rM2, install the updated `display` and `rm2fb-client` packages and make sure that Xochitl with the rm2fb client shim starts without errors.