### PR TITLE
Update chessmarkable to 0.8.0-1

### DIFF
--- a/package/chessmarkable/package
+++ b/package/chessmarkable/package
@@ -5,8 +5,8 @@
 pkgnames=(chessmarkable)
 pkgdesc="Chess game"
 url=https://github.com/LinusCDE/chessmarkable
-pkgver=0.7.1-2
-timestamp=2021-06-21T22:30Z
+pkgver=0.8.0-1
+timestamp=2021-07-22T12:04Z
 section="games"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT
@@ -14,8 +14,8 @@ installdepends=(display)
 flags=(patch_rm2fb)
 
 image=rust:v2.1
-source=(https://github.com/LinusCDE/chessmarkable/archive/0.7.1-1.zip)
-sha256sums=(fabefb488ef566d37ba730f11c395c5bf4be5e9b24aa5645f62aec5064b9286c)
+source=(https://github.com/LinusCDE/chessmarkable/archive/0.8.0-1.zip)
+sha256sums=(17675d30bb45050c1db5bc81d3d76b99a1b18e497c9a331177b853a5f9aa12af)
 
 build() {
     # Fall back to system-wide config


### PR DESCRIPTION
This adds a new [PGN](https://en.wikipedia.org/wiki/Portable_Game_Notation) Viewer (can replay PGN files [like these](https://www.pgnmentor.com/files.html), when placed in `~/.config/chessmarkable/pgn`).

The release shouldn't change anything in terms of stability. @rmadhwal added this feature in a PR and initially tested it on his rM 2. I later checked it on my rM 1 and rM 2 as well.

Test plan:
 - Either just check that it runs
 - Or just test some pgn file as explained in the first paragraph if you want to