### PR TITLE
Fix bootstrap script dep error during toltec-bootstrap install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To automatically install Opkg, Entware and Toltec, make sure your device is conn
 
 ```sh
 wget http://toltec-dev.org/bootstrap
-echo "2d1233271e0cc8232e86827bcb37ab2a44be2c5675cd15f32952614916ae246a  bootstrap" | sha256sum -c && bash bootstrap
+echo "aa808c87fae9a9ad8c5f264044f8d770f7cd8ac07f96d2c5df648f7a20856d3d  bootstrap" | sha256sum -c && bash bootstrap
 ```
 
 > **Warning:**

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -10,6 +10,8 @@ timestamp=2021-10-06T07:51Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
+# NOTE: The following dependencies will NOT be honored during bootstrap
+# and will only be available after the install is completed
 installdepends=(coreutils-tsort)
 
 source=(

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -153,7 +153,8 @@ main() {
     # Remove those binaries in any case when the script exits
     trap cleanup EXIT
 
-    # Download and install the latest toltec-bootstrap package to load toltecctl
+    # Download and install the latest toltec-bootstrap package (without
+    # its dependencies) to use toltecctl definitions
     local pkg_basename
     pkg_basename="$(
         wget --quiet "$toltec_remote/Packages" -O - \
@@ -162,7 +163,8 @@ main() {
     local pkg_filename="/tmp/$pkg_basename"
     wget --no-verbose "$toltec_remote/$pkg_basename" -O "$pkg_filename"
 
-    opkg install --add-arch rmall:200 --offline-root / "$pkg_filename"
+    opkg install --add-arch rmall:200 --offline-root / --force-depends \
+        "$pkg_filename" > /dev/null 2>&1
     rm "$pkg_filename"
 
     # shellcheck source=../../package/toltec-bootstrap/toltecctl
@@ -235,8 +237,8 @@ main() {
         opkg install "$@"
     fi
 
-    # Reinstall toltec-bootstrap to mark toltecctl file as managed
-    # and set the user’s PATH in configure
+    # Reinstall toltec-bootstrap to mark its files as managed,
+    # to install its dependencies, and to set the user’s PATH
     opkg install toltec-bootstrap
     log "After each system upgrade, run 'toltecctl reenable' to re-enable Toltec"
 }


### PR DESCRIPTION
Following #456, a dependency on coreutils-tsort was added to the toltec-bootstrap package. That dependency is only needed during uninstall and is used to sort the packages in reverse dependency order.

The bootstrap script does an initial temporary install of toltec-bootstrap in order to use the toltecctl definitions. It does not expect the package to have dependencies. As a consequence, the script fails to perform installs in its current state.

This fix makes the script ignore dependencies for the temporary install. The dependencies do get installed at the end of the install procedure. I also added a warning above the dependency list in toltec-bootstrap to inform future contributors that those dependencies will not be honored in the initial temporary install of toltec-bootstrap.

Sorry that I missed this when writing #456!

**To test:** simply use the bootstrap script from this PR to make a new Toltec install.

<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was sucessfully tested on both
devices, we can add it! 🎊🎉🎊

-->
