### PR TITLE
xochitl: Fix missing launcher.service alias

### DIFF
--- a/package/xochitl/package
+++ b/package/xochitl/package
@@ -5,8 +5,8 @@
 pkgnames=(xochitl)
 pkgdesc="Read documents and take notes"
 url=https://remarkable.com
-pkgver=0.0.0-12
-timestamp=2021-11-29T22:06Z
+pkgver=0.0.0-13
+timestamp=2022-03-05T23:26Z
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT
@@ -14,7 +14,7 @@ license=MIT
 # below as a transitional dependency to ensure that it gets installed for
 # existing users (see toltec-dev/toltec#532 for context). This dependency
 # should be removed once the package has reached enough users
-installdepends=(findutils toltec-base)
+installdepends=(toltec-base)
 
 source=(
     xochitl
@@ -60,8 +60,22 @@ package() {
 
 configure() {
     systemctl daemon-reload
+
+    if is-enabled xochitl.service && ! is-enabled launcher.service; then
+        # This package changes xochitl.service to alias it to launcher.service
+        # when enabled. If xochitl was previously enabled, force the creation
+        # of this alias by re-enabling the service
+        systemctl enable xochitl.service 2> /dev/null
+    fi
 }
 
 postremove() {
     systemctl daemon-reload
+
+    if is-enabled xochitl.service && is-enabled launcher.service; then
+        # If xochitl is currently the active launcher, make sure the
+        # launcher.service alias is removed
+        systemctl disable xochitl.service 2> /dev/null
+        systemctl enable xochitl.service 2> /dev/null
+    fi
 }

--- a/package/xochitl/xochitl
+++ b/package/xochitl/xochitl
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 for file in /opt/etc/xochitl.env.d/*.env; do
-    echo "Sourcing $file"
-    # shellcheck disable=SC1090
-    source "$file"
+    if [[ -r $file ]]; then
+        echo "Sourcing $file"
+        # shellcheck disable=SC1090
+        source "$file"
+    fi
 done
 exec /usr/bin/xochitl "$@"


### PR DESCRIPTION
This PR contains some fixes for the xochitl package:

* On configure, force creating the launcher.service symlink if Xochitl was previously enabled (closes #558). After removal, force cleaning the launcher.service if Xochitl is enabled.
* Remove unused dependency on `findutils`.
* Fix the following warning in `xochitl` wrapper script that would appear in Xochitl logs when there are no files in /opt/etc/xochitl.env.d (such as by default on rM1):

```
/opt/bin/xochitl: line 8: /opt/etc/xochitl.env.d/*.env: No such file or directory
```

<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
