### PR TITLE
upgrade whiteboard-hypercard to v0.3.4

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ If you’re updating an existing package, please give information on where the
 changelog can be found.
 
 A maintainer will reply to you shortly to get the package ready for testing.
-As soon as the package file looks good and it was sucessfully tested on both
+As soon as the package file looks good and it was successfully tested on both
 devices, we can add it! 🎊🎉🎊
 
 -->

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -2,30 +2,35 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-archs=(rm1)
+archs=(rm1 rm2)
 pkgnames=(whiteboard-hypercard)
 pkgdesc="Real-time collaboration, drawing or whiteboarding"
 url=https://github.com/fenollp/reMarkable-tools
-pkgver=0.3.0-2
-timestamp=2020-09-23T18:01Z
+pkgver=0.3.4-1
+timestamp=2021-10-25T15:45Z
 section="drawing"
 maintainer="Pierre Fenoll <pierrefenoll@gmail.com>"
 license=Apache-2.0
 
 image=rust:v1.1
 source=(
-    https://github.com/fenollp/reMarkable-tools/archive/v0.3.0.zip
+    https://github.com/fenollp/reMarkable-tools/archive/v0.3.4.zip
     whiteboard-hypercard.draft
 )
 sha256sums=(
-    3d160d77cd384ee9339c7f791b3f762bb295a670c0c728373c6a09f14a061046
+    b343e1b4af9e0bf247ff2fab8331648ddd89941fb5c0ea9a45417d3bb4b20193
     SKIP
 )
 
 build() {
+    # https://github.com/rust-embedded/cross/tree/2b2a01220c73ae517129019d436d382412d1928b#docker-in-docker
+    export CROSS_DOCKER_IN_DOCKER=true
+    cargo install cross
+
+    rustup component add rustfmt
+
     cd marauder
-    rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
-    cargo build --release --bin whiteboard --locked
+    cross build --target=armv7-unknown-linux-gnueabihf --release --bin whiteboard --locked
 }
 
 package() {

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -25,7 +25,7 @@ sha256sums=(
 
 build() {
     cd marauder
-    rustup component add rustfmt
+    rustup component add rustfmt --toolchain armv7-unknown-linux-gnueabihf
     cargo build --release --bin whiteboard --locked
 }
 

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -13,7 +13,7 @@ license=Apache-2.0
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=rust:v2.1
+image=rust:v2.2
 source=(
     https://github.com/fenollp/reMarkable-tools/archive/v0.3.4.zip
     whiteboard-hypercard.draft
@@ -25,7 +25,7 @@ sha256sums=(
 
 build() {
     cd marauder
-    rustup component add rustfmt --toolchain armv7-unknown-linux-gnueabihf
+    rustup component add rustfmt
     cargo build --release --bin whiteboard --locked
 }
 

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -2,7 +2,6 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-archs=(rm1 rm2)
 pkgnames=(whiteboard-hypercard)
 pkgdesc="Real-time collaboration, drawing or whiteboarding"
 url=https://github.com/fenollp/reMarkable-tools
@@ -11,8 +10,10 @@ timestamp=2021-10-25T15:45Z
 section="drawing"
 maintainer="Pierre Fenoll <pierrefenoll@gmail.com>"
 license=Apache-2.0
+installdepends=(display)
+flags=(patch_rm2fb)
 
-image=rust:v1.1
+image=rust:v2.1
 source=(
     https://github.com/fenollp/reMarkable-tools/archive/v0.3.4.zip
     whiteboard-hypercard.draft
@@ -23,14 +24,9 @@ sha256sums=(
 )
 
 build() {
-    # https://github.com/rust-embedded/cross/tree/2b2a01220c73ae517129019d436d382412d1928b#docker-in-docker
-    export CROSS_DOCKER_IN_DOCKER=true
-    cargo install cross
-
-    rustup component add rustfmt
-
     cd marauder
-    cross build --target=armv7-unknown-linux-gnueabihf --release --bin whiteboard --locked
+    rustup component add rustfmt
+    cargo build --release --bin whiteboard --locked
 }
 
 package() {


### PR DESCRIPTION
Hi! Author of this package here, upgrading it.

A "changelog": https://github.com/fenollp/reMarkable-tools/compare/v0.3.0...v0.3.4
Really it's a collection of functional & UI fixes and the addition of rM2 support.

Note: I'm still testing building toltec packages...