### PR TITLE
yaft & tilem: Add missing dependency on display

### DIFF
--- a/package/tilem/package
+++ b/package/tilem/package
@@ -5,12 +5,13 @@
 pkgnames=(tilem)
 pkgdesc="TI-84+ calculator emulator"
 url=https://github.com/timower/rM2-stuff/tree/master/apps/tilem
-pkgver=0.0.7-1
+pkgver=0.0.7-2
 timestamp=2021-04-30T10:42Z
-maintainer="None <none@example.com>"
+maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 section="utils"
 image=base:v2.1
+installdepends=(display)
 
 source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.7.tar.gz)
 sha256sums=(ed2db5f1aa7c9e8b0bead53bd60cb8fd9eec24c028d789fdbdc4b1655d6c78ce)

--- a/package/yaft/package
+++ b/package/yaft/package
@@ -5,12 +5,13 @@
 pkgnames=(yaft)
 pkgdesc="Yet another framebuffer terminal"
 url=https://github.com/timower/rM2-stuff/tree/master/apps/yaft
-pkgver=0.0.4-3
+pkgver=0.0.4-4
 timestamp=2021-04-30T10:42Z
-maintainer="None <none@example.com>"
+maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 section="admin"
 image=base:v2.1
+installdepends=(display)
 
 source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.4.tar.gz)
 sha256sums=(dee471ac19ea43ba741f826c9a0a17d7a01bda6472043d400fbcab6fad1931fe)


### PR DESCRIPTION
Yaft and TilEm need the rm2fb server to work properly on rM2. This PR adds this missing dependency to both packages. I’m also setting myself as the maintainer since it’s missing one, unless someone else wants to take the maintainership.