### PR TITLE
Update KOReader to v2021.11

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2021.10.1-1
+pkgver=2021.11-1
 timestamp=2021-10-18T10:37:17Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    0b36e2d950c5d077cd4d44c5ff5a4d3bba2e879b8954f71224decafd685ef028
+    d864e4617344dae1218f78ccb7091422768be40144426ffe9fb0f9228104d1db
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
No reMarkable specific changes.

Some highlights:

- Bookmarks: new settings and tweaks
- ReaderHighlight: allow updating a highlight drawing style
- Autowarmth: wording, help_text, menu tweaks
- [plugin] Autowarmth: Fix sanity check for longitude
- FileManager: no notification on successful file operations
- DocSettings/Purge .sdr: reword, don't purge other books
- plugins: add Japanese Support plugin
- Bookmarks: icon by type, combined view, filter, bulk remove
- keyboard: japanese: switch to 12-key flick layout
- ReaderGoto: adds Go to %
- [plugin] Display OPDS download titles if available
- DocSettings: fix settings not saved when book on read-only FS
- sdcv: update to include multiple results

[release](https://github.com/koreader/koreader/releases/tag/v2021.11) - [changelog](https://github.com/koreader/koreader/compare/v2021.10.1...v2021.11) - [issues](https://github.com/koreader/koreader/milestone/47?closed=1)