### PR TITLE
workflows: Allow setting the SSH port for the sync action

### DIFF
--- a/.github/actions/sync-repository/action.yml
+++ b/.github/actions/sync-repository/action.yml
@@ -10,6 +10,10 @@ inputs:
     ssh-known-hosts:
         description: Public SSH key of the remote repository
         required: true
+    ssh-port:
+        description: SSH port to use to reach the remote repository
+        required: false
+        default: 22
     remote-path:
         description: Path to the remote directory to place the packages in
         required: true
@@ -25,7 +29,7 @@ runs:
             echo '${{ inputs.ssh-known-hosts }}' > private/known_hosts
             chmod 600 private/*
             rsync --archive --verbose --compress --delete \
-                -e "ssh -i private/id_rsa -o UserKnownHostsFile=private/known_hosts" \
+                -e "ssh -p ${{ inputs.ssh-port }} -i private/id_rsa -o UserKnownHostsFile=private/known_hosts" \
                 '${{ inputs.local-path }}' \
                 '${{ inputs.remote-path }}'
             rm -r private

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -25,6 +25,7 @@ jobs:
                 local-path: build/repo/
                 ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
                 ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+                ssh-port: ${{ secrets.SSH_PORT }}
                 remote-path: ${{ secrets.REMOTE_SSH }}:/srv/toltec/stable
             - name: Trigger website rebuild
               run: gh api repos/toltec-dev/web/dispatches -f event_type='update-bootstrap-from-stable'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,6 +25,7 @@ jobs:
                 local-path: build/repo/
                 ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
                 ssh-known-hosts: ${{ secrets.SSH_KNOWN_HOSTS }}
+                ssh-port: ${{ secrets.SSH_PORT }}
                 remote-path: ${{ secrets.REMOTE_SSH }}:/srv/toltec/testing
             - name: Send notification to Discord
               continue-on-error: true


### PR DESCRIPTION
I recently migrated the Toltec website to a different server in which the SSH server listens on a non-standard port. This PR changes our CI workflow to allow specifying this port when syncing stable/testing updates to the website. The port is set through a secret called `SSH_PORT` which I have already registered.

<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
