### PR TITLE
Make koreader.service conflict with xochitl.service

### DIFF
--- a/package/koreader/koreader-toltec.service
+++ b/package/koreader/koreader-toltec.service
@@ -4,6 +4,7 @@ StartLimitIntervalSec=600
 StartLimitBurst=4
 After=home.mount
 OnFailure=xochitl.service
+Conflicts=xochitl.service
 
 [Service]
 ExecStart=/opt/bin/koreader


### PR DESCRIPTION
Fix #437 

This might cause problems with the OnFailure entry though, so that should be tested.