### PR TITLE
puzzles: Fix missing save dir

### DIFF
--- a/package/puzzles/package
+++ b/package/puzzles/package
@@ -15,7 +15,7 @@ flags=(patch_rm2fb)
 
 image=python:v2.1
 source=(
-    https://github.com/mrichards42/remarkable_puzzles/releases/download/v${pkgver%-*}/puzzles-source.tar.gz
+    "https://github.com/mrichards42/remarkable_puzzles/releases/download/v${pkgver%-*}/puzzles-source.tar.gz"
     puzzles.draft
 )
 sha256sums=(

--- a/package/puzzles/package
+++ b/package/puzzles/package
@@ -4,17 +4,18 @@
 
 pkgnames=(puzzles)
 timestamp=2021-03-04T14:03-08:00
-maintainer="NONE"
-pkgver=0.2.2-2
+maintainer="Mattéo Delabre <spam@delab.re>"
+pkgver=0.2.2-3
 license=MIT
 pkgdesc="Simon Tatham's Puzzle Package"
 url="https://github.com/mrichards42/remarkable_puzzles"
 section="games"
+makedepends=(build:git)
 flags=(patch_rm2fb)
 
 image=python:v2.1
 source=(
-    https://github.com/mrichards42/remarkable_puzzles/releases/download/v0.2.2/puzzles-source.tar.gz
+    https://github.com/mrichards42/remarkable_puzzles/releases/download/v${pkgver%-*}/puzzles-source.tar.gz
     puzzles.draft
 )
 sha256sums=(
@@ -23,8 +24,6 @@ sha256sums=(
 )
 
 build() {
-    apt update
-    apt install git -y
     pip3 install okp
 
     # do the build
@@ -32,10 +31,9 @@ build() {
 }
 
 package() {
-    mkdir -p "$pkgdir"/opt/etc/draft
-    mkdir -p "$pkgdir"/opt/etc/puzzles
+    install -d "$pkgdir"/opt/etc/{draft,puzzles,puzzles/save}
     install -D -m 755 "$srcdir"/build/release/puzzles "$pkgdir"/opt/bin/puzzles
-    install -D -m 755 "$srcdir"/puzzles.draft "$pkgdir"/opt/etc/draft/
+    install -D -m 644 "$srcdir"/puzzles.draft "$pkgdir"/opt/etc/draft/
     install -D -m 644 "$srcdir"/config/* -t "$pkgdir"/opt/etc/puzzles/config/
     install -D -m 644 "$srcdir"/help/* -t "$pkgdir"/opt/etc/puzzles/help/
     install -D -m 644 "$srcdir"/icons/* -t "$pkgdir"/opt/etc/puzzles/icons/


### PR DESCRIPTION
The `/opt/etc/puzzles/save` directory should be shipped with the `puzzles` package in order for its save system to work properly. In the current version, try to open any game, change its state, then quit it and come back, and you will notice that the game’s state has been reset. In the logs, the following message can be seen: `Error opening save file for writing: /opt/etc/puzzles/save/[…].sav`.

This PR fixes this issue. If you install the new package, the previously described bug should disappear.

Since the maintainer field of that package is empty, I’m assigning myself, unless someone else wants to take over the maintainership.