### PR TITLE
display: Release 0.0.13

### DIFF
--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2021-12-15T17:10:54Z
+timestamp=2021-12-29T03:05:58Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.12-2
+pkgver=1:0.0.13-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    3c0ed7a837883e046bb3c6c240e0dc1f4928e148343e65cc259042f75247267b
+    ffdd9e5c2a62e529995b2aae04b41459b58f5f963bccd9947b01cfb3c514b117
     SKIP
     SKIP
     SKIP

--- a/package/display/rm2fb.service
+++ b/package/display/rm2fb.service
@@ -7,10 +7,10 @@ Before=xochitl.service launcher.service remarkable-reboot.service remarkable-shu
 After=opt.mount
 StartLimitInterval=30
 StartLimitBurst=5
-Conflicts=
 ConditionFileNotEmpty=/opt/lib/librm2fb_server.so.1
 
 [Service]
+Type=notify
 ExecStart=/usr/bin/xochitl
 Restart=on-failure
 RestartSec=5
@@ -18,4 +18,4 @@ Environment="HOME=/home/root"
 Environment="LD_PRELOAD=/opt/lib/librm2fb_server.so.1"
 
 [Install]
-WantedBy=multi-user.target xochitl.service
+WantedBy=multi-user.target


### PR DESCRIPTION
This release of remarkable2-framebuffer complements PR #455 and brings a
fix for a potential bug in the client (see ddvk/remarkable2-framebuffer#85).

The rm2fb service will now only open the IPC channels after it has
confirmed that all the required offsets for the current system release
are available. This can take a few seconds; the service will also notify
the systemd daemon when it is ready to accept requests, so that
dependent services such as Xochitl can correctly wait for the server to
be available before starting.

To test:

* Upgrade both the rm2fb-client and display packages.
* Enable xochitl.service, disable launchers.
* Reboot.
* Expected logs from rm2fb.service:

```
$ journalctl --unit rm2fb --boot=0 | head
Dec 29 18:44:02: Starting reMarkable 2 Framebuffer Server...
Dec 29 18:44:03: STARTING RM2FB
Dec 29 18:44:03: getInstance() at address: 0x3a042c
Dec 29 18:44:03: REPLACING THE IMAGE with shared memory
Dec 29 18:44:04: Reading waveforms from /usr/share/remarkable/320_R349_AF0411_E
Dec 29 18:44:04: Running INIT (99 phases)
Dec 29 18:44:04: 1404 1872 16
Dec 29 18:44:04: WAITING FOR SEND UPDATE ON MSG Q
Dec 29 18:44:04: Started reMarkable 2 Framebuffer Server.
```

* Expected logs from xochitl.service:

```
$ journalctl --unit xochitl --boot=0 | head
Dec 29 18:44:04: Started reMarkable main application.
Dec 29 18:44:05: Sourcing /opt/etc/xochitl.env.d/rm2fb-preload.env
Dec 29 18:44:05: Replacing 'update' (at 0x3a9cdc): OK
Dec 29 18:44:05: Replacing 'create' (at 0x3ac134): OK
Dec 29 18:44:05: Replacing 'shutdown' (at 0x3ac0d8): OK
Dec 29 18:44:05: Replacing 'wait' (at 0x3ab614): OK
...
```

* (The absolute times will be different, but notice the relative
  ordering of log entries between the two services.)
* Edit `/etc/version` to an unsupported version number and reboot.
* Expected logs from rm2fb.service:

```
$ journalctl --unit rm2fb --boot=0 | head
Dec 29 18:53:11: Starting reMarkable 2 Framebuffer Server...
Dec 29 18:53:12: STARTING RM2FB
Dec 29 18:53:12: Missing address for function 'getInstance'
Dec 29 18:53:12: PLEASE SEE https://github.com/ddvk/remarkable2-framebuffer/issues/18
Dec 29 18:53:12: rm2fb.service: Main process exited, code=exited, status=255/EXCEPTION
Dec 29 18:53:12: rm2fb.service: Failed with result 'exit-code'.
Dec 29 18:53:12: Failed to start reMarkable 2 Framebuffer Server.
Dec 29 18:53:17: rm2fb.service: Scheduled restart job, restart counter is at 1.
Dec 29 18:53:17: Stopped reMarkable 2 Framebuffer Server.
```

* Expected logs from xochitl.service:

```
$ journalctl --unit xochitl --boot=0 | head
Dec 29 18:53:12: Started reMarkable main application.
Dec 29 18:53:12: Sourcing /opt/etc/xochitl.env.d/rm2fb-preload.env
Dec 29 18:53:12: rm2fb server is not running: starting without rm2fb client
...
```

<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
