### PR TITLE
Stable merge for week 38 of 2021

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+
+Thank you for your interest in contributing to Toltec! Before submitting your
+pull request, please take a moment to read our contributing guidelines at
+<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>
+
+Most importantly, make sure to base your pull request on the **testing**
+branch (which is not the default branch). Pull requests to the stable
+branch cannot be accepted.
+
+If you’re proposing a new package please give us some details on:
+
+* What the package does
+* Whether you're the author of it
+* If the package was developed/tested for a specific reMarkable model
+
+If you’re updating an existing package, please give information on where the
+changelog can be found.
+
+A maintainer will reply to you shortly to get the package ready for testing.
+As soon as the package file looks good and it was sucessfully tested on both
+devices, we can add it! 🎊🎉🎊
+
+-->

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To automatically install Opkg, Entware and Toltec, run the bootstrap script in a
 
 ```sh
 $ wget http://toltec-dev.org/bootstrap
-$ echo "9195122984700c76ccdc58e25d09d0fca486324e8fc55ba781f6e1b812cc186c  bootstrap" | sha256sum -c && bash bootstrap
+$ echo "2d1233271e0cc8232e86827bcb37ab2a44be2c5675cd15f32952614916ae246a  bootstrap" | sha256sum -c && bash bootstrap
 ```
 
 > **Warning:**

--- a/package/fbink/package
+++ b/package/fbink/package
@@ -4,7 +4,7 @@
 
 pkgnames=(fbink fbdepth fbink-doom)
 url=https://github.com/NiLuJe/FBInk
-pkgver=1.23.2-1
+pkgver=1.24.0-1
 timestamp=2021-03-25T23:41:13Z
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
@@ -20,6 +20,7 @@ prepare() {
 build() {
     pushd FBInk
     REMARKABLE=1 make remarkable
+    REMARKABLE=1 make fbdepth
     REMARKABLE=1 make utils
     popd
 }

--- a/package/innernet/build.patch
+++ b/package/innernet/build.patch
@@ -1,0 +1,10 @@
+--- build.rs	2021-08-31 14:35:34.226760718 +0200
++++ build-patched.rs	2021-08-31 17:16:52.195765743 +0200
+@@ -6,6 +6,7 @@
+         let bindings = bindgen::Builder::default()
+             .rust_target(bindgen::RustTarget::Stable_1_40)
+             .derive_default(true)
++            .clang_arg("--sysroot=".to_owned() + &env::var("SYSROOT").unwrap())
+             .header("c/wireguard.h")
+             .impl_debug(true)
+             .allowlist_function("wg_.*")

--- a/package/innernet/package
+++ b/package/innernet/package
@@ -5,26 +5,35 @@
 pkgnames=(innernet-client)
 pkgdesc="A private network system that uses WireGuard under the hood."
 url="https://github.com/tonarino/innernet"
-pkgver=1.4.0-1
-timestamp=2021-07-11T13:36:15Z
+pkgver=1.4.1-2
+timestamp=2021-08-31T17:57:00Z
 section="utils"
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"
 license=MIT
 installdepends=(wireguard)
-makedepends=(build:librust-clang-sys-dev build:libclang-dev build:libc6 build:libc6-dev build:clang build:gcc-multilib build:g++-multilib)
+makedepends=(build:librust-clang-sys-dev build:libclang-dev build:libc6 build:libc6-dev build:clang)
 
 image=rust:v2.1
 _srcver="v${pkgver%-*}"
-source=("https://github.com/tonarino/innernet/archive/refs/tags/$_srcver.zip")
-sha256sums=(b1297177d377c1374be5db9e0ab9ccf82b2199d47969e1bbee58dcecbe2ca933)
+source=(
+    "https://github.com/tonarino/innernet/archive/refs/tags/$_srcver.zip"
+    build.patch
+)
+sha256sums=(
+    3dd87538f53a7665713f88399f3388abe24b878765605dfadd25ca194cc47ac1
+    SKIP
+)
 
 prepare() {
     # Change config folders to live under /opt
     sed -i "s/\/etc\/innernet/\/opt\/etc\/innernet/g" "$srcdir/shared/src/lib.rs"
     sed -i "s/\/var\/lib\/innernet/\/opt\/var\/lib\/innernet/g" "$srcdir/shared/src/lib.rs"
 
-    #Change binary path in service file
+    # Change binary path in service file
     sed -i "s/\/usr\/bin\/innernet/\/opt\/bin\/innernet/g" "$srcdir/client/innernet@.service"
+
+    # Insert line to look for headers under $SYSROOT instead of root filesystem
+    patch -u "$srcdir/wgctrl-sys/build.rs" -i "$srcdir/build.patch"
 
     #tbd: change wireguard config dir to /opt/etc/wireguard?
     #sed -i "s/\/etc\/wireguard/\/opt\/etc\/wireguard/g" "$srcdir/shared/src/lib.rs"

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2021.07-1
-timestamp=2021-06-25T19:49:18Z
+pkgver=2021.09-1
+timestamp=2021-09-20T08:33:06Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -20,7 +20,7 @@ source=(
     koreader
 )
 sha256sums=(
-    47cd8a7f8f0fcfca8974ad02c3c6977e66502fef970de3881172c10cfe40774a
+    12ebc96521a390fc10f236e4dc9097fa8bea7e8d6928d474a7966b35a045cd2a
     SKIP
     SKIP
     SKIP

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -144,7 +144,7 @@ nao() {
 remux() {
     pkgdesc="Launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.9-4
+    pkgver=0.1.9-5
     section="launchers"
 
     package() {

--- a/package/rmkit/remux.service
+++ b/package/rmkit/remux.service
@@ -3,7 +3,8 @@
 
 [Unit]
 Description=App launcher that supports multi-tasking applications
-After=xochitl.service opt.mount
+Requires=dev-input-event0.device dev-input-event1.device dev-input-event2.device
+After=xochitl.service opt.mount dev-input-event0.device dev-input-event1.device dev-input-event2.device
 StartLimitInterval=30
 StartLimitBurst=5
 Conflicts=draft.service tarnish.service

--- a/package/toltec-bootstrap/15-systemd-input.rules
+++ b/package/toltec-bootstrap/15-systemd-input.rules
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+# This rule makes systemd track input devices as `.device` units, so that
+# other services can declare a dependency on them.
+ACTION=="add", SUBSYSTEM=="input", TAG+="systemd"

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,23 +5,33 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Manage your Toltec install"
 url=https://toltec-dev.org/
-pkgver=0.1.0-1
-timestamp=2021-06-25T21:16Z
+pkgver=0.2.0-1
+timestamp=2021-09-25T10:36Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
-source=(toltecctl)
-sha256sums=(SKIP)
+source=(
+    toltecctl
+    15-systemd-input.rules
+)
+sha256sums=(
+    SKIP
+    SKIP
+)
 
 package() {
     install -D -m 744 -t "$pkgdir"/home/root/.local/bin "$srcdir"/toltecctl
+    install -D -m 644 -t "$pkgdir"/lib/udev/rules.d/ "$srcdir"/15-systemd-input.rules
 }
 
 configure() {
     # shellcheck source=toltecctl
     source /home/root/.local/bin/toltecctl
     set-path
+
+    # Apply the input udev rule
+    udevadm control --reload-rules && udevadm trigger
 
     if [[ ! -d $opkg_conf_dir ]]; then
         # Migrate existing config in /opt/etc/opkg.conf to be generated

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -33,13 +33,7 @@ toltec_remote="${toltec_remote:-https://toltec-dev.org/$toltec_branch/rmall}"
 
 # Remove all temporary files
 cleanup() {
-    if [[ -e $wget_path ]]; then
-        rm "$wget_path"
-    fi
-
-    if [[ -e $opkg_path ]]; then
-        rm "$opkg_path"
-    fi
+    rm -f "$wget_path" "$opkg_path"
 }
 
 # Remove unfinished installation after unexpected error
@@ -62,6 +56,11 @@ error-cleanup() {
     rm -rf "$toltec_dest" "$toltec_src" "$toltecctl_path"
 }
 
+# Check that a directory exists and is not empty
+exists-non-empty() {
+    [[ -d $1 ]] && files="$(ls -A -- "$1")" && [[ -n $files ]]
+}
+
 # Check whether a Toltec install already exists or if conflicting files
 # remain from previous installs
 check-installed() {
@@ -69,7 +68,7 @@ check-installed() {
         return
     fi
 
-    if [[ -d /opt ]] && files="$(ls -A -- "/opt")" && [[ -n $files ]]; then
+    if exists-non-empty /opt || exists-non-empty /home/root/.entware; then
         log "Toltec is already installed or partially installed"
         log "To re-enable Toltec after a system upgrade, run 'toltecctl reenable'"
         log "To reinstall Toltec, run 'toltecctl uninstall' first"
@@ -80,24 +79,27 @@ check-installed() {
 # Install a local wget binary which supports TLS (the original one
 # installed on the reMarkable does not) in the PATH
 wget-bootstrap() {
-    log "Fetching secure wget"
-    local wget_remote=https://toltec-dev.org/thirdparty/bin/wget-v1.21.1
+    local wget_remote=http://toltec-dev.org/thirdparty/bin/wget-v1.21.1
     local wget_checksum=8798fcdabbe560722a02f95b30385926e4452e2c98c15c2c217583eaa0db30fc
 
     if [[ ! -x $wget_path ]]; then
         if [[ -e $wget_path ]]; then
             log ERROR "'$wget_path' exists, but is not executable"
-            error-cleanup
             exit 1
         fi
 
+        log "Fetching secure wget"
+
         # Download and compare to hash
         mkdir -p "$(dirname "$wget_path")"
-        wget "$wget_remote" --output-document "$wget_path" 2> /dev/null
+
+        if ! wget -q "$wget_remote" --output-document "$wget_path"; then
+            log ERROR "Could not fetch wget, make sure you have a stable Wi-Fi connection"
+            exit 1
+        fi
 
         if ! sha256sum -c <(echo "$wget_checksum  $wget_path") > /dev/null 2>&1; then
             log ERROR "Invalid checksum for the local wget binary"
-            error-cleanup
             exit 1
         fi
 
@@ -120,12 +122,14 @@ opkg-bootstrap() {
     if [[ ! -x $opkg_path ]]; then
         if [[ -e $opkg_path ]]; then
             log ERROR "'$opkg_path' exists, but is not executable"
-            error-cleanup
             exit 1
         fi
 
-        # Install standalone Opkg from Entware
-        wget --no-verbose "$entware_remote/opkg" -O "$opkg_path"
+        if ! wget --no-verbose "$entware_remote/opkg" --output-document "$opkg_path"; then
+            log ERROR "Could not fetch opkg, make sure you have a stable Wi-Fi connection"
+            exit 1
+        fi
+
         chmod 755 "$opkg_path"
     fi
 
@@ -142,13 +146,14 @@ main() {
     # (otherwise it could get wiped out by the error-cleanup hook below)
     check-installed
 
-    trap cleanup EXIT
-    trap error-cleanup ERR
-
+    # Fetch temporary wget and opkg binaries used for bootstrapping
     wget-bootstrap
     opkg-bootstrap
 
-    # Download and install the latest toltec-bootstrap package
+    # Remove those binaries in any case when the script exits
+    trap cleanup EXIT
+
+    # Download and install the latest toltec-bootstrap package to load toltecctl
     local pkg_basename
     pkg_basename="$(
         wget --quiet "$toltec_remote/Packages" -O - \
@@ -162,6 +167,9 @@ main() {
 
     # shellcheck source=../../package/toltec-bootstrap/toltecctl
     source /home/root/.local/bin/toltecctl
+
+    # Clean up the partial install if an uncaught error happens
+    trap error-cleanup ERR
 
     log "Installing Toltec and Entware"
 

--- a/scripts/toltec/bash.py
+++ b/scripts/toltec/bash.py
@@ -402,6 +402,7 @@ def run_script_in_container(
                 )
             ),
         ],
+        security_opt=["label=disable"],
         detach=True,
     )
 


### PR DESCRIPTION
Fixes:

* TLS issues with the bootstrap script (#422, #423)
* Bootstrap script could overwrite existing installs (#409, #423)

Updated packages:

* fbink, fbdepth, fbink-doom - 1.24.0-1 (#425)
* innernet - 1.4.1-2 (#420)
* koreader - 2021.09-1 (#436)
* remux - 0.1.9-5 (#431) (fixes 2.9 issues)
* toltec-bootstrap - 0.2.0-1 (#431)