### PR TITLE
fuse: Fix on-demand loading after install on rM1

### DIFF
--- a/package/fuse/package
+++ b/package/fuse/package
@@ -6,7 +6,7 @@ archs=(rm1 rm2)
 pkgnames=(fuse)
 pkgdesc="FUSE (Filesystem in Userspace) Kernel Module"
 url=https://github.com/libfuse/libfuse
-pkgver=1.0.0-2
+pkgver=1.0.0-3
 timestamp=2021-04-06T22:16Z
 section=utils
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"
@@ -59,7 +59,15 @@ package() {
 
 configure() {
     if [[ $arch = rm1 ]]; then
+        # Regenerate /lib/modules/[ver]/modules.devname to request the
+        # creation of /dev/fuse used for on-demand loading of fuse
         depmod -a
+
+        # Force creation of /dev/fuse so that the module gets autoloaded
+        # on-demand (otherwise, the device needs to be rebooted or the module
+        # needs to be manually loaded before it can work)
+        systemctl restart kmod-static-nodes
+        systemctl restart systemd-tmpfiles-setup-dev
     fi
 }
 


### PR DESCRIPTION
In the current state of the fuse package, the module will not get autoloaded if you try to use it right after installing. You can see this
on rM1 by installing gocryptfs and trying to decrypt a directory (without rebooting after installing the package).

This PR fixes that by forcing the creation of `/dev/fuse` that is used for on-demand loading of the fuse kernel module. If you install this new version of the package without having fuse installed before, the module should get autoloaded without needing a restart of the device.