### PR TITLE
Add doomarkable 0.4.0

### DIFF
--- a/package/doomarkable/package
+++ b/package/doomarkable/package
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(doomarkable)
+pkgdesc="DOOM game"
+url=https://github.com/LinusCDE/doomarkable
+pkgver=0.4.0-1
+timestamp=2021-10-25T23:02Z
+section="games"
+maintainer="Linus K. <linus@cosmos-ink.net>"
+license=MIT
+installdepends=(display)
+flags=(patch_rm2fb)
+
+image=rust:v2.2
+source=(https://github.com/LinusCDE/doomarkable/archive/0.4.0.zip)
+sha256sums=(39988c0a607560787789b0e71aa34059c64d11ba1b98e11145d08677ed420c5f)
+
+build() {
+    # Fall back to system-wide config
+    rm .cargo/config
+    cargo build --release
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/doomarkable
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft "$srcdir"/doomarkable.draft
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons "$srcdir"/doomarkable.png
+}


### PR DESCRIPTION
Here it is!

Tested the package to build and run fine on the rM 1 with all major launchers.

While the rM 2 is supported it isn't really pleasant to play. (Not sure if it ever will.) I'll look whether I can do anything the coming weeks. Otherwise we could also consider marking it rm1-only.

The game runs at about 13 FPS. The recent brightness bump made the game a lot better to look at, but also increased artifacts a bit. There is certainly a lot of things to do (a bit more performance, better/multiple input schemes, todolist on readme), but this should be a solid game already.

- Keep in mind that even when the game doesn't seem to run, while the app is active, it sucks a lot of battery! I need to solve why doom keeps consuming cpu even when quit.)
- To run the game, you need a wad file. The easiest to get is from [here](https://doomwiki.org/wiki/DOOM1.WAD). Place it into the home directory and be sure to rename it to all uppercase. The app should note this however.