### PR TITLE
Bump ddvk 2.13.0.758

### DIFF
--- a/package/ddvk-hacks/package
+++ b/package/ddvk-hacks/package
@@ -6,15 +6,15 @@ archs=(rm1 rm2)
 pkgnames=(ddvk-hacks)
 pkgdesc="Enhance Xochitl with additional features"
 url=https://github.com/ddvk/remarkable-hacks
-pkgver=32.02-1
-timestamp=2022-04-08T11:41:50Z
+pkgver=33.02-1
+timestamp=2022-06-05T01:21:25+02:00
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT
 flags=(nostrip)
 
-source=(https://github.com/ddvk/remarkable-hacks/archive/afdb603fa4d5aeca6f8f752638e874dbb405386f.zip)
-sha256sums=(01cf5dc45ec523ccd948615689773edb90207b74b4bd0d328c33de9c3d974002)
+source=(https://github.com/ddvk/remarkable-hacks/archive/408694677aba3607aa8ee56bc0368baf91568ce7.zip)
+sha256sums=(ie821c99751f12c65137d5c5dc3387b6663123cf03e1551b5af970ef4290fad5a)
 
 _patches_dir="/opt/share/ddvk-hacks"
 _xochitl_path="/usr/bin/xochitl"
@@ -36,7 +36,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2110442_rm1/patch_29.1.02
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2121527_rm1/patch_30.1.08
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2122573_rm1/patch_31.1.01
-        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2123606_rm1/patch_32.1.02
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2123606_rm1/patch_32.1.03
     elif [[ $arch = rm2 ]]; then
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26171_rm2/patch_19.2.02
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26275_rm2/patch_20.2.03
@@ -52,6 +52,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2121527_rm2/patch_30.2.07
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2122573_rm2/patch_31.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2123606_rm2/patch_32.2.02
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2123606_rm2/patch_33.2.01
     fi
 }
 
@@ -66,7 +67,7 @@ configure() {
         device="reMarkable 1"
         case "$build_date" in
             "20220330140034")
-                patch_version="32.1.02"
+                patch_version="32.1.03"
                 original_hash="e6693c76ad588c7a223cf5be5a280214495a68e0"
                 xochitl_version="2.12.3.606"
                 ;;
@@ -136,6 +137,11 @@ configure() {
     elif [[ $arch = rm2 ]]; then
         device="reMarkable 2"
         case "$build_date" in
+            "20220519120030")
+                patch_version="33.2.01"
+                original_hash="c77016e4608ccab1b1e619a6ef2769a205312025"
+                xochitl_version="2.13.0.758"
+                ;;
             "20220330134519")
                 patch_version="32.2.02"
                 original_hash="b7d8f0ca786117cdf715e3f7b08b1eac3aed907a"

--- a/package/ddvk-hacks/package
+++ b/package/ddvk-hacks/package
@@ -14,7 +14,7 @@ license=MIT
 flags=(nostrip)
 
 source=(https://github.com/ddvk/remarkable-hacks/archive/408694677aba3607aa8ee56bc0368baf91568ce7.zip)
-sha256sums=(ie821c99751f12c65137d5c5dc3387b6663123cf03e1551b5af970ef4290fad5a)
+sha256sums=(e821c99751f12c65137d5c5dc3387b6663123cf03e1551b5af970ef4290fad5a)
 
 _patches_dir="/opt/share/ddvk-hacks"
 _xochitl_path="/usr/bin/xochitl"

--- a/package/ddvk-hacks/package
+++ b/package/ddvk-hacks/package
@@ -52,7 +52,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2121527_rm2/patch_30.2.07
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2122573_rm2/patch_31.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2123606_rm2/patch_32.2.02
-        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2123606_rm2/patch_33.2.01
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2130758_rm2/patch_33.2.01
     fi
 }
 


### PR DESCRIPTION
This bumps ddvk's hacks to rm1: 2.12.3.606 and rm2: 2.13.0.758.

For rm1 version 32.1.02 has been superseeded by 32.1.3.

I am still on 2.12.3.606 so I can't test this PR.