### PR TITLE
linux-mainline: Improve backup instructions

### DIFF
--- a/package/linux-mainline/package
+++ b/package/linux-mainline/package
@@ -45,8 +45,8 @@ package() {
 configure() {
     echo "The new kernel files have been copied, but not installed."
     echo "Before installing them, make a backup of the existing kernel:"
-    echo "  mkdir -p /opt/boot-backup"
-    echo "  cp -rvf /boot/* /opt/boot-backup/"
+    echo "  mkdir -p /home/root/boot-backup"
+    echo "  cp -rvf /boot/* /home/root/boot-backup/"
     echo
     echo "Then replace it with the new kernel and reboot:"
     echo "  tar -xvf /opt/usr/share/kernelctl/mainline-${pkgver%-*}.tar.bz2 -C /"
@@ -63,7 +63,7 @@ configure() {
 postremove() {
     echo "To restore to the original kernel, run and then reboot"
     echo "  rm -rf /lib/modules/${pkgver%-*}/"
-    echo "  cp -f /opt/boot-backup/zImage /boot/"
-    echo "  cp -f /opt/boot-backup/zero-sugar.dtb /boot/"
+    echo "  cp -f /home/root/boot-backup/zImage /boot/"
+    echo "  cp -f /home/root/boot-backup/zero-sugar.dtb /boot/"
     echo "  /bin/sync"
 }


### PR DESCRIPTION
The manual install/uninstall instructions for the `linux-mainline` package will be superseded by kernelctl (#569), but in the meantime I believe it would be safer to instruct users to make their backup outside of the Toltec root, since otherwise it will get deleted upon uninstall.

<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
