### PR TITLE
Stable merge for week 34 of 2022

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.06-1
-timestamp=2022-06-23T19:32:08Z
+pkgver=2022.07-1
+timestamp=2022-07-31T13:31:10Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    2338591c3bc4eebd5a67e065ab98315f6a687f1c52111d39a30ac860fc3eec80
+    3703ed2d6f207def0c7f41a4056ff57707f7b72c3dba2119fb384bf771bc1e3b
     SKIP
     SKIP
     SKIP

--- a/package/lf/package
+++ b/package/lf/package
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(lf)
+pkgdesc="Terminal file manager"
+url=https://github.com/gokcehan/lf
+pkgver=r27-1
+timestamp=2022-04-02T09:40Z
+section="utils"
+maintainer="gbyl <gbyl@users.noreply.github.com>"
+license=MIT
+
+image=golang:v2.3
+source=("https://github.com/gokcehan/lf/archive/refs/tags/r27.zip")
+sha256sums=(a4f7b3ada4aa1348b7f102374d8580b6992977f7e84053aa04ef6aadb69dc205)
+
+build() {
+    export GOARCH=arm
+    go build
+}
+
+package() {
+    install -D -m 755 "$srcdir"/lf "$pkgdir"/opt/bin/lf
+}

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -2,29 +2,28 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety)
-pkgver=2.3-1
-timestamp=2022-01-06T22:47:15Z
+pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety liboxide libsentry)
+pkgver=2.4-1
+_sentryver=0.4.17
+timestamp=2022-05-22T03:18:32Z
 maintainer="Eeems <eeems@eeems.email>"
 url=https://oxide.eeems.codes
 license=MIT
 flags=(patch_rm2fb)
-
-image=qt:v2.1
-_srcver="v${pkgver%-*}"
-source=("https://github.com/Eeems/oxide/archive/refs/tags/$_srcver.tar.gz")
-sha256sums=(abea9dea4232b36e4fdabf27b0707683a757e1bb0a928daeb191d97fb876cf33)
+image=qt:v2.3
+source=("https://github.com/Eeems-Org/oxide/archive/e6c62a6860b52cd1cbd47e21377f8d1ecf72bb0a.tar.gz")
+sha256sums=(a29cf455d5f66fee4ee67722c6f1d20627930920286398932c3d5c813d58ebee)
 
 build() {
     find . -name "*.pro" -type f -print0 \
         | xargs -r -0 sed -i 's/linux-oe-g++/linux-arm-remarkable-g++/g'
-    make release
+    CMAKE_TOOLCHAIN_FILE="/usr/share/cmake/$CHOST.cmake" make FEATURES=sentry release
 }
 
 erode() {
     pkgdesc="Task manager"
     section="admin"
-    installdepends=(display "tarnish=$pkgver")
+    installdepends=(display "tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/erode
@@ -37,7 +36,7 @@ erode() {
 fret() {
     pkgdesc="Take screenshots"
     section="utils"
-    installdepends=("tarnish=$pkgver")
+    installdepends=("tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/fret
@@ -48,7 +47,7 @@ fret() {
 oxide() {
     pkgdesc="Launcher application"
     section="launchers"
-    installdepends=(display "erode=$pkgver" "fret=$pkgver" "tarnish=$pkgver" "rot=$pkgver" "decay=$pkgver")
+    installdepends=("erode=$pkgver" "fret=$pkgver" "tarnish=$pkgver" "rot=$pkgver" "decay=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/oxide
@@ -69,7 +68,7 @@ oxide() {
 rot() {
     pkgdesc="Manage Oxide settings through the command line"
     section="admin"
-    installdepends=("tarnish=$pkgver")
+    installdepends=("tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/rot
@@ -79,7 +78,7 @@ rot() {
 tarnish() {
     pkgdesc="Service managing power states, connectivity and buttons"
     section="devel"
-    installdepends=(display xochitl)
+    installdepends=(display xochitl "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 644 -t "$pkgdir"/etc/dbus-1/system.d "$srcdir"/release/etc/dbus-1/system.d/codes.eeems.oxide.conf
@@ -107,7 +106,7 @@ tarnish() {
 decay() {
     pkgdesc="Lockscreen application"
     section="utils"
-    installdepends=(display "tarnish=$pkgver")
+    installdepends=(display "tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/decay
@@ -117,7 +116,7 @@ decay() {
 corrupt() {
     pkgdesc="Task Switcher for Oxide"
     section="utils"
-    installdepends=(display "tarnish=$pkgver")
+    installdepends=(display "tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/corrupt
@@ -128,12 +127,33 @@ corrupt() {
 anxiety() {
     pkgdesc="Screenshot viewer for Oxide"
     section="utils"
-    installdepends=(display "tarnish=$pkgver")
+    installdepends=(display "tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/anxiety
         install -D -m 644 -t "$pkgdir"/opt/usr/share/applications "$srcdir"/release/opt/usr/share/applications/codes.eeems.anxiety.oxide
         install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons "$srcdir"/release/opt/etc/draft/icons/image.svg
         install -D -m 644 -t "$pkgdir"/opt/etc/draft/icons "$srcdir"/release/opt/etc/draft/icons/anxiety-splash.png
+    }
+}
+
+liboxide() {
+    pkgdesc="Shared library for oxide applications"
+    section=devel
+
+    package() {
+        install -D -m 755 -t "$pkgdir"/opt/usr/lib "$srcdir"/release/opt/usr/lib/libliboxide.so*
+    }
+}
+
+libsentry() {
+    pkgdesc="Sentry SDK for C, C++ and native applications."
+    section=devel
+    url=https://github.com/getsentry/sentry-native
+    pkgver="$_sentryver"
+    timestamp="2021-12-20T14:25:11Z"
+
+    package() {
+        install -D -m 755 -t "$pkgdir"/opt/lib "$srcdir"/release/opt/lib/libsentry.so
     }
 }

--- a/package/ripgrep/package
+++ b/package/ripgrep/package
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(ripgrep)
+pkgdesc="Modern grep for recursive regex pattern searching"
+url=https://github.com/BurntSushi/ripgrep
+pkgver=13.0.0-1
+timestamp=2021-06-12T10:54Z
+section="utils"
+maintainer="gbyl <gbyl@users.noreply.github.com>"
+license=MIT
+
+image=rust:v2.3
+source=("https://github.com/BurntSushi/ripgrep/archive/refs/tags/13.0.0.zip")
+sha256sums=(5f9d35c2db0513d9d1cbc5254aa9d48fcd74243259b7b15955e131f36f627745)
+
+build() {
+    cargo build --release
+}
+
+package() {
+    install -D -m 755 "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/rg "$pkgdir"/opt/bin/rg
+}

--- a/package/rmfm/package
+++ b/package/rmfm/package
@@ -5,15 +5,15 @@
 pkgnames=(rmfm)
 pkgdesc="Bare-bones file manager using Node.js and sas"
 url="https://codeberg.org/sun/rmFM"
-pkgver=1.3.0-1
-timestamp=2022-07-22T19:29:42+02:00
+pkgver=1.4.0-1
+timestamp=2022-08-19T11:20:10+02:00
 section=utils
 maintainer="Sunny <roesch.eric@protonmail.com>"
 license=MIT
 installdepends=(node simple)
 
-source=(https://codeberg.org/sun/rmFM/archive/1.3.0.zip)
-sha256sums=(6c82bb47842e17203f5104d764ec6dbde75ada63a75d527ea6d17da59b46d7ae)
+source=(https://codeberg.org/sun/rmFM/archive/1.4.0.zip)
+sha256sums=(28ce80c67fecc370d11f3fe2069742c2789b388a9426fff49d269d7900ae3dc9)
 
 package() {
     install -D -m 755 "$srcdir"/rmfm "$pkgdir"/opt/bin/rmfm

--- a/package/rmfm/package
+++ b/package/rmfm/package
@@ -5,15 +5,28 @@
 pkgnames=(rmfm)
 pkgdesc="Bare-bones file manager using Node.js and sas"
 url="https://codeberg.org/sun/rmFM"
-pkgver=1.4.0-1
+pkgver=1.4.0-2
 timestamp=2022-08-19T11:20:10+02:00
 section=utils
 maintainer="Sunny <roesch.eric@protonmail.com>"
 license=MIT
 installdepends=(node simple)
 
-source=(https://codeberg.org/sun/rmFM/archive/1.4.0.zip)
-sha256sums=(28ce80c67fecc370d11f3fe2069742c2789b388a9426fff49d269d7900ae3dc9)
+source=(
+    https://codeberg.org/sun/rmFM/archive/1.4.0.zip
+    path_fix.patch
+)
+sha256sums=(
+    28ce80c67fecc370d11f3fe2069742c2789b388a9426fff49d269d7900ae3dc9
+    SKIP
+)
+
+prepare() {
+    # Assume node to be in /opt/bin and add that directory
+    # to the path of the app to allow finding simple
+    # This is a temporary fix for not working in remux
+    patch -d "$srcdir" < "$srcdir"/path_fix.patch
+}
 
 package() {
     install -D -m 755 "$srcdir"/rmfm "$pkgdir"/opt/bin/rmfm

--- a/package/rmfm/package
+++ b/package/rmfm/package
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(rmfm)
+pkgdesc="Bare-bones file manager using Node.js and sas"
+url="https://codeberg.org/sun/rmFM"
+pkgver=1.3.0-1
+timestamp=2022-07-22T19:29:42+02:00
+section=utils
+maintainer="Sunny <roesch.eric@protonmail.com>"
+license=MIT
+installdepends=(node simple)
+
+source=(https://codeberg.org/sun/rmFM/archive/1.3.0.zip)
+sha256sums=(6c82bb47842e17203f5104d764ec6dbde75ada63a75d527ea6d17da59b46d7ae)
+
+package() {
+    install -D -m 755 "$srcdir"/rmfm "$pkgdir"/opt/bin/rmfm
+    install -D -m 644 "$srcdir"/rmfm.draft "$pkgdir"/opt/etc/draft/rmfm.draft
+    install -D -m 644 "$srcdir"/rmfm.png "$pkgdir"/opt/etc/draft/icons/rmfm.png
+}

--- a/package/rmfm/path_fix.patch
+++ b/package/rmfm/path_fix.patch
@@ -1,0 +1,9 @@
+diff --git a/rmfm b/rmfm
+index 4571db9..172eedf 100755
+--- a/rmfm
++++ b/rmfm
+@@ -1,2 +1,3 @@
+-#!/usr/bin/env node
++#!/opt/bin/node
++process.env.PATH += ":/opt/bin"
+ 

--- a/package/yaft/input.patch
+++ b/package/yaft/input.patch
@@ -1,0 +1,23 @@
+--- Device.cpp  2022-08-03 20:07:16.705724406 0000
++++ Device-rM1-inputfix.cpp      2022-08-03 20:07:36.455219878 0000
+@@ -22,17 +22,17 @@
+
+ const InputPaths rm1_paths = {
+   // touch
+-  "/dev/input/event1",
++  "/dev/input/event2",
+   Transform{ { { -float(screen_width) / rm1_touch_width, 0 },
+                { 0, -float(screen_height) / rm1_touch_height } },
+              { screen_width, screen_height } },
+
+   // pen
+-  "/dev/input/event0",
++  "/dev/input/event1",
+   wacom_transform,
+
+   // keys
+-  "/dev/input/event2"
++  "/dev/input/event0"
+ };
+
+ const InputPaths rm2_paths = {

--- a/package/yaft/package
+++ b/package/yaft/package
@@ -1,22 +1,30 @@
 #!/usr/bin/env bash
-# Copyright (c) 2020 The Toltec Contributors
+# Copyright (c) 2022 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
 pkgnames=(yaft)
 pkgdesc="Yet another framebuffer terminal"
 url=https://github.com/timower/rM2-stuff/tree/master/apps/yaft
-pkgver=0.0.4-4
-timestamp=2021-04-30T10:42Z
+pkgver=0.0.7-1
+timestamp=2021-05-02T09:23Z
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 section="admin"
-image=base:v2.1
+image=base:v2.3
 installdepends=(display)
 
-source=(https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.4.tar.gz)
-sha256sums=(dee471ac19ea43ba741f826c9a0a17d7a01bda6472043d400fbcab6fad1931fe)
+source=(
+    https://github.com/timower/rM2-stuff/archive/refs/tags/v0.0.7.zip
+    input.patch
+)
+
+sha256sums=(
+    df3c74e08c6f047be8cea3d50f9b84bf20a9191d9ee1850e9957146134dfef1c
+    5f3c6be207dda291950eece920fca853977fef772c6eddd7fb37c4dbf44c2b3b
+)
 
 build() {
+    patch -u libs/rMlib/Device.cpp -i input.patch
     mkdir build
     mkdir install
     cd build


### PR DESCRIPTION
### New Packages

- `rmfm` - 1.4.0-1 (#608 #617)
- `ripgrep` - 13.0.0-1 (#611)
- `lf` - r27-1 (#612)
- `liboxide` - 2.4-1 (#603)
  - Shared library for Oxide to provide an easier API for applications to use
- `libsentry` - 0.4.17 (#603)
  - An error and crash reporting client for native applications

### Updated Packages

- `yaft` - 0.0.7-1 (#613)
  - Fix input on rM1
  - Update to 0.0.7
- `koreader` -  2022.07-1 (#609)
- `erode` `fret` `oxide` `rot` `tarnish` `decay` `corrupt` `anxiety` - 2.4-1 (#603)
   - Opt-in crash reporting
   - Fixed issue where launcher will crash if a notification is removed with the API instead of through the UI
   - Fixed issue where the task switcher background will disappear if you close an application
   - Fixed issue where applications will be imported even though the file isn't executable, and thus would fail to launch