### PR TITLE
Update yaft to v0.0.7 and add rM1 input patch

### DIFF
--- a/package/yaft/input.patch
+++ b/package/yaft/input.patch
@@ -1,0 +1,23 @@
+--- Device.cpp  2022-08-03 20:07:16.705724406 0000
++++ Device-rM1-inputfix.cpp      2022-08-03 20:07:36.455219878 0000
+@@ -22,17 +22,17 @@
+
+ const InputPaths rm1_paths = {
+   // touch
+-  "/dev/input/event1",
++  "/dev/input/event2",
+   Transform{ { { -float(screen_width) / rm1_touch_width, 0 },
+                { 0, -float(screen_height) / rm1_touch_height } },
+              { screen_width, screen_height } },
+
+   // pen
+-  "/dev/input/event0",
++  "/dev/input/event1",
+   wacom_transform,
+
+   // keys
+-  "/dev/input/event2"
++  "/dev/input/event0"
+ };
+
+ const InputPaths rm2_paths = {

--- a/package/yaft/package
+++ b/package/yaft/package
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
-# Copyright (c) 2020 The Toltec Contributors
+# Copyright (c) 2022 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
 pkgnames=(yaft)
 pkgdesc="Yet another framebuffer terminal"
 url=https://github.com/timower/rM2-stuff/tree/master/apps/yaft
-pkgver=0.0.4-4
-timestamp=2021-04-30T10:42Z
+pkgver=0.0.7-1
+timestamp=2021-05-02T09:23Z
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 section="admin"
 image=base:v2.1
 installdepends=(display)
 
-source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.4.tar.gz)
-sha256sums=(dee471ac19ea43ba741f826c9a0a17d7a01bda6472043d400fbcab6fad1931fe)
+source=(
+    https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.7.zip
+    input.patch
+)
+
+sha256sums=(
+    df3c74e08c6f047be8cea3d50f9b84bf20a9191d9ee1850e9957146134dfef1c
+    5f3c6be207dda291950eece920fca853977fef772c6eddd7fb37c4dbf44c2b3b
+)
 
 build() {
+    patch -u libs/rMlib/Device.cpp -i input.patch
     mkdir build
     mkdir install
     cd build

--- a/package/yaft/package
+++ b/package/yaft/package
@@ -10,7 +10,7 @@ timestamp=2021-05-02T09:23Z
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 section="admin"
-image=base:v2.1
+image=base:v2.3
 installdepends=(display)
 
 source=(


### PR DESCRIPTION
I saw this was requested in the discord server. Tested on rM1 and rM2.
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
