### PR TITLE
Stable merge for week 46 of 2021

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ If you’re updating an existing package, please give information on where the
 changelog can be found.
 
 A maintainer will reply to you shortly to get the package ready for testing.
-As soon as the package file looks good and it was sucessfully tested on both
+As soon as the package file looks good and it was successfully tested on both
 devices, we can add it! 🎊🎉🎊
 
 -->

--- a/package/display/package
+++ b/package/display/package
@@ -8,7 +8,7 @@ timestamp=2021-08-23T09:53:41Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.8-2
+pkgver=1:0.0.9-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    c898ed00afcee1ed7bdd63fe95b92ad586577586fd238915a5aecbe490d639b5
+    661a8a96a9eb587074c38879d6ae4783af2b2aec185d8f8cad618c4e8002a7e6
     SKIP
     SKIP
     SKIP

--- a/package/doomarkable/package
+++ b/package/doomarkable/package
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(doomarkable)
+pkgdesc="DOOM game"
+url=https://github.com/LinusCDE/doomarkable
+pkgver=0.4.0-1
+timestamp=2021-10-25T23:02Z
+section="games"
+maintainer="Linus K. <linus@cosmos-ink.net>"
+license=MIT
+installdepends=(display)
+flags=(patch_rm2fb)
+
+image=rust:v2.2
+source=(https://github.com/LinusCDE/doomarkable/archive/0.4.0.zip)
+sha256sums=(39988c0a607560787789b0e71aa34059c64d11ba1b98e11145d08677ed420c5f)
+
+build() {
+    # Fall back to system-wide config
+    rm .cargo/config
+    cargo build --release
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/doomarkable
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft "$srcdir"/doomarkable.draft
+    install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons "$srcdir"/doomarkable.png
+}

--- a/package/dotnet/package
+++ b/package/dotnet/package
@@ -12,7 +12,7 @@ pkgnames=(
     aspnet-targeting-pack
     netstandard-targeting-pack
 )
-pkgver=3.1.10-3
+pkgver=3.1.20-1
 timestamp=2020-12-27T18:48Z
 maintainer="Eeems <eeems@eeems.email>"
 url=https://www.microsoft.com/net/core
@@ -20,11 +20,11 @@ section="devel"
 license=MIT
 
 source=(
-    https://download.visualstudio.microsoft.com/download/pr/2ebe1f4b-4423-4694-8f5b-57f22a315d66/4bceeffda88fc6f19fad7dfb2cd30487/dotnet-sdk-3.1.404-linux-arm.tar.gz
+    https://download.visualstudio.microsoft.com/download/pr/cefd43b6-16ac-4435-bcc6-594ebb0441cf/7d064f0f61c4174f620eafe97484e6cb/dotnet-sdk-3.1.414-linux-arm.tar.gz
     dotnet-profile.sh
 )
 sha256sums=(
-    c95e8cf72abbcde1ac3974158ed9355d8d5588bade463fdf69d6932f915f453a
+    dd9cf827b9af32a975f5c62c59221568782768d7ff5fc1622111f13c1dbe9339
     SKIP
 )
 

--- a/package/mmc-utils/0001-Makefile-Remove-Werror.patch
+++ b/package/mmc-utils/0001-Makefile-Remove-Werror.patch
@@ -1,0 +1,39 @@
+From 898bae517a42c1bf088e1c7b2bd34cd1fb086d22 Mon Sep 17 00:00:00 2001
+From: Alistair Francis <alistair@alistair23.me>
+Date: Wed, 3 Nov 2021 22:23:46 +1000
+Subject: [PATCH] Makefile: Remove -Werror
+
+Signed-off-by: Alistair Francis <alistair@alistair23.me>
+---
+ Makefile | 6 ++----
+ 1 file changed, 2 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index aa27ff2..3402007 100644
+--- a/Makefile
++++ b/Makefile
+@@ -8,11 +8,9 @@ objects = \
+ 	3rdparty/hmac_sha/hmac_sha2.o \
+ 	3rdparty/hmac_sha/sha2.o
+ 
+-CHECKFLAGS = -Wall -Werror -Wuninitialized -Wundef
+-
+ DEPFLAGS = -Wp,-MMD,$(@D)/.$(@F).d,-MT,$@
+ 
+-override CFLAGS := $(CHECKFLAGS) $(AM_CFLAGS) $(CFLAGS)
++override CFLAGS := $(AM_CFLAGS) $(CFLAGS)
+ 
+ INSTALL = install
+ prefix ?= /usr/local
+@@ -24,7 +22,7 @@ progs = mmc
+ 
+ # make C=1 to enable sparse
+ ifdef C
+-	check = sparse $(CHECKFLAGS)
++	check = sparse
+ endif
+ 
+ all: $(progs) manpages
+-- 
+2.31.1
+

--- a/package/mmc-utils/package
+++ b/package/mmc-utils/package
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+archs=(rmall)
+pkgnames=(mmc-utils)
+pkgdesc="A tool for monitoring the eMMC protocol"
+url=https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/
+pkgver=1.0-0
+timestamp=2021-08-12T19:41:07Z
+section="devel"
+maintainer="Alistair Francis <alistair@alistair23.me>"
+license=GPL-2.0-only
+
+image=base:v2.2
+source=(
+    "https://git.kernel.org/pub/scm/utils/mmc/mmc-utils.git/snapshot/mmc-utils-7769a4d7abe339ce273c13a203394a79a11fcff9.tar.gz"
+    0001-Makefile-Remove-Werror.patch
+)
+sha256sums=(
+    0578e546d8893b6207180def7966e7314cae54c237a931b8f94779ce5c7d0668
+    SKIP
+)
+
+build() {
+    # Use our toolchain
+    export AR=arm-linux-gnueabihf-ar
+    export CC=arm-linux-gnueabihf-gcc
+    export STRIP=arm-linux-gnueabihf-strip
+
+    patch < "$srcdir"/0001-Makefile-Remove-Werror.patch
+    make -j4
+}
+
+package() {
+    DESTDIR="$pkgdir" make -C "$srcdir" install
+}

--- a/package/vnsee/package
+++ b/package/vnsee/package
@@ -5,8 +5,8 @@
 pkgnames=(vnsee)
 pkgdesc="VNC client allowing you to use the device as a second screen"
 url=https://github.com/matteodelabre/vnsee
-pkgver=0.4.0-2
-timestamp=2021-04-24T20:36:31Z
+pkgver=0.4.1-1
+timestamp=2021-08-29T13:45:26Z
 section="screensharing"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0-only
@@ -24,7 +24,7 @@ source=(
     VNSee.oxide
 )
 sha256sums=(
-    ae961d43c3795a2694bc11920a6b462e7f7ec899be9318617578ccf0fb7c8f7d
+    bf6fd0d6478f0dd865bb25a4a4c061f306f53c84cff06ab51e0db36f518d6af9
     3f2f07a0c0a0d7bb1392e646a40f73028069e4fe1fa18dd7fc45ef5f66641f32
     SKIP
     SKIP

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -2,29 +2,30 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-archs=(rm1)
 pkgnames=(whiteboard-hypercard)
 pkgdesc="Real-time collaboration, drawing or whiteboarding"
 url=https://github.com/fenollp/reMarkable-tools
-pkgver=0.3.0-2
-timestamp=2020-09-23T18:01Z
+pkgver=0.3.4-1
+timestamp=2021-10-25T15:45Z
 section="drawing"
 maintainer="Pierre Fenoll <pierrefenoll@gmail.com>"
 license=Apache-2.0
+installdepends=(display)
+flags=(patch_rm2fb)
 
-image=rust:v1.1
+image=rust:v2.2
 source=(
-    https://github.com/fenollp/reMarkable-tools/archive/v0.3.0.zip
+    https://github.com/fenollp/reMarkable-tools/archive/v0.3.4.zip
     whiteboard-hypercard.draft
 )
 sha256sums=(
-    3d160d77cd384ee9339c7f791b3f762bb295a670c0c728373c6a09f14a061046
+    b343e1b4af9e0bf247ff2fab8331648ddd89941fb5c0ea9a45417d3bb4b20193
     SKIP
 )
 
 build() {
     cd marauder
-    rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
+    rustup component add rustfmt
     cargo build --release --bin whiteboard --locked
 }
 


### PR DESCRIPTION
New packages:

- doomarkable
- mmc-utils

Updated packages:

- whiteboard-hypercard - 0.3.4
- vnsee - 0.4.1
- aspnet-runtime, aspnet-targetting-pack, dotnet-profile, dotnet-host, dotnet-sdk, dotnet-targetting-pack, netstandard-targetting-pack - 3.1.20
- display, rm2fb-client 0.0.9