### PR TITLE
scripts/toltec/bash.py: Disable security_ops

### DIFF
--- a/scripts/toltec/bash.py
+++ b/scripts/toltec/bash.py
@@ -402,6 +402,7 @@ def run_script_in_container(
                 )
             ),
         ],
+        security_opt=['label=disable'],
         detach=True,
     )
 

--- a/scripts/toltec/bash.py
+++ b/scripts/toltec/bash.py
@@ -402,7 +402,7 @@ def run_script_in_container(
                 )
             ),
         ],
-        security_opt=['label=disable'],
+        security_opt=["label=disable"],
         detach=True,
     )
 


### PR DESCRIPTION
Specify security_ops "label=disable" to avoid permission issues with SE
Linux.

See the Docker documentation
https://docs.docker.com/engine/reference/run/#security-configuration for
more details.

Signed-off-by: Alistair Francis <alistair@alistair23.me>