### PR TITLE
Stable merge for week 39 of 2022

### DIFF
--- a/package/ddvk-hacks/package
+++ b/package/ddvk-hacks/package
@@ -6,15 +6,15 @@ archs=(rm1 rm2)
 pkgnames=(ddvk-hacks)
 pkgdesc="Enhance Xochitl with additional features"
 url=https://github.com/ddvk/remarkable-hacks
-pkgver=35.01-1
-timestamp=2022-07-09T00:05:57+0200
+pkgver=36.01-1
+timestamp=2022-09-07T00:05:57+0200
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT
 flags=(nostrip)
 
-source=(https://github.com/ddvk/remarkable-hacks/archive/5e5aabf1dfe02b802a3ce8ce1046bd05fe29ffd2.zip)
-sha256sums=(cb47f0291f8712a8df563bb6a5793fd2b699074fe055d56c40efe987eb5f7571)
+source=(https://github.com/ddvk/remarkable-hacks/archive/c3ec0b6aa480baaaaf63460c99796f952265bf19.zip)
+sha256sums=(7ce383e5be058fa7bd90ec069211a74c737c36ef61a1c767bff9a352963d94a0)
 
 _patches_dir="/opt/share/ddvk-hacks"
 _xochitl_path="/usr/bin/xochitl"
@@ -39,6 +39,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2123606_rm1/patch_32.1.03
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2140861_rm1/patch_34.1.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2141866_rm1/patch_35.1.01
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm1/patch_36.1.01
     elif [[ $arch = rm2 ]]; then
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26171_rm2/patch_19.2.02
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26275_rm2/patch_20.2.03
@@ -57,6 +58,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2130758_rm2/patch_33.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2140861_rm2/patch_34.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2141866_rm2/patch_35.2.01
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm2/patch_36.2.01
     fi
 }
 
@@ -70,6 +72,11 @@ configure() {
     if [[ $arch = rm1 ]]; then
         device="reMarkable 1"
         case "$build_date" in
+            "20220825122914")
+                patch_version="36.1.01"
+                original_hash="a88faec812ae20960bfbab38be0aa49aafec902a"
+                xochitl_version="2.14.3.977"
+                ;;
             "20220617142418")
                 patch_version="35.1.01"
                 original_hash="d172016ac8a97ca5df3c551648e0b3314f17f72a"
@@ -151,6 +158,11 @@ configure() {
     elif [[ $arch = rm2 ]]; then
         device="reMarkable 2"
         case "$build_date" in
+            "20220825124750")
+                patch_version="36.2.01"
+                original_hash="470e88f8d5fb62f64939fe4ea3b89c515113f7e5"
+                xochitl_version="2.14.3.977"
+                ;;
             "20220617143306")
                 patch_version="35.2.01"
                 original_hash="1d7f6f049e5a6b192caaf07cbf67ba7c2555e5f0"

--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-06-22T13:16:48Z
+timestamp=2022-08-22T09:40:15Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.20-1
+pkgver=1:0.0.21-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    02acb6c77e4b9b973151ba6eb4e6093a0f7733d9aeca513ecbc36f6008acda89
+    815cf46e282257077b791a795cd8e2395fb18af5f3ba58ed911d526168002ea0
     SKIP
     SKIP
     SKIP

--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-08-22T09:40:15Z
+timestamp=2022-09-10T09:40:15Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.21-1
+pkgver=1:0.0.23-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    815cf46e282257077b791a795cd8e2395fb18af5f3ba58ed911d526168002ea0
+    f29fc4c1683a4833059291ccc1a8b472be1e4cdbdd4f1f3f39317b9e994e840c
     SKIP
     SKIP
     SKIP

--- a/package/kernelctl/kernelctl
+++ b/package/kernelctl/kernelctl
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+# kernel staging dir
+kernelctl_dir=/opt/usr/share/kernelctl
+
+# Formatting
+bf="\033[1m"    # bold
+sf="\033[0m"    # standard
+gr="\033[1;32m" # green
+bl="\033[1;34m" # blue
+
+# change our working directory to / to ease filesystem operations
+cd /
+
+help() {
+    read -r -d '' msg <<- EOM
+		Usage: $(basename "$0") COMMAND
+		Manage your booting kernel.
+
+		${gr}Available commands:${sf}
+		${bf}    backup <kernel_name>    ${sf}Backup current kernel and name it <kernel_name>. This is guaranteed to work only with vanilla (i.e. upstream) kernels.
+		${bf}    help                    ${sf}Show this help message.
+		${bf}    list                    ${sf}List available kernels.
+		${bf}    show                    ${sf}Show the current configured kernel.
+		${bf}    delete <kernel>         ${sf}Delete kernel from the staging dir. WARNING this is irreversible.
+		${bf}    set <kernel>            ${sf}Change booting kernel.
+
+		${bf}        <kernel>            ${sf}Kernel name or number (from 'list' command) or "default" to revert to the upstram kernel.
+	EOM
+    echo -e "$msg"
+}
+
+# backup current kernel
+backup() {
+    if [[ "$1" = "vanilla" ]]; then
+        kernel_name="vanilla-$(< /etc/version)"
+    else
+        kernel_name=$1
+    fi
+
+    kernel_file="$kernelctl_dir"/"$kernel_name".tar.bz2
+
+    if [[ -e "$kernel_file" ]]; then
+        read -r -d "" msg <<- EOM
+			It looks like there is already copy of $kernel_name in the staging area.
+			If you really want to back it up again please run
+
+			$(basename "$0") delete $kernel_name
+			$(basename "$0") backup $kernel_name
+		EOM
+        echo -e "$msg"
+        exit 1
+    else
+        tar cpjf "$kernel_file" lib/modules/* boot/zImage* boot/*.dtb
+        rm -f "$kernelctl_dir"/current.tar.bz2
+        ln "$kernel_file" "$kernelctl_dir"/current.tar.bz2
+    fi
+}
+
+# get available kernels
+get_kernel_names() {
+    mapfile -t kernel_names < <(find "$kernelctl_dir" -path "*.tar.bz2" ! -name current.tar.bz2 -print0 | xargs -0 -I"{}" basename {} .tar.bz2)
+}
+
+# get current kernel
+get_current_kernel_name() {
+    current_kernel_name=$(find "$kernelctl_dir" -samefile "$kernelctl_dir"/current.tar.bz2 ! -name current.tar.bz2 -print0 | xargs -0 -I"{}" basename {} .tar.bz2)
+}
+
+# translate input into a kernel name
+to_kernel_name() {
+    local ker
+    get_kernel_names
+    if [[ "$1" =~ ^[0-9]+$ ]] && ((0 < $1 && $1 <= ${#kernel_names[@]})); then
+        echo "${kernel_names[$(($1 - 1))]}"
+        return
+    elif [[ "$1" = "default" ]]; then
+        ker="vanilla-$(< /etc/version)"
+    else
+        ker="$1"
+    fi
+    if [[ $(echo "${kernel_names[@]}" | grep -ow "$ker" | wc -w) -gt 0 ]]; then
+        echo "$ker"
+    else
+        echo "Can't find $ker in the staging area."
+        exit 1
+    fi
+}
+
+# list available kernels
+list() {
+    get_kernel_names
+    get_current_kernel_name
+    echo -e "${gr}Available kernels:${sf}"
+    for i in "${!kernel_names[@]}"; do
+        if [[ "$current_kernel_name" = "${kernel_names[$i]}" ]]; then cur=" ${bl}*${sf}"; else cur=""; fi
+        echo -e "  ${bf}[$((i + 1))]${sf}\t${kernel_names[$i]}$cur"
+    done
+}
+
+# show the current configured kernel
+show() {
+    get_current_kernel_name
+    echo -e "${gr}Current kernel:${sf}"
+    echo -e "  ${bf}${current_kernel_name}${sf}"
+}
+
+# actually switch kernels
+switch() {
+    tar tjf "$1" | sort -r | xargs -r -I {} bash -c 'if [[ -d "{}" ]]; then rmdir "{}"; else rm "{}"; fi'
+    tar xpjf "$2"
+}
+
+# change the kernel that will boot next time
+set() {
+    new_kernel_name=$(to_kernel_name "$1")
+    new_kernel_file="${kernelctl_dir}/${new_kernel_name}.tar.bz2"
+    current_kernel_file="${kernelctl_dir}/current.tar.bz2"
+    if [[ ! -e "$current_kernel_file" ]]; then
+        read -r -d '' msg <<- EOM
+			${bf}There is no link to the current running kernel in the staging
+			area, you might have accidentally deleted it!${sf}
+			Try making a backup first.
+		EOM
+        echo -e "$msg"
+        exit 1
+    fi
+    if switch "$current_kernel_file" "$new_kernel_file"; then
+        rm -f "$current_kernel_file"
+        ln "$new_kernel_file" "$current_kernel_file"
+        /bin/sync
+        echo "Reboot system to use your newly installed kernel."
+    else
+        read -r -d '' msg <<- EOM
+			${bf}WARNING: failed to extract the new kernel!${sf}
+			This may be due to a lack of space in the root partition.
+			Attempting to revert to the current running kernel.
+		EOM
+        echo -e "$msg"
+        if switch "$new_kernel_file" "$current_kernel_file"; then
+            /bin/sync
+            read -r -d '' msg <<- EOM
+				Successfully reverted to the current running kernel.
+				Please check that everything is in order before rebooting.
+			EOM
+            echo -e "$msg"
+        else
+            read -r -d '' msg <<- EOM
+				Unable to revert to a working configuration.
+				If you do not know how to proceed, please do not reboot your device,
+                do not let the battery die, and seek assistance
+				in the reMarkable's community Discord server: https://discord.gg/ATqQGfu
+			EOM
+            echo -e "$msg"
+            exit 1
+        fi
+    fi
+}
+
+# delete kernel from staging dir
+delete() {
+    kernel_name=$(to_kernel_name "$1")
+    echo "Deleting $kernel_name from the staging area is irreversible."
+    echo "If the kernel was installed as a toltec package this may confuse the package manager"
+    echo -n "Do you want to proceed? [N/y]: "
+    read -r ans
+    if [[ "$ans" = "y" || "$ans" = "Y" ]]; then
+        rm "${kernelctl_dir}/${kernel_name}.tar.bz2"
+    fi
+}
+
+if [[ $0 = "${BASH_SOURCE[0]}" ]]; then
+    if [[ $# -eq 0 ]]; then
+        help
+        exit 1
+    fi
+
+    action="$1"
+    shift
+
+    case $action in
+        help | -h | --help)
+            help
+            ;;
+        list)
+            list
+            ;;
+        show)
+            show
+            ;;
+        backup)
+            if [[ $# -ne 1 ]]; then
+                help
+                exit 1
+            fi
+            backup "$1"
+            ;;
+        set)
+            if [[ $# -ne 1 ]]; then
+                help
+                exit 1
+            fi
+            set "$1"
+            ;;
+        delete)
+            if [[ $# -ne 1 ]]; then
+                help
+                exit 1
+            fi
+            delete "$1"
+            ;;
+        *)
+            echo -e "Error: Invalid command '$action'\n"
+            help
+            exit 1
+            ;;
+    esac
+fi

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,7 +5,7 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.1-1
+pkgver=0.1-2
 timestamp=2022-03-14T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"
@@ -27,5 +27,15 @@ package() {
 }
 
 configure() {
-    kernelctl backup vanilla
+    if [[ "$(kernelctl list | tail -n +2 | awk '{print $2}' | grep "vanilla-$(< /etc/version)")" == "" ]]; then
+        read -r -d '' msg <<- EOM
+		It looks like there is no backup of the upstream kernel for the
+		installed version of codex.
+
+		Please standby while one is produced (assuming that the
+		currently running kernel is upstream).
+	EOM
+        echo -e "$msg"
+        kernelctl backup vanilla
+    fi
 }

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(kernelctl)
+pkgdesc="Manage aftermarket kernels"
+url=https://toltec-dev.org/
+pkgver=0.1-1
+timestamp=2022-03-14T00:00Z
+section="utils"
+maintainer="Salvatore Stella <etn45p4m@gmail.com>"
+license=MIT
+
+source=(
+    kernelctl
+    force_reinstall_on_toltecctl_reenable
+)
+sha256sums=(
+    SKIP
+    SKIP
+)
+
+package() {
+    install -D -m 744 -t "$pkgdir"/opt/bin "$srcdir"/kernelctl
+    install -d "$pkgdir"/opt/usr/share/kernelctl
+    install -D -m 666 -t "$pkgdir"/usr/share/kernelctl/ "$srcdir"/force_reinstall_on_toltecctl_reenable
+}
+
+configure() {
+    kernelctl backup vanilla
+}

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.07-1
+pkgver=2022.08-1
 timestamp=2022-07-31T13:31:10Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    3703ed2d6f207def0c7f41a4056ff57707f7b72c3dba2119fb384bf771bc1e3b
+    57abc32b2af8c5d7765cf24fba8127a3dba9272d44d8abdc38311d8888d62ef6
     SKIP
     SKIP
     SKIP

--- a/package/linux-mainline/package
+++ b/package/linux-mainline/package
@@ -6,7 +6,7 @@ archs=(rm2)
 pkgnames=(linux-mainline)
 pkgdesc="reMarkable 2 kernel based on the mainline kernel"
 url=https://www.kernel.org
-pkgver=5.18.0-1
+pkgver=5.19.0-1
 timestamp=2022-05-22T21:50:09Z
 section=kernel
 maintainer="Alistair Francis <alistair@alistair23.me>"
@@ -15,8 +15,8 @@ license=GPL-2.0-only
 flags=(nostrip)
 
 image=base:v2.3
-source=("https://github.com/alistair23/linux/archive/f9fe680995e01398f0813077711fe1b744251c5b.tar.gz")
-sha256sums=(d38c883a31f5f87483377e78b4b3a2eb1ce73ada38fc25949e692dd0b2dd7895)
+source=("https://github.com/alistair23/linux/archive/6df274810d20448125834115e2181de288fdc8a4.tar.gz")
+sha256sums=(a7538198dbef21868d2c52e8b379576c8791726809bd5886176ab88d1f9df49f)
 
 build() {
     ARCH=arm make imx_v6_v7_defconfig
@@ -38,19 +38,13 @@ package() {
     # Create the kernel archive
     local archive="mainline-${pkgver%-*}.tar.bz2"
     install -d "$pkgdir"/opt/usr/share/kernelctl
-    tar --owner root:0 --group root:0 --mtime=$timestamp \
-        -cjf "$pkgdir"/opt/usr/share/kernelctl/"$archive" -C "$staging" .
+    (cd "$staging" && tar --owner root:0 --group root:0 --mtime=$timestamp \
+        -cjf "$pkgdir"/opt/usr/share/kernelctl/"$archive" boot/* lib/modules/*)
 }
 
 configure() {
     echo "The new kernel files have been copied, but not installed."
-    echo "Before installing them, make a backup of the existing kernel:"
-    echo "  mkdir -p /home/root/boot-backup"
-    echo "  cp -rvf /boot/* /home/root/boot-backup/"
-    echo
-    echo "Then replace it with the new kernel and reboot:"
-    echo "  tar -xvf /opt/usr/share/kernelctl/mainline-${pkgver%-*}.tar.bz2 -C /"
-    echo "  /bin/sync"
+    echo "Please use kernelctl to select the kernel to boot."
     echo
     echo "Known issues with the mainline kernel:"
     echo " - No support for low power mode (suspend uses more power then it should)"
@@ -58,12 +52,4 @@ configure() {
     echo " - GUI shutdown in Oxide doesn't work"
     echo " - Wacom stylus doesn't work in Xochitl (works everywhere else though)"
     echo " - No OTG control support"
-}
-
-postremove() {
-    echo "To restore to the original kernel, run and then reboot"
-    echo "  rm -rf /lib/modules/${pkgver%-*}/"
-    echo "  cp -f /home/root/boot-backup/zImage /boot/"
-    echo "  cp -f /home/root/boot-backup/zero-sugar.dtb /boot/"
-    echo "  /bin/sync"
 }

--- a/package/linux-stracciatella/package
+++ b/package/linux-stracciatella/package
@@ -6,8 +6,8 @@ archs=(rm1 rm2)
 pkgnames=(linux-stracciatella)
 pkgdesc="RemarkableAS's vanilla kernel with a few extra flakes"
 url=https://github.com/Etn40ff/linux-remarkable
-pkgver=5.4.70-1
-timestamp=2022-06-26T23:50:04+02:00
+pkgver=5.4.70-2
+timestamp=2022-09-26T21:23:39Z
 section="kernel"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"
 makedepends=(build:flex build:bison build:libssl-dev build:bc build:lzop build:libgmp-dev build:libmpc-dev build:kmod)
@@ -15,8 +15,8 @@ license=GPL-2.0-only
 flags=(nostrip)
 installdepends=(kernelctl)
 image=base:v2.3
-source=(https://github.com/Etn40ff/linux-remarkable/archive/c6aa07709109f9b5879628396052f60a97ec9197.tar.gz)
-sha256sums=(529fe57ddc25bbaed5f0b3a9f7f79b51ab9ea3388d2acf8a933a8a4c77bd93c0)
+source=(https://github.com/Etn40ff/linux-remarkable/archive/41121ea10ed2235c441cfe717461988859d7f5b6.tar.gz)
+sha256sums=(ade87a10bfa7069222cbf8eb1d00ca460d38aab9685223d2fa3ee4f363a75cfa)
 
 build() {
     if [[ $arch = rm1 ]]; then

--- a/package/linux-stracciatella/package
+++ b/package/linux-stracciatella/package
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+archs=(rm1 rm2)
+pkgnames=(linux-stracciatella)
+pkgdesc="RemarkableAS's vanilla kernel with a few extra flakes"
+url=https://github.com/Etn40ff/linux-remarkable
+pkgver=5.4.70-1
+timestamp=2022-06-26T23:50:04+02:00
+section="kernel"
+maintainer="Salvatore Stella <etn45p4m@gmail.com>"
+makedepends=(build:flex build:bison build:libssl-dev build:bc build:lzop build:libgmp-dev build:libmpc-dev build:kmod)
+license=GPL-2.0-only
+flags=(nostrip)
+installdepends=(kernelctl)
+image=base:v2.3
+source=(https://github.com/Etn40ff/linux-remarkable/archive/c6aa07709109f9b5879628396052f60a97ec9197.tar.gz)
+sha256sums=(529fe57ddc25bbaed5f0b3a9f7f79b51ab9ea3388d2acf8a933a8a4c77bd93c0)
+
+build() {
+    if [[ $arch = rm1 ]]; then
+        ARCH=arm make zero-gravitas_defconfig
+    elif [[ $arch = rm2 ]]; then
+        ARCH=arm make zero-sugar_defconfig
+    fi
+    ARCH=arm make -j8
+}
+
+package() {
+    # Prepare files for the kernel archive
+    local staging="$srcdir"/staging
+    mkdir -p "$staging/boot"
+
+    cp --no-dereference {"$srcdir"/arch/arm,"$staging"}/boot/zImage
+    if [[ $arch = rm1 ]]; then
+        cp --no-dereference "$srcdir"/arch/arm/boot/dts/zero-gravitas.dtb "$staging"/boot/zero-gravitas.dtb
+    elif [[ $arch = rm2 ]]; then
+        cp --no-dereference "$srcdir"/arch/arm/boot/dts/zero-sugar.dtb "$staging"/boot/zero-sugar.dtb
+    fi
+
+    ARCH=arm make -C "$srcdir" modules_install INSTALL_MOD_PATH="$staging"
+    rm "$staging"/lib/modules/*/{source,build}
+
+    # Create the kernel archive
+    local archive="stracciatella-${pkgver%-*}.tar.bz2"
+    install -d "$pkgdir"/opt/usr/share/kernelctl
+    (cd "$staging" && tar --owner root:0 --group root:0 --mtime=$timestamp \
+        -cjf "$pkgdir"/opt/usr/share/kernelctl/"$archive" boot/* lib/modules/*)
+}
+
+configure() {
+    if [[ $(< /etc/version) -le 20210709090000 ]]; then
+        echo "WARNING: Your system is too old; this kernel will most likely not work unless you add the appropriate firmware blobs to /lib/firmware."
+        echo "Please consider updating your system instead."
+    fi
+    echo "The new kernel files have been copied, but not installed."
+    echo "Please use kernelctl to select the kernel to boot."
+}

--- a/package/template-noso-grid/package
+++ b/package/template-noso-grid/package
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(template-noso-grid)
+pkgdesc="Nosometric grid template"
+url=https://github.com/RobotCaleb/noso_template
+pkgver=1.0.0
+timestamp=2022-03-20T18:34Z
+section="templates"
+maintainer="Caleb Anderson <robotrising@gmail.com>"
+license=MIT
+installdepends=(templatectl)
+
+source=("https://github.com/RobotCaleb/noso_template/archive/refs/tags/v${pkgver%-*}.zip")
+sha256sums=(cd7cfcb0c2e9b9734a5e79c00182a4d27858e2c6e2501da54f4d58569171a734)
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-high/noso-cube-high.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-high/noso-cube-high.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-low/noso-cube-low.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-low/noso-cube-low.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-mid/noso-cube-mid.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/cube-mid/noso-cube-mid.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-high/noso-tall-high.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-high/noso-tall-high.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-low/noso-tall-low.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-low/noso-tall-low.svg
+
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-mid/noso-tall-mid.png
+    install -D -m 755 -t "$pkgdir"/opt/share/remarkable/templates \
+        "$srcdir"/templates/tall-mid/noso-tall-mid.svg
+}
+
+configure() {
+    templatectl add -n "Noso Cube Low Density" -f "noso-cube-low.png" \
+        -c "Custom" -c "Grids"
+    templatectl add -n "Noso Cube Mid Density" -f "noso-cube-mid.png" \
+        -c "Custom" -c "Grids"
+    templatectl add -n "Noso Cube High Density" -f "noso-cube-high.png" \
+        -c "Custom" -c "Grids"
+    templatectl add -n "Noso Tall Low Density" -f "noso-tall-low.png" \
+        -c "Custom" -c "Grids"
+    templatectl add -n "Noso Tall Mid Density" -f "noso-tall-mid.png" \
+        -c "Custom" -c "Grids"
+    templatectl add -n "Noso Tall High Density" -f "noso-tall-high.png" \
+        -c "Custom" -c "Grids"
+}
+
+preremove() {
+    templatectl remove --name "Noso Cube Low Density"
+    templatectl remove --name "Noso Cube Mid Density"
+    templatectl remove --name "Noso Cube High Density"
+    templatectl remove --name "Noso Tall Low Density"
+    templatectl remove --name "Noso Tall Mid Density"
+    templatectl remove --name "Noso Tall High Density"
+}


### PR DESCRIPTION
This update brings official support for OS 2.14.3.977 to toltec.

2.14.3.958 and 2.14.3.1005 will have partial support, but will not be listed as supported on the website due to lack of support in `ddvk-hacks`.

### New Packages

- `template-noso-grid` -  (#573)
  - Nosometric grid template
- `kernelctl` - 0.1-2 (#569)
  - Manage aftermarket kernels
- `linux-stracciatella` - 5.4.70-2 (#582 #630)
  - RemarkableAS's vanilla kernel with a few extra flakes

### Updated Packages

- `ddvk-hacks` - 36.01-1 (#627)
  - Add support for OS 2.14.3.977
- `display` `rm2fb-client` - 1:0.0.23-1 (#621 #628)
  - Add support for 2.14.3.1005
  - Add support for 2.14.3.977
  - Add support for 2.14.3.958
- `koreader` - 2022.08-1 (#622)
- `linux-mainline` - 5.19.0-1 (#610)
  - Use kernelctl for install/uninstall
  - Bump from the 5.18 to the 5.19 kernel