### PR TITLE
[rmkit] update harmony and bufshot

### DIFF
--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(bufshot genie harmony iago lamp mines nao remux simple)
-timestamp=2021-12-24T07:33:10Z
+timestamp=2021-12-27T07:33:10Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 installdepends=(display)
@@ -11,12 +11,12 @@ flags=(patch_rm2fb)
 
 image=python:v2.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/cc1dfe4be29de113a9997899b85f3fa9be417f1b.zip
+    https://github.com/rmkit-dev/rmkit/archive/493916d4112545b2ff6c32a67e3928a9bf7365a9.zip
     remux.service
     genie.service
 )
 sha256sums=(
-    e51f0782aed5503f09855349ef5d5e3226460459d06855a6e83e5733eeabaacb
+    8d9e9d62cbd918b541d0e5f62a4fd3f9208b289e42d04738da3db146ddf281b1
     SKIP
     SKIP
 )
@@ -29,7 +29,7 @@ build() {
 bufshot() {
     pkgdesc="program for saving the framebuffer as a png"
     url="https://github.com/rmkit-dev/rmkit/tree/master/src/bufshot"
-    pkgver=0.1.0-5
+    pkgver=0.1.1-1
     section="utils"
 
     package() {
@@ -67,7 +67,7 @@ genie() {
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.1.3-3
+    pkgver=0.1.4-1
     section="drawing"
 
     package() {


### PR DESCRIPTION
* fix harmony not loading saved images (due to trying to save them in color)
* fix bufshot to correctly recognize the tablet

testing: 

* run bufshot from commandline, verifies it saves the screen to fb.png (in grayscale)
* run harmony, draw a little bit and then use the menu to click 'save'. after saving the image, use 'load' and click the image to verify it loads. make sure to move /home/root/saved_images/* to a new directory since they may not be compatible with the updated harmony code (and were causing crashes previously)