### PR TITLE
Bump to the new rm2fb release

### DIFF
--- a/package/display/package
+++ b/package/display/package
@@ -4,7 +4,7 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-05-05T00:00:00Z
+timestamp=2022-06-05T02:34:52Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"

--- a/package/display/package
+++ b/package/display/package
@@ -8,7 +8,7 @@ timestamp=2022-04-07T06:07:54Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.16-1
+pkgver=1:0.0.17-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    fb4860e25dcd9bc842c0c62b516c1c578d9f0df03c181aaea803c9e343c26556
+    db80d5e2a7b5e1823d3b3a332abb0cd5f6e7caca936bdc9b0b4a2ce6b6ffae52
     SKIP
     SKIP
     SKIP

--- a/package/display/package
+++ b/package/display/package
@@ -4,7 +4,7 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-04-07T06:07:54Z
+timestamp=2022-05-05T00:00:00Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"


### PR DESCRIPTION
Just a version bump to pick up: https://github.com/ddvk/remarkable2-framebuffer/releases/tag/v0.0.17

Re: testing - I've been running with these values in rm2fb.conf for some time with no issues.