### PR TITLE
Add package: ripgrep

### DIFF
--- a/package/ripgrep/package
+++ b/package/ripgrep/package
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(ripgrep)
+pkgdesc="Modern grep for recursive regex pattern searching"
+url=https://github.com/BurntSushi/ripgrep
+pkgver=13.0.0-1
+timestamp=2021-06-12T10:54Z
+section="utils"
+maintainer="Mattéo Delabre <spam@delab.re>"
+license=MIT
+
+image=rust:v2.3
+source=("https://github.com/BurntSushi/ripgrep/archive/refs/tags/13.0.0.zip")
+sha256sums=(5f9d35c2db0513d9d1cbc5254aa9d48fcd74243259b7b15955e131f36f627745)
+
+build() {
+	cargo build --release
+}
+
+package() {
+	install -D -m 755 "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/rg "$pkgdir"/opt/bin/rg
+}

--- a/package/ripgrep/package
+++ b/package/ripgrep/package
@@ -16,9 +16,9 @@ source=("https://github.com/BurntSushi/ripgrep/archive/refs/tags/13.0.0.zip")
 sha256sums=(5f9d35c2db0513d9d1cbc5254aa9d48fcd74243259b7b15955e131f36f627745)
 
 build() {
-	cargo build --release
+    cargo build --release
 }
 
 package() {
-	install -D -m 755 "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/rg "$pkgdir"/opt/bin/rg
+    install -D -m 755 "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/rg "$pkgdir"/opt/bin/rg
 }

--- a/package/ripgrep/package
+++ b/package/ripgrep/package
@@ -8,7 +8,7 @@ url=https://github.com/BurntSushi/ripgrep
 pkgver=13.0.0-1
 timestamp=2021-06-12T10:54Z
 section="utils"
-maintainer="Mattéo Delabre <spam@delab.re>"
+maintainer="gbyl <gbyl@users.noreply.github.com>"
 license=MIT
 
 image=rust:v2.3


### PR DESCRIPTION
I could not find [ripgrep](https://github.com/BurntSushi/ripgrep) through entware. So, I decided to add it to toltec. Tested on rM1 and rM2.
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
