### PR TITLE
Update KOReader to 2021.10.1

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2021.10-1
-timestamp=2021-10-16T11:37:17Z
+pkgver=2021.10.1-1
+timestamp=2021-10-18T10:37:17Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    121920ca958a79f5d0187649cf7ff6e9a9d3f485246e7d0aacdf30ddeda60864
+    0b36e2d950c5d077cd4d44c5ff5a4d3bba2e879b8954f71224decafd685ef028
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
Minor bugfix for a crash sometimes caused by the book status when sleeping.