### PR TITLE
Minor opkg completion update

### DIFF
--- a/package/toltec-completion/_opkg
+++ b/package/toltec-completion/_opkg
@@ -96,7 +96,6 @@ _opkg() {
         esac
 
         # Completion of subcommand arguments involving package names
-        # TODO: Cache package listings to speed up completion
         local available_pkgs installed_pkgs
         mapfile -t available_pkgs < <(opkg list | awk '{ print $1 }')
         mapfile -t installed_pkgs < <(opkg list-installed | awk '{ print $1 }')

--- a/package/toltec-completion/package
+++ b/package/toltec-completion/package
@@ -5,8 +5,8 @@
 pkgnames=(toltec-completion)
 pkgdesc="Expands bash-completion with functions for toltec-specific commands"
 url=https://github.com/toltec-dev/toltec
-pkgver=0.3.0-1
-timestamp=2021-07-29T22:55Z
+pkgver=0.3.1-1
+timestamp=2022-01-23T23:29Z
 section="utils"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=MIT


### PR DESCRIPTION
Pretty small update just removing one comment.

Did look at some scripts and found that it contained a todo I already pondered and deemed as not useful (linked in the commit description).

I also checked whether the globally disabled spellchecks were now unnecessary (maybe some refactoring) but they are still good.

Not sure about the comments/descriptions of the variables, but since I didn't find any documentation in the [https://github.com/scop/bash-completion], these are probably still helpful for anyone taking a look at it (checked source code as well as explicit docs).