### PR TITLE
folly: Remove hardcoded paths and values in recipe

### DIFF
--- a/package/folly/package
+++ b/package/folly/package
@@ -5,7 +5,7 @@
 pkgnames=(folly)
 pkgdesc="Z-machine interpreter for interactive fiction"
 url="https://github.com/bkirwi/folly"
-pkgver=0.0.1-1
+pkgver=0.0.1-2
 timestamp=2022-01-29T15:35:52-05:00
 section=games
 maintainer="Ben Kirwin <ben@kirw.in>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(display)
 makedepends=(build:librust-clang-sys-dev build:libclang-dev build:libc6 build:libc6-dev build:clang)
 
-image=rust:v2.2.2
+image=rust:v2.3
 
 # Whitespace-separated list of source archives that are needed to build the package
 source=(
@@ -27,27 +27,29 @@ sha256sums=(
 )
 
 build() {
-    X_TOOLS="/opt/x-tools/arm-remarkable-linux-gnueabihf/arm-remarkable-linux-gnueabihf"
-    X_TOOLS_CPP="$X_TOOLS/include/c++/10.2.0"
+    local cpp_includes
+    local gcc_version
+    gcc_version="$("$CROSS_COMPILE"gcc -dumpfullversion)"
+    cpp_includes="$(realpath "$SYSROOT"/../include/c++/"$gcc_version")"
 
     # Arguments for bindgen's usage of clang
-    export BINDGEN_EXTRA_CLANG_ARGS="\
-      --sysroot=$X_TOOLS/sysroot\
-      -I$X_TOOLS_CPP -I$X_TOOLS_CPP/arm-remarkable-linux-gnueabihf"
+    export BINDGEN_EXTRA_CLANG_ARGS="--sysroot=$SYSROOT -I$cpp_includes \
+        -I$cpp_includes/$NGCONFIG"
 
     # Arguments for the gcc-based tensorflow build in the build.rs file of tflite-rs.
-    export TFLITE_RS_MAKE_TARGET_TOOLCHAIN_PREFIX="arm-remarkable-linux-gnueabihf-"
-    export TFLITE_RS_MAKE_EXTRA_CFLAGS="$BINDGEN_EXTRA_CLANG_ARGS -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9"
+    export TFLITE_RS_MAKE_TARGET_TOOLCHAIN_PREFIX="$CROSS_COMPILE"
+    export TFLITE_RS_MAKE_EXTRA_CFLAGS="$BINDGEN_EXTRA_CLANG_ARGS \
+        -mfpu=neon -mfloat-abi=hard -mcpu=cortex-a9"
 
     cargo build --release
 
     # Save the build system the trouble of stripping unused binaries
     rm -r target/release/build
-    rm -r target/armv7-unknown-linux-gnueabihf/release/build
+    rm -r target/*/release/build
 }
 
 package() {
     # Install the app binary and the draft file
-    install -D -m 755 "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/folly "$pkgdir"/opt/bin/folly
+    install -D -m 755 "$srcdir"/target/*/release/folly "$pkgdir"/opt/bin/folly
     install -D -m 644 "$srcdir"/folly.draft "$pkgdir"/opt/etc/draft/folly.draft
 }


### PR DESCRIPTION
No substantial changes in this PR, simply some changes in the recipe for `folly` (added in #543) to replace some hardcoded paths to toolchain locations and the hardcoded GCC version with values from the environment (populated by default in the toolchain Docker images).

This makes the recipe more robust to changes in the toolchain images. For example in the 2.3 toolchain update the GCC version was bumped from 10.2.0 to 10.3.0, which made the recipe fail as it was searching for 10.2.0 includes.

I’ve tested that the recipe still builds, installed folly on my rM2, and went through part of the tutorial to make sure that it still works. Pinging @bkirwi: does this look good to you?