### PR TITLE
Update KOReader to v2021.09

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2021.07-1
-timestamp=2021-06-25T19:49:18Z
+pkgver=2021.09-1
+timestamp=2021-09-20T08:33:06Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -20,7 +20,7 @@ source=(
     koreader
 )
 sha256sums=(
-    47cd8a7f8f0fcfca8974ad02c3c6977e66502fef970de3881172c10cfe40774a
+    12ebc96521a390fc10f236e4dc9097fa8bea7e8d6928d474a7966b35a045cd2a
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
No reMarkable specific fixes, but various fixes/improvments. You can see the full changelog here: https://github.com/koreader/koreader/releases/tag/v2021.09