### PR TITLE
Fix toltecctl set-path command if .bashrc does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "47f208632d93f368b267e66413150aa7c7da43bac0431f893b1fd2ea146ceced  bootstrap" | sha256sum -c && bash bootstrap
+$ echo "c930e94a4145c31e63ac8c66b1b0f5a192a91f31946d758bfc1470338cb64bae  bootstrap" | sha256sum -c && bash bootstrap
 ```
 
 > **Warning:**

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,8 +5,8 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Manage your Toltec install"
 url=https://toltec-dev.org/
-pkgver=0.0.6-1
-timestamp=2021-06-06T08:36Z
+pkgver=0.0.7-1
+timestamp=2021-06-20T20:46Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/package/toltec-bootstrap/toltecctl
+++ b/package/toltec-bootstrap/toltecctl
@@ -115,10 +115,12 @@ reinstall-root() {
 
 clean-path() {
     # Remove all PATH definitions for /opt in bashrc
-    sed -i "/^$bashrc_start_marker\$/,/^$bashrc_end_marker\$/d" "$bashrc_path"
-    sed -i "/^$bashrc_old_start_marker\$/!b;n;d" "$bashrc_path"
-    sed -i "/^$bashrc_old_start_marker\$/d" "$bashrc_path"
-    sed -i '/^\(export \)\?PATH="\?\.*\/opt\/bin:\/opt\/sbin.*"\?$/d' "$bashrc_path"
+    if [[ -f $bashrc_path ]]; then
+        sed -i "/^$bashrc_start_marker\$/,/^$bashrc_end_marker\$/d" "$bashrc_path"
+        sed -i "/^$bashrc_old_start_marker\$/!b;n;d" "$bashrc_path"
+        sed -i "/^$bashrc_old_start_marker\$/d" "$bashrc_path"
+        sed -i '/^\(export \)\?PATH="\?\.*\/opt\/bin:\/opt\/sbin.*"\?$/d' "$bashrc_path"
+    fi
 }
 
 set-path() {

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -95,7 +95,7 @@ check-installed() {
     if ((has_entware_files == 0)) && ((has_opt_files == 0)) \
         && ((has_bashrc_defs == 0)) && ((has_systemd_mount == 0)); then
         log "Toltec is already installed"
-        log "To re-enable Toltec after a system upgrade, run 'toltecctl enable'"
+        log "To re-enable Toltec after a system upgrade, run 'toltecctl reenable'"
         log "To reinstall Toltec, run 'toltecctl uninstall' first"
         exit
     fi
@@ -375,7 +375,7 @@ main() {
     entware-install
     toltec-install "$@"
 
-    log "After each system upgrade, run 'toltecctl enable' to re-enable Toltec"
+    log "After each system upgrade, run 'toltecctl reenable' to re-enable Toltec"
 }
 
 main "$@"


### PR DESCRIPTION
The `toltecctl set-path` command is used to make sure that the user’s shell PATH is properly configured to see Toltec binaries. It first scans the existing .bashrc to remove old Toltec-related PATH definitions, and then appends its own definitions.

In the current implementation, if there’s no existing /home/root/.bashrc file, the script will exit with an error. This is a problem because `set-path` is called as part of the bootstrap script, so if someone runs bootstrap after doing a factory reset (which removes the .bashrc file), the bootstrap will fail.

This PR changes the implementation to skip cleaning the .bashrc if it doesn’t exist. It also fixes two wrong messages in the bootstrap script that refer to the `toltecctl enable` command, that is actually called `toltecctl reenable`.

Test plan: Remove (or rename) your .bashrc and upgrade toltec-bootstrap to the new version. Since `set-path` is called automatically when the package is upgraded, this should recreate a new .bashrc containing Toltec-related PATH definitions.

I tested this on my rM2.