### PR TITLE
Hotfixes for stable merge of week 6

### DIFF
--- a/package/innernet/package
+++ b/package/innernet/package
@@ -5,8 +5,8 @@
 pkgnames=(innernet-client)
 pkgdesc="A private network system that uses WireGuard under the hood."
 url="https://github.com/tonarino/innernet"
-pkgver=1.5.3-1
-timestamp=2021-08-31T17:57:00Z
+pkgver=1.5.3-2
+timestamp=2022-01-31T20:08:43Z
 section="utils"
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"
 license=MIT

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,7 +5,7 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.25-1
+pkgver=0.9.25-2
 timestamp=2022-02-08T23:54Z
 section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
@@ -36,6 +36,10 @@ build() {
     ./clean.sh
     ./build.sh
     ./dist.sh
+
+    # Patch wrapper script to have a process name consistent with the
+    # path of the symlink in /opt/bin
+    sed -i 's#exec ./plato#exec -a /opt/bin/plato ./plato#' dist/plato.sh
 }
 
 package() {

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(bufshot dumbskull genie harmony iago lamp mines nao remux rpncalc simple wordlet)
-timestamp=2021-01-29T09:18:10Z
+timestamp=2022-01-29T09:18:10Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 installdepends=(display)
@@ -29,7 +29,7 @@ build() {
 bufshot() {
     pkgdesc="program for saving the framebuffer as a png"
     url="https://github.com/rmkit-dev/rmkit/tree/master/src/bufshot"
-    pkgver=0.1.2-1
+    pkgver=0.1.2-2
     section="utils"
 
     package() {
@@ -40,7 +40,7 @@ bufshot() {
 dumbskull() {
     pkgdesc="Dungeon Crawl themed Solitaire"
     url="https://rmkit.dev/apps/dumbskull"
-    pkgver=0.0.1-1
+    pkgver=0.0.1-2
     section="games"
 
     package() {
@@ -53,7 +53,7 @@ dumbskull() {
 genie() {
     pkgdesc="Gesture engine that connects commands to gestures"
     url="https://rmkit.dev/apps/genie"
-    pkgver=0.1.6-1
+    pkgver=0.1.6-2
     section="utils"
 
     package() {
@@ -80,7 +80,7 @@ genie() {
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.1.5-1
+    pkgver=0.1.5-2
     section="drawing"
 
     package() {
@@ -97,7 +97,7 @@ harmony() {
 iago() {
     pkgdesc="overlay for drawing shapes via stroke injection"
     url="https://rmkit.dev/apps/iago"
-    pkgver=0.1.1-1
+    pkgver=0.1.1-2
     section="utils"
     installdepends+=("lamp")
 
@@ -109,7 +109,7 @@ iago() {
 lamp() {
     pkgdesc="config based stroke injection utility"
     url="https://rmkit.dev/apps/lamp"
-    pkgver=0.1.1-1
+    pkgver=0.1.1-2
     section="utils"
 
     package() {
@@ -120,7 +120,7 @@ lamp() {
 mines() {
     pkgdesc="Mine detection game"
     url="https://rmkit.dev/apps/minesweeper"
-    pkgver=0.1.4-1
+    pkgver=0.1.4-2
     section="games"
 
     package() {
@@ -147,7 +147,7 @@ nao() {
 remux() {
     pkgdesc="Launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.2.1-1
+    pkgver=0.2.1-2
     section="launchers"
 
     package() {
@@ -179,7 +179,7 @@ remux() {
 rpncalc() {
     pkgdesc="RPN Calculator"
     url="https://rmkit.dev/apps/rpncalc"
-    pkgver=0.0.2-1
+    pkgver=0.0.2-2
     section="math"
 
     package() {
@@ -193,7 +193,7 @@ rpncalc() {
 simple() {
     pkgdesc="Simple app script for writing scripted applications"
     url="https://rmkit.dev/apps/sas"
-    pkgver=0.1.5-1
+    pkgver=0.1.5-2
     section="devel"
 
     package() {
@@ -204,7 +204,7 @@ simple() {
 wordlet() {
     pkgdesc="Wordle clone"
     url="https://rmkit.dev/apps/wordlet"
-    pkgver=0.0.1-1
+    pkgver=0.0.1-2
     section="games"
 
     package() {


### PR DESCRIPTION
* Update innernet timestamp
* Fix rmkit timestamp for apps updated in #542
* Patch the Plato wrapper script to make the process name be
  `/opt/bin/plato`, so that it can be properly recognized by remux

<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
