### PR TITLE
rmfm: Update to 1.4.0

### DIFF
--- a/package/rmfm/package
+++ b/package/rmfm/package
@@ -5,15 +5,15 @@
 pkgnames=(rmfm)
 pkgdesc="Bare-bones file manager using Node.js and sas"
 url="https://codeberg.org/sun/rmFM"
-pkgver=1.3.0-1
-timestamp=2022-07-22T19:29:42+02:00
+pkgver=1.4.0-1
+timestamp=2022-08-19T11:20:10+02:00
 section=utils
 maintainer="Sunny <roesch.eric@protonmail.com>"
 license=MIT
 installdepends=(node simple)
 
-source=(https://codeberg.org/sun/rmFM/archive/1.3.0.zip)
-sha256sums=(6c82bb47842e17203f5104d764ec6dbde75ada63a75d527ea6d17da59b46d7ae)
+source=(https://codeberg.org/sun/rmFM/archive/1.4.0.zip)
+sha256sums=(28ce80c67fecc370d11f3fe2069742c2789b388a9426fff49d269d7900ae3dc9)
 
 package() {
     install -D -m 755 "$srcdir"/rmfm "$pkgdir"/opt/bin/rmfm


### PR DESCRIPTION
This PR updates rmFM to the latest release. I've used it over the past few weeks and noticed some missing features, as well as some edge-cases that I wanted to fix.

There is no changelog per se, but one could probably skim through the [relevant commits](https://codeberg.org/sun/rmFM/compare/1.3.0...1.4.0) in a few minutes. In short, the following was added:

- a disclaimer next to the file preview stating that it is read-only
- a "more" button showing properties of the selected file/directory such as owner, permissions and modification dates
- a "new" button to create new, empty files and directories

Other changes/fixes:

- the clipboard isn't cleared anymore when the user taps on "move"/"copy", but then decides to cancel
- when creating a new file/folder or renaming an existing one, slashes are no longer replaced by underscores, so that one can create a recursive structure by entering something like "x/y/z"
- selected files/folders are removed from the clipboard upon deletion