### PR TITLE
Add link to Entware repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ echo "2d1233271e0cc8232e86827bcb37ab2a44be2c5675cd15f32952614916ae246a  bootstra
 You now have access to all of the Toltec and Entware packages!
 To seamlessly switch between applications, you may want to start by installing a [launcher](https://toltec-dev.org/stable#section-launchers).
 
-[Browse the list of available packages →](https://toltec-dev.org/stable)
+[Browse the list of available Toltec packages →](https://toltec-dev.org/stable)
+[Browse the list of available Entware packages →](https://bin.entware.net/armv7sf-k3.2/Packages.html)
 
 ### Use it
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You now have access to all of the Toltec and Entware packages!
 To seamlessly switch between applications, you may want to start by installing a [launcher](https://toltec-dev.org/stable#section-launchers).
 
 [Browse the list of available Toltec packages →](https://toltec-dev.org/stable)
+
 [Browse the list of available Entware packages →](https://bin.entware.net/armv7sf-k3.2/Packages.html)
 
 ### Use it


### PR DESCRIPTION
Mirror the Entware link introduced in https://github.com/toltec-dev/web/pull/6

Inspired by @LinusCDE's idea https://github.com/toltec-dev/web/issues/2#issuecomment-769868114