### PR TITLE
Add /opt/etc directory to xochitl oxide application

### DIFF
--- a/package/xochitl/package
+++ b/package/xochitl/package
@@ -5,8 +5,8 @@
 pkgnames=(xochitl)
 pkgdesc="Read documents and take notes"
 url=https://remarkable.com
-pkgver=0.0.0-9
-timestamp=2021-09-25T16:36Z
+pkgver=0.0.0-10
+timestamp=2021-11-20T23:31Z
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT

--- a/package/xochitl/xochitl.oxide
+++ b/package/xochitl/xochitl.oxide
@@ -6,18 +6,17 @@
     "flags": ["nosplash", "chroot"],
     "permissions": ["power"],
     "directories": [
+        "/dev/shm",
         "/etc",
         "/home/root",
         "/opt/etc",
-        "/tmp/runtime-root",
-        "/usr/share",
-        "/run/udev",
         "/run/dbus",
         "/run/systemd/resolve",
-        "/var/lib/dbus",
+        "/run/udev",
+        "/tmp/runtime-root",
+        "/usr/share",
         "/var/cache/fontconfig",
-        "/dev/shm",
-        "/opt/etc/xochitl.env.d"
+        "/var/lib/dbus",
     ],
     "environment": {
         "QMLSCENE_DEVICE": "epaper",

--- a/package/xochitl/xochitl.oxide
+++ b/package/xochitl/xochitl.oxide
@@ -8,6 +8,7 @@
     "directories": [
         "/etc",
         "/home/root",
+        "/opt/etc",
         "/tmp/runtime-root",
         "/usr/share",
         "/run/udev",


### PR DESCRIPTION
This directory needs to be visible for rM2 users who have a custom `/opt/etc/rm2fb.conf` - usually due to running a tablet version that rm2fb that does not support yet.

See Eeems/oxide#231. Originally fixes Eeems/oxide#228.