### PR TITLE
package: mmc-utils: Initial commit

### DIFF
--- a/package/mmc-utils/0001-Makefile-Remove-Werror.patch
+++ b/package/mmc-utils/0001-Makefile-Remove-Werror.patch
@@ -1,0 +1,39 @@
+From 898bae517a42c1bf088e1c7b2bd34cd1fb086d22 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair@alistair23.me>
+Date: Wed, 3 Nov 2021 22:23:46 +1000
+Subject: [PATCH] Makefile: Remove -Werror
+
+Signed-off-by: Alistair Francis <alistair@alistair23.me>
+---
+ Makefile | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index aa27ff2..3402007 100644
+--- a/Makefile
++++ b/Makefile
+@@ -8,11 +8,9 @@ objects = \
+ 	3rdparty/hmac_sha/hmac_sha2.o \
+ 	3rdparty/hmac_sha/sha2.o
+ 
+-CHECKFLAGS = -Wall -Werror -Wuninitialized -Wundef
+-
+ DEPFLAGS = -Wp,-MMD,$(@D)/.$(@F).d,-MT,$@
+ 
+-override CFLAGS := $(CHECKFLAGS) $(AM_CFLAGS) $(CFLAGS)
++override CFLAGS := $(AM_CFLAGS) $(CFLAGS)
+ 
+ INSTALL = install
+ prefix ?= /usr/local
+@@ -24,7 +22,7 @@ progs = mmc
+ 
+ # make C=1 to enable sparse
+ ifdef C
+-	check = sparse $(CHECKFLAGS)
++	check = sparse
+ endif
+ 
+ all: $(progs) manpages
+-- 
+2.31.1
+

--- a/package/mmc-utils/package
+++ b/package/mmc-utils/package
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+archs=(rmall)
+pkgnames=(mmc-utils)
+pkgdesc="A tool for monitoring the eMMC protocol"
+url=https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/
+pkgver=1.0-0
+timestamp=2021-08-12T19:41:07Z
+section="devel"
+maintainer="Alistair Francis <alistair@alistair23.me>"
+license=GPL-2.0-only
+
+image=base:v2.2
+source=(
+    "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-7769a4d7abe339ce273c13a203394a79a11fcff9.tar.gz"
+    0001-Makefile-Remove-Werror.patch
+)
+sha256sums=(
+    0578e546d8893b6207180def7966e7314cae54c237a931b8f94779ce5c7d0668
+    SKIP
+)
+
+build() {
+    # Use our toolchain
+    export AR=arm-linux-gnueabihf-ar
+    export CC=arm-linux-gnueabihf-gcc
+    export STRIP=arm-linux-gnueabihf-strip
+
+    patch < "$srcdir"/0001-Makefile-Remove-Werror.patch
+    make -j4
+}
+
+package() {
+    DESTDIR="$pkgdir" make -C "$srcdir" install
+}


### PR DESCRIPTION
Add support for the mmc-utils package. This can be used to determine the life of the MMC, for example as described here: https://www.cnx-software.com/2019/08/16/wear-estimation-emmc-flash-memory/

This also completes part of: https://github.com/toltec-dev/toltec/issues/9