### PR TITLE
Update KOReader to v2022.03.1

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.03-1
+pkgver=2022.03.1-1
 timestamp=2022-03-20T08:31:59Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    e63ecea94d2ecaa466b72d2e778b1e69a78c891b942b031cb571d37fc3ea0f3a
+    109947258172456baeaadcf329b8b1fa4cfe1c03315c7e7222c3e4d83d81363c
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
[Release notes](https://github.com/koreader/koreader/releases/tag/v2022.03.1)
Don't use KOReader suspend/screensaver/autosuspend when Oxide is running