### PR TITLE
Make a backup at install time only if it is not there yet

### DIFF
--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,7 +5,7 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.1-1
+pkgver=0.2-1
 timestamp=2022-03-14T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -27,5 +27,15 @@ package() {
 }
 
 configure() {
-    kernelctl backup vanilla
+    if [[ ! -e "/opt/usr/share/kernelctl/vanilla-$(< /etc/version)" ]]; then
+        read -r -d '' msg <<- EOM
+		It looks like there is no backup of the upstream kernel for the
+		installed version of codex.
+
+		Please standby while one is produced (assuming that the
+		currently running kernel is upstream).
+	EOM
+        echo -e "$msg"
+        kernelctl backup vanilla
+    fi
 }

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,7 +5,7 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.2-1
+pkgver=0.1-1
 timestamp=2022-03-14T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -27,7 +27,7 @@ package() {
 }
 
 configure() {
-    if [[ ! -e "/opt/usr/share/kernelctl/vanilla-$(< /etc/version)" ]]; then
+    if [[ "$(kernelctl list | tail -n +2 | awk '{print $2}' | grep "vanilla-$(< /etc/version)")" == "" ]]; then
         read -r -d '' msg <<- EOM
 		It looks like there is no backup of the upstream kernel for the
 		installed version of codex.

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,7 +5,7 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.1-1
+pkgver=0.1-2
 timestamp=2022-03-14T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"


### PR DESCRIPTION
Currently if one installs kernelctl twice with the same version of codex `configure` will fail. 

This PR fixes this behaviour
