### PR TITLE
[rmkit] upgrade remux with further 2.9+ support

### DIFF
--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(bufshot genie harmony iago lamp mines nao remux simple)
-timestamp=2021-09-21T14:20-08:00
+timestamp=2021-11-15T16:30-08:00
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 installdepends=(display)
@@ -11,12 +11,12 @@ flags=(patch_rm2fb)
 
 image=python:v2.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/8254893999d7334fd14c162d5a15605dcff77ec5.zip
+    https://github.com/rmkit-dev/rmkit/archive/285e7572420167bf02c2c13eaea15ca9777e5197.zip
     remux.service
     genie.service
 )
 sha256sums=(
-    977c38d652d8088e9b25c69aff5013b85173be363b5cb341529df261773ff9be
+    63f5a8a053f3af62745afd926b39eea66ea86f3945d3466badcb497f8e135f0f
     SKIP
     SKIP
 )
@@ -134,7 +134,7 @@ nao() {
 remux() {
     pkgdesc="Launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.10-1
+    pkgver=0.1.11-1
     section="launchers"
 
     package() {

--- a/package/rmkit/remux.service
+++ b/package/rmkit/remux.service
@@ -3,8 +3,7 @@
 
 [Unit]
 Description=App launcher that supports multi-tasking applications
-Requires=dev-input-event0.device dev-input-event1.device dev-input-event2.device
-After=xochitl.service opt.mount dev-input-event0.device dev-input-event1.device dev-input-event2.device
+After=xochitl.service opt.mount
 StartLimitInterval=30
 StartLimitBurst=5
 Conflicts=draft.service tarnish.service


### PR DESCRIPTION
1) fix for fast show/hide behavior (https://github.com/rmkit-dev/rmkit/commit/b6b86a464774c699e265c0b3cc71933db5af65bb)
2) error in remux if the input device is not available when the machine starts (https://github.com/rmkit-dev/rmkit/commit/285e7572420167bf02c2c13eaea15ca9777e5197)
