### PR TITLE
Update KOReader to 2022.05.1

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.05-1
-timestamp=2022-05-21T08:28:00Z
+pkgver=2022.05.1-1
+timestamp=2022-05-22T09:17:57Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    cadbf1c089e7407a4238d68be65c522ed25800a1d8f1382d51145de3f4208a47
+    19f3ab67b04ccad798de1ad87842dc417e14b54305b9a6f21e0dc3630dceaaed
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
Fix crash on reMarkable after first touching the screen.

[Full release notes](https://github.com/koreader/koreader/releases/tag/v2022.05.1)