### PR TITLE
rmfakecloud-proxy:  Add status subcommand

### DIFF
--- a/package/rmfakecloud-proxy/package
+++ b/package/rmfakecloud-proxy/package
@@ -7,7 +7,7 @@ pkgdesc="Connect Xochitl to a rmfakecloud server"
 _url=https://github.com/ddvk/rmfakecloud-proxy
 url="$_url"
 _upver=0.0.3
-pkgver="$_upver-1"
+pkgver="$_upver-2"
 timestamp=2021-09-26T20:38:44Z
 section="utils"
 maintainer="Mattéo Delabre <spam@delab.re>"
@@ -59,18 +59,7 @@ configure() {
         uninstall-hosts
     fi
 
-    if ! is-enabled; then
-        cat << MSG
-
-Run the following commands to use rmfakecloud-proxy:
-
-$ rmfakecloudctl set-upstream https://your-server.example.org
-$ rmfakecloudctl enable
-
-Replace your-server.example.org with the address of the server you want to use.
-
-MSG
-    fi
+    rmfakecloudctl status
 }
 
 preremove() {

--- a/package/rmfakecloud-proxy/rmfakecloudctl
+++ b/package/rmfakecloud-proxy/rmfakecloudctl
@@ -323,7 +323,6 @@ uninstall() {
     disconnect-cloud
     mark-disabled
     systemctl disable --now rmfakecloud-proxy
-    rm -f "$conf_dir/config"
     uninstall-hosts
     uninstall-certificates
     set -e

--- a/package/rmfakecloud-proxy/rmfakecloudctl
+++ b/package/rmfakecloud-proxy/rmfakecloudctl
@@ -26,6 +26,12 @@ xochitl_conf_path=/home/root/.config/remarkable/xochitl.conf
 # Path to Xochitl data
 xochitl_data_dir=/home/root/.local/share/remarkable/xochitl
 
+# ANSI escapes for colors
+red="\033[31m"
+green="\033[32m"
+yellow="\033[33m"
+reset="\033[m"
+
 # Disconnect Xochitl from the cloud
 #
 # This is a necessary step when switching cloud servers to prevent the client
@@ -138,6 +144,43 @@ key: $data_dir/rmfakecloud-proxy.key
 upstream: $1
 addr: $proxy_listen:443
 YAML
+}
+
+# Check if a given server is an rmfakecloud host
+#
+# Output: Details on the given host status
+# Exit code:
+#
+# 0 - If the server seems to be a valid rmfakecloud host
+# 1 - If it’s definitely not
+check-upstream() {
+    local url="$upstream/service/json/1/test"
+    local contents
+    local wget_exit
+    contents="$(wget --output-document - --quiet "$url" 2>&1)" \
+        && wget_exit=$? || wget_exit=$?
+
+    if [[ $wget_exit = 8 ]]; then
+        # HTTP error, the page probably doesn't exist
+        echo "invalid"
+        return 1
+    elif [[ $wget_exit = 4 ]]; then
+        # Network error, the server probably doesn't exist or is offline
+        echo "unreachable"
+        return 1
+    elif [[ $wget_exit != 0 ]]; then
+        # Other error
+        echo "error"
+        return 1
+    fi
+
+    if [[ $contents != '{"Host":"local.appspot.com","Status":"OK"}' ]]; then
+        echo "invalid"
+        return 1
+    fi
+
+    echo "working"
+    return 0
 }
 
 # Generate a local certificate authority, add it to the system trust,
@@ -291,8 +334,9 @@ help() {
 Manage rmfakecloud-proxy. Available commands:
 
     help                    Show this help message.
+    status                  Check the current status of rmfakecloud-proxy.
     enable                  Enable rmfakecloud-proxy.
-    set-upstream            Define the rmfakecloud server.
+    set-upstream            Set the upstream rmfakecloud server.
     disable                 Disable rmfakecloud-proxy."
 }
 
@@ -306,6 +350,42 @@ if [[ $0 = "${BASH_SOURCE[0]}" ]]; then
     shift
 
     case $action in
+        status)
+            is-enabled && state="${green}enabled" || state="${red}disabled"
+            service="$(systemctl is-active rmfakecloud-proxy.service)" || true
+
+            if [[ $service = active ]]; then
+                service="$green$service"
+            else
+                service="$yellow$service"
+            fi
+
+            if ! upstream="$(get-upstream)"; then
+                upstream="(${yellow}not set$reset)"
+            else
+                if ! upstream_status="$(check-upstream "$upstream")"; then
+                    upstream="$upstream ($red$upstream_status$reset)"
+                else
+                    upstream="$upstream ($green$upstream_status$reset)"
+                fi
+            fi
+
+            echo -e "Status: $state$reset ($service$reset)"
+            echo -e "Upstream server: $upstream"
+            echo
+
+            if is-enabled; then
+                echo "Run \`rmfakecloudctl disable\` to disable \
+rmfakecloud-proxy."
+            else
+                echo "Run \`rmfakecloudctl enable\` to enable \
+rmfakecloud-proxy."
+            fi
+
+            echo "Run \`rmfakecloudctl set-upstream https://<server>\` to \
+set the upstream server."
+            ;;
+
         enable)
             if is-enabled; then
                 echo "rmfakecloud-proxy is already enabled."
@@ -336,14 +416,6 @@ if [[ $0 = "${BASH_SOURCE[0]}" ]]; then
                 if is-enabled; then
                     systemctl restart rmfakecloud-proxy
                 fi
-            fi
-
-            if ! is-enabled; then
-                cat << MSG
-Run the following command to enable rmfakecloud-proxy:
-
-$ rmfakecloudctl enable
-MSG
             fi
             ;;
 


### PR DESCRIPTION
This PR addresses the points from @Eeems’ review of last PR: https://github.com/toltec-dev/toltec/pull/448#issuecomment-986156400

The new `rmfakecloudctl status` introduced by this PR reports whether rmfakecloud-proxy is enabled, currently active, and whether the upstream server has been set. If the upstream server is set, it also checks whether it is reachable and a valid rmfakecloud server. Here are some possible states that can be shown by the command:

*Disabled (happens, for example, right after install):*

![rmfc-disabled](https://user-images.githubusercontent.com/1370040/146284158-5ce0fee6-7aa4-4264-9997-245c7e09e3d7.png)

*Enabled, but upstream not set:*

![rmfc-enabled-inactive](https://user-images.githubusercontent.com/1370040/146284156-1090e6e3-3731-46ee-a1ca-3ddf83a2374d.png)

*Enabled, but upstream is unreachable:*

![rmfc-enabled-unreachable](https://user-images.githubusercontent.com/1370040/146284154-15b0c339-4787-4dab-bb6c-fe88fc1ba063.png)

*Enabled, but upstream does not seem to be an rmfakecloud server:*

![rmfc-enabled-invalid](https://user-images.githubusercontent.com/1370040/146284153-c534586d-08e1-4665-96e1-35360cd9a21f.png)

*Enabled and working:*

![rmfc-enabled-working](https://user-images.githubusercontent.com/1370040/146284300-47deb1bd-8aad-4847-88cb-9c8a54055370.png)

This PR also changes the disable command to not clean up the `/opt/etc/rmfakecloud-proxy/config` file. This fixes the issue where doing `rmfakecloudctl set-upstream`, followed by an interrupted `rmfakecloudctl enable`, would unset the upstream.