### PR TITLE
Update Oxide to v2.3

### DIFF
--- a/package/oxide/package
+++ b/package/oxide/package
@@ -6,7 +6,7 @@ pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety)
 pkgver=2.3-1
 timestamp=2022-01-06T22:47:15Z
 maintainer="Eeems <eeems@eeems.email>"
-url="https://oxide.eeems.codes"
+url=https://oxide.eeems.codes
 license=MIT
 flags=(patch_rm2fb)
 

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -4,8 +4,9 @@
 
 pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety)
 pkgver=2.3-1
-timestamp=2021-09-26T23:37:41Z
+timestamp=2022-01-06T22:47:15Z
 maintainer="Eeems <eeems@eeems.email>"
+url="https://oxide.eeems.codes"
 license=MIT
 flags=(patch_rm2fb)
 
@@ -22,7 +23,6 @@ build() {
 
 erode() {
     pkgdesc="Task manager"
-    url=https://github.com/Eeems/oxide/tree/master/applications/process-manager
     section="admin"
     installdepends=(display "tarnish=$pkgver")
 
@@ -36,7 +36,6 @@ erode() {
 
 fret() {
     pkgdesc="Take screenshots"
-    url=https://github.com/Eeems/oxide/tree/master/applications/screenshot-tool
     section="utils"
     installdepends=("tarnish=$pkgver")
 
@@ -48,7 +47,6 @@ fret() {
 
 oxide() {
     pkgdesc="Launcher application"
-    url=https://github.com/Eeems/oxide/tree/master/applications/launcher
     section="launchers"
     installdepends=(display "erode=$pkgver" "fret=$pkgver" "tarnish=$pkgver" "rot=$pkgver" "decay=$pkgver")
 
@@ -70,7 +68,6 @@ oxide() {
 
 rot() {
     pkgdesc="Manage Oxide settings through the command line"
-    url=https://github.com/Eeems/oxide/tree/master/applications/settings-manager
     section="admin"
     installdepends=("tarnish=$pkgver")
 
@@ -81,7 +78,6 @@ rot() {
 
 tarnish() {
     pkgdesc="Service managing power states, connectivity and buttons"
-    url=https://github.com/Eeems/oxide/tree/master/applications/system-service
     section="devel"
     installdepends=(display xochitl)
 
@@ -110,7 +106,6 @@ tarnish() {
 
 decay() {
     pkgdesc="Lockscreen application"
-    url=https://github.com/Eeems/oxide/tree/master/applications/lockscreen
     section="utils"
     installdepends=(display "tarnish=$pkgver")
 
@@ -121,7 +116,6 @@ decay() {
 }
 corrupt() {
     pkgdesc="Task Switcher for Oxide"
-    url=https://github.com/Eeems/oxide/tree/master/applications/task-switcher
     section="utils"
     installdepends=(display "tarnish=$pkgver")
 
@@ -133,7 +127,6 @@ corrupt() {
 
 anxiety() {
     pkgdesc="Screenshot viewer for Oxide"
-    url=https://github.com/Eeems/oxide/tree/master/applications/screenshot-viewer
     section="utils"
     installdepends=(display "tarnish=$pkgver")
 

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety)
-pkgver=2.2.2-1
+pkgver=2.3-1
 timestamp=2021-09-26T23:37:41Z
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
@@ -12,7 +12,7 @@ flags=(patch_rm2fb)
 image=qt:v2.1
 _srcver="v${pkgver%-*}"
 source=("https://github.com/Eeems/oxide/archive/refs/tags/$_srcver.tar.gz")
-sha256sums=(0d221c084f5583075052dd2369144c04cf97010d5641ebc029ae596d8ef1a40d)
+sha256sums=(abea9dea4232b36e4fdabf27b0707683a757e1bb0a928daeb191d97fb876cf33)
 
 build() {
     find . -name "*.pro" -type f -print0 \


### PR DESCRIPTION
Update to Oxide v2.3
- [Release Notes](https://github.com/Eeems/oxide/releases/tag/v2.3)