### PR TITLE
Declare rM2 as supported in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ![Status of the stable repository](https://github.com/toltec-dev/toltec/workflows/stable/badge.svg)
 ![Status of the testing repository](https://github.com/toltec-dev/toltec/workflows/testing/badge.svg)
-[![rm1](https://img.shields.io/badge/rM1-supported-green)](https://remarkable.com/store/remarkable)
-[![rm2](https://img.shields.io/badge/rM2-experimental-yellow)](https://remarkable.com/store/remarkable-2)
+[![rM1: supported](https://img.shields.io/badge/rM1-supported-green)](https://remarkable.com/store/remarkable)
+[![rM2: supported](https://img.shields.io/badge/rM2-supported-green)](https://remarkable.com/store/remarkable-2)
 [![Discord](https://img.shields.io/discord/385916768696139794.svg?label=reMarkable&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/ATqQGfu)
 
 Toltec is a community-maintained repository of free software for [the reMarkable tablet](https://remarkable.com/).


### PR DESCRIPTION
Now that most apps support rM2, that rm2fb is fairly stable and that Toltec has been updated to differentiate rM1-only packages and rM2-only packages with automatic rm2fb install when needed (#310), I think rM2 support is pretty much on par with rM1 support in Toltec. Furthermore, I’ve been running Toltec testing on my rM2 for several months without issues. So I think it’s safe to update the rM2 support badge in our README to read “supported” instead of “experimental”.