### PR TITLE
Package: noso_template

### DIFF
--- a/package/template-noso-grid/package
+++ b/package/template-noso-grid/package
@@ -49,17 +49,17 @@ package() {
 
 configure() {
     templatectl add -n "Noso Cube Low Density" -f "noso-cube-low.png" \
-        -c "Custom Grids"
+        -c "Custom" -c "Grids"
     templatectl add -n "Noso Cube Mid Density" -f "noso-cube-mid.png" \
-        -c "Custom Grids"
+        -c "Custom" -c "Grids"
     templatectl add -n "Noso Cube High Density" -f "noso-cube-high.png" \
-        -c "Custom Grids"
+        -c "Custom" -c "Grids"
     templatectl add -n "Noso Tall Low Density" -f "noso-tall-low.png" \
-        -c "Custom Grids"
+        -c "Custom" -c "Grids"
     templatectl add -n "Noso Tall Mid Density" -f "noso-tall-mid.png" \
-        -c "Custom Grids"
+        -c "Custom" -c "Grids"
     templatectl add -n "Noso Tall High Density" -f "noso-tall-high.png" \
-        -c "Custom Grids"
+        -c "Custom" -c "Grids"
 }
 
 preremove() {

--- a/package/template-noso-grid/package
+++ b/package/template-noso-grid/package
@@ -48,18 +48,18 @@ package() {
 }
 
 configure() {
-    templatectl add --name "Noso Cube Low Density" --filename "noso-cube-low" \
-        --category "Custom" --category "Grids"
-    templatectl add --name "Noso Cube Mid Density" --filename "noso-cube-mid" \
-        --category "Custom" --category "Grids"
-    templatectl add --name "Noso Cube High Density" --filename "noso-cube-high" \
-        --category "Custom" --category "Grids"
-    templatectl add --name "Noso Tall Low Density" --filename "noso-tall-low" \
-        --category "Custom" --category "Grids"
-    templatectl add --name "Noso Tall Mid Density" --filename "noso-tall-mid" \
-        --category "Custom" --category "Grids"
-    templatectl add --name "Noso Tall High Density" --filename "noso-tall-high" \
-        --category "Custom" --category "Grids"
+    templatectl add -n "Noso Cube Low Density" -f "noso-cube-low.png" \
+        -c "Custom Grids"
+    templatectl add -n "Noso Cube Mid Density" -f "noso-cube-mid.png" \
+        -c "Custom Grids"
+    templatectl add -n "Noso Cube High Density" -f "noso-cube-high.png" \
+        -c "Custom Grids"
+    templatectl add -n "Noso Tall Low Density" -f "noso-tall-low.png" \
+        -c "Custom Grids"
+    templatectl add -n "Noso Tall Mid Density" -f "noso-tall-mid.png" \
+        -c "Custom Grids"
+    templatectl add -n "Noso Tall High Density" -f "noso-tall-high.png" \
+        -c "Custom Grids"
 }
 
 preremove() {

--- a/package/template-noso-grid/package
+++ b/package/template-noso-grid/package
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(template-noso-grid)
+pkgdesc="Nosometric grid template"
+url=https://github.com/RobotCaleb/noso_template
+pkgver=1.0.0
+timestamp=2022-03-20T18:34Z
+section="templates"
+maintainer="Caleb Anderson <robotrising@gmail.com>"
+license=MIT
+installdepends=(templatectl)
+
+source=("https://github.com/RobotCaleb/noso_template/archive/refs/tags/v${pkgver%-*}.zip")
+sha256sums=(cd7cfcb0c2e9b9734a5e79c00182a4d27858e2c6e2501da54f4d58569171a734)
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-high/noso-cube-high.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-high/noso-cube-high.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-low/noso-cube-low.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-low/noso-cube-low.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-mid/noso-cube-mid.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-mid/noso-cube-mid.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-high/noso-tall-high.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-high/noso-tall-high.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-low/noso-tall-low.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-low/noso-tall-low.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-mid/noso-tall-mid.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-mid/noso-tall-mid.svg
+}
+
+configure() {
+    templatectl add --name "Noso Cube Low Density" --filename "noso-cube-low" \
+        --category "Custom" --category "Grids"
+    templatectl add --name "Noso Cube Mid Density" --filename "noso-cube-mid" \
+        --category "Custom" --category "Grids"
+    templatectl add --name "Noso Cube High Density" --filename "noso-cube-high" \
+        --category "Custom" --category "Grids"
+    templatectl add --name "Noso Tall Low Density" --filename "noso-tall-low" \
+        --category "Custom" --category "Grids"
+    templatectl add --name "Noso Tall Mid Density" --filename "noso-tall-mid" \
+        --category "Custom" --category "Grids"
+    templatectl add --name "Noso Tall High Density" --filename "noso-tall-high" \
+        --category "Custom" --category "Grids"
+}
+
+preremove() {
+    templatectl remove --name "Noso Cube Low Density"
+    templatectl remove --name "Noso Cube Mid Density"
+    templatectl remove --name "Noso Cube High Density"
+    templatectl remove --name "Noso Tall Low Density"
+    templatectl remove --name "Noso Tall Mid Density"
+    templatectl remove --name "Noso Tall High Density"
+}


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
`noso_template` is a not-quite-isometric (so, nosometric) template useful for drawing 3d-ish isometric-ish images. Quick outlining of basic woodworking projects is a good example usage.

This adds the default templates included at https://github.com/RobotCaleb/noso_template

I am the author of both this package and the templates.

I have only tested the templates (but not this package, I don't know how to do that) on RM2 but I understand the displays are the same.

![image](https://user-images.githubusercontent.com/113401/159177936-f6998595-dc4c-4c2f-9ff3-d4e1e6e9e6d5.png)
