### PR TITLE
Update KOReader to 2022.02

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.01-1
-timestamp=2022-01-16T13:04:08Z
+pkgver=2022.02-1
+timestamp=2022-02-27T14:33:06Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    0c8ca8705fa49dd10dc5359a86acdd1d16349c30d7dce166fe57f90112ec6c44
+    666557f3d053479a7a8642abbc00caec7c75413862ce2c85fe1122272f97f00f
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
[Release notes](https://github.com/koreader/koreader/releases/tag/v2022.02)