### PR TITLE
Remove HTTPS from secure wget url

### DIFF
--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -81,7 +81,7 @@ check-installed() {
 # installed on the reMarkable does not) in the PATH
 wget-bootstrap() {
     log "Fetching secure wget"
-    local wget_remote=https://toltec-dev.org/thirdparty/bin/wget-v1.21.1
+    local wget_remote=http://toltec-dev.org/thirdparty/bin/wget-v1.21.1
     local wget_checksum=8798fcdabbe560722a02f95b30385926e4452e2c98c15c2c217583eaa0db30fc
 
     if [[ ! -x $wget_path ]]; then


### PR DESCRIPTION
Since wget on the most recent version of the Remarkable firmware (2.9.1.217) has no certificate validation, it fails.

Quick and dirty justification of the fix:
```
reMarkable: ~/ wget https://toltec-dev.org/thirdparty/bin/wget-v1.21.1
Connecting to toltec-dev.org (172.104.246.107:443)
wget: note: TLS certificate validation not implemented
wget: TLS error from peer (alert code 80): 80
wget: error getting response: Connection reset by peer
reMarkable: ~/ wget http://toltec-dev.org/thirdparty/bin/wget-v1.21.1
Connecting to toltec-dev.org (172.104.246.107:80)
saving to 'wget-v1.21.1'
wget-v1.21.1         100% |*****************************************************************************************| 3042k  0:00:00 ETA
'wget-v1.21.1' saved
```