### PR TITLE
rmfm: Add version 1.3.0

### DIFF
--- a/package/rmfm/package
+++ b/package/rmfm/package
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(rmfm)
+pkgdesc="Bare-bones file manager using Node.js and sas"
+url="https://codeberg.org/sun/rmFM"
+pkgver=1.3.0-1
+timestamp=2022-07-22T19:29:42+02:00
+section=utils
+maintainer="Sunny <roesch.eric@protonmail.com>"
+license=MIT
+installdepends=(node simple)
+
+source=(https://codeberg.org/sun/rmFM/archive/1.3.0.zip)
+sha256sums=(6c82bb47842e17203f5104d764ec6dbde75ada63a75d527ea6d17da59b46d7ae)
+
+package() {
+    install -D -m 755 "$srcdir"/rmfm "$pkgdir"/opt/bin/rmfm
+    install -D -m 644 "$srcdir"/rmfm.draft "$pkgdir"/opt/etc/draft/rmfm.draft
+    install -D -m 644 "$srcdir"/rmfm.png "$pkgdir"/opt/etc/draft/icons/rmfm.png
+}


### PR DESCRIPTION
Since I couldn't find one, I wrote a (relatively) simple file manager called rmFM. It can be used for viewing, moving, copying, renaming and deleting files and directories.

I tested it on my reMarkable 2 (including the built IPK file). Since it uses Node.js and rmkit's simple app script, it should work on the rM 1 as well, but I can't test it since I don't own one.