### PR TITLE
Update KOReader to v2022.07

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.06-1
-timestamp=2022-06-23T19:32:08Z
+pkgver=2022.07-1
+timestamp=2022-07-31T13:31:10Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    2338591c3bc4eebd5a67e065ab98315f6a687f1c52111d39a30ac860fc3eec80
+    3703ed2d6f207def0c7f41a4056ff57707f7b72c3dba2119fb384bf771bc1e3b
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
There are no reMarkable specific changes.

[Release notes](https://github.com/koreader/koreader/releases/tag/v2022.07)