### PR TITLE
[rmkit] update remux and minesweeper

### DIFF
--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(bufshot genie harmony iago lamp mines nao remux simple)
-timestamp=2021-11-27T07:33:10Z
+timestamp=2021-12-24T07:33:10Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 installdepends=(display)
@@ -11,12 +11,12 @@ flags=(patch_rm2fb)
 
 image=python:v2.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/b810e68e18eeb33b70b6dd37c35f0d6b78e82cc4.zip
+    https://github.com/rmkit-dev/rmkit/archive/cc1dfe4be29de113a9997899b85f3fa9be417f1b.zip
     remux.service
     genie.service
 )
 sha256sums=(
-    a76100542f6a08d656003e7f6b16a71fd443688e7c16bef657e424e06a46c2e2
+    e51f0782aed5503f09855349ef5d5e3226460459d06855a6e83e5733eeabaacb
     SKIP
     SKIP
 )
@@ -107,7 +107,7 @@ lamp() {
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.1.2-4
+    pkgver=0.1.3-1
     section="games"
 
     package() {
@@ -134,7 +134,7 @@ nao() {
 remux() {
     pkgdesc="Launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.1.13-1
+    pkgver=0.1.14-1
     section="launchers"
 
     package() {


### PR DESCRIPTION
* add `launch` command to remux, use like: `echo "launch xochitl" > /run/remux.api`
* fix pixmap display in minesweeper so icons show up
