### PR TITLE
Update dotnet to 3.1.20

### DIFF
--- a/package/dotnet/package
+++ b/package/dotnet/package
@@ -12,7 +12,7 @@ pkgnames=(
     aspnet-targeting-pack
     netstandard-targeting-pack
 )
-pkgver=3.1.10-3
+pkgver=3.1.20-1
 timestamp=2020-12-27T18:48Z
 maintainer="Eeems <eeems@eeems.email>"
 url=https://www.microsoft.com/net/core
@@ -20,11 +20,11 @@ section="devel"
 license=MIT
 
 source=(
-    https://download.visualstudio.microsoft.com/download/pr/2ebe1f4b-4423-4694-8f5b-57f22a315d66/4bceeffda88fc6f19fad7dfb2cd30487/dotnet-sdk-3.1.404-linux-arm.tar.gz
+    https://download.visualstudio.microsoft.com/download/pr/cefd43b6-16ac-4435-bcc6-594ebb0441cf/7d064f0f61c4174f620eafe97484e6cb/dotnet-sdk-3.1.414-linux-arm.tar.gz
     dotnet-profile.sh
 )
 sha256sums=(
-    c95e8cf72abbcde1ac3974158ed9355d8d5588bade463fdf69d6932f915f453a
+    dd9cf827b9af32a975f5c62c59221568782768d7ff5fc1622111f13c1dbe9339
     SKIP
 )
 


### PR DESCRIPTION
Update to the latest 3.1 version.
 We might want to look at also packaging dotnet 5 and allowing it to install alongside, but I'm not sure how best to manage it.