### PR TITLE
bootstrap: Fix TLS, check if .entware exists, and improve error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "9195122984700c76ccdc58e25d09d0fca486324e8fc55ba781f6e1b812cc186c  bootstrap" | sha256sum -c && bash bootstrap
+$ echo "2d1233271e0cc8232e86827bcb37ab2a44be2c5675cd15f32952614916ae246a  bootstrap" | sha256sum -c && bash bootstrap
 ```
 
 > **Warning:**

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -33,13 +33,7 @@ toltec_remote="${toltec_remote:-https://toltec-dev.org/$toltec_branch/rmall}"
 
 # Remove all temporary files
 cleanup() {
-    if [[ -e $wget_path ]]; then
-        rm "$wget_path"
-    fi
-
-    if [[ -e $opkg_path ]]; then
-        rm "$opkg_path"
-    fi
+    rm -f "$wget_path" "$opkg_path"
 }
 
 # Remove unfinished installation after unexpected error
@@ -62,6 +56,11 @@ error-cleanup() {
     rm -rf "$toltec_dest" "$toltec_src" "$toltecctl_path"
 }
 
+# Check that a directory exists and is not empty
+exists-non-empty() {
+    [[ -d $1 ]] && files="$(ls -A -- "$1")" && [[ -n $files ]]
+}
+
 # Check whether a Toltec install already exists or if conflicting files
 # remain from previous installs
 check-installed() {
@@ -69,7 +68,7 @@ check-installed() {
         return
     fi
 
-    if [[ -d /opt ]] && files="$(ls -A -- "/opt")" && [[ -n $files ]]; then
+    if exists-non-empty /opt || exists-non-empty /home/root/.entware; then
         log "Toltec is already installed or partially installed"
         log "To re-enable Toltec after a system upgrade, run 'toltecctl reenable'"
         log "To reinstall Toltec, run 'toltecctl uninstall' first"
@@ -80,24 +79,27 @@ check-installed() {
 # Install a local wget binary which supports TLS (the original one
 # installed on the reMarkable does not) in the PATH
 wget-bootstrap() {
-    log "Fetching secure wget"
-    local wget_remote=https://toltec-dev.org/thirdparty/bin/wget-v1.21.1
+    local wget_remote=http://toltec-dev.org/thirdparty/bin/wget-v1.21.1
     local wget_checksum=8798fcdabbe560722a02f95b30385926e4452e2c98c15c2c217583eaa0db30fc
 
     if [[ ! -x $wget_path ]]; then
         if [[ -e $wget_path ]]; then
             log ERROR "'$wget_path' exists, but is not executable"
-            error-cleanup
             exit 1
         fi
 
+        log "Fetching secure wget"
+
         # Download and compare to hash
         mkdir -p "$(dirname "$wget_path")"
-        wget "$wget_remote" --output-document "$wget_path" 2> /dev/null
+
+        if ! wget -q "$wget_remote" --output-document "$wget_path"; then
+            log ERROR "Could not fetch wget, make sure you have a stable Wi-Fi connection"
+            exit 1
+        fi
 
         if ! sha256sum -c <(echo "$wget_checksum  $wget_path") > /dev/null 2>&1; then
             log ERROR "Invalid checksum for the local wget binary"
-            error-cleanup
             exit 1
         fi
 
@@ -120,12 +122,14 @@ opkg-bootstrap() {
     if [[ ! -x $opkg_path ]]; then
         if [[ -e $opkg_path ]]; then
             log ERROR "'$opkg_path' exists, but is not executable"
-            error-cleanup
             exit 1
         fi
 
-        # Install standalone Opkg from Entware
-        wget --no-verbose "$entware_remote/opkg" -O "$opkg_path"
+        if ! wget --no-verbose "$entware_remote/opkg" --output-document "$opkg_path"; then
+            log ERROR "Could not fetch opkg, make sure you have a stable Wi-Fi connection"
+            exit 1
+        fi
+
         chmod 755 "$opkg_path"
     fi
 
@@ -142,13 +146,14 @@ main() {
     # (otherwise it could get wiped out by the error-cleanup hook below)
     check-installed
 
-    trap cleanup EXIT
-    trap error-cleanup ERR
-
+    # Fetch temporary wget and opkg binaries used for bootstrapping
     wget-bootstrap
     opkg-bootstrap
 
-    # Download and install the latest toltec-bootstrap package
+    # Remove those binaries in any case when the script exits
+    trap cleanup EXIT
+
+    # Download and install the latest toltec-bootstrap package to load toltecctl
     local pkg_basename
     pkg_basename="$(
         wget --quiet "$toltec_remote/Packages" -O - \
@@ -162,6 +167,9 @@ main() {
 
     # shellcheck source=../../package/toltec-bootstrap/toltecctl
     source /home/root/.local/bin/toltecctl
+
+    # Clean up the partial install if an uncaught error happens
+    trap error-cleanup ERR
 
     log "Installing Toltec and Entware"
 


### PR DESCRIPTION
This PR contains several fixes for the bootstrap script.

* If the standalone `wget` binary cannot be fetched, a more helpful error message is printed instead of the catch-all error message (see #422).
* The standalone `wget` binary is fetched over HTTP instead of HTTPS, since the implementation of TLS in Busybox’s wget causes issues with the latest version of nginx. This does not reduce security since the checksum is still verified after fetching the binary (fixes #422, I believe).
* Abort installation if `/home/root/.entware` already exists. Previously, only the existence of `/opt` was checked, leading to #409.

Test plan (on rM1 and rM2):

* Try to run the script normally. Issue #422 should be fixed and the install should proceed.
* Try to run the script while not being connected to Wi-Fi. Expected output:

```sh
INFO:  Fetching secure wget
wget: bad address 'toltec-dev.org'
ERROR: Could not fetch wget, make sure you have a stable Wi-Fi connection
```

* Try to run it with `127.0.0.1 toltec-dev.org` in `/etc/hosts`. Expected output:

```sh
INFO:  Fetching secure wget
wget: can't connect to remote host (127.0.0.1): Connection refused
ERROR: Could not fetch wget, make sure you have a stable Wi-Fi connection
```

* Starting from a complete Toltec install, unmount /opt (`systemctl stop opt.mount`) and remove the /opt folder. Try to run the script. Expected output:

```sh
INFO:  Toltec is already installed or partially installed
INFO:  To re-enable Toltec after a system upgrade, run 'toltecctl reenable'
INFO:  To reinstall Toltec, run 'toltecctl uninstall' first
```