### PR TITLE
Stable merge for week 45 of 2022

### DIFF
--- a/package/ddvk-hacks/package
+++ b/package/ddvk-hacks/package
@@ -6,15 +6,15 @@ archs=(rm1 rm2)
 pkgnames=(ddvk-hacks)
 pkgdesc="Enhance Xochitl with additional features"
 url=https://github.com/ddvk/remarkable-hacks
-pkgver=37.01-1
-timestamp=2022-09-28T20:38:22Z
+pkgver=38.03-1
+timestamp=2022-10-18T16:35:20Z
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT
 flags=(nostrip)
 
-source=(https://github.com/ddvk/remarkable-hacks/archive/9ff935ef09efe4bdb9f9371b84bef21ef1b766e2.zip)
-sha256sums=(55818b14839301aa3f8da5ba70ef9de3f92bcab8ea9f72b9c6ab20d27e6b5655)
+source=(https://github.com/ddvk/remarkable-hacks/archive/49a6117b2a9ae3d5116069670702e7aa28ed1584.zip)
+sha256sums=(099d65801eda0e38a7f65a40659d32d1b37239deb2a3c4a896e37a7ed0b4f0a4)
 
 _patches_dir="/opt/share/ddvk-hacks"
 _xochitl_path="/usr/bin/xochitl"
@@ -41,6 +41,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2141866_rm1/patch_35.1.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm1/patch_36.1.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21431047_rm1/patch_37.1.01
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21501067_rm1/patch_38.1.03
     elif [[ $arch = rm2 ]]; then
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26171_rm2/patch_19.2.02
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26275_rm2/patch_20.2.03
@@ -61,6 +62,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2141866_rm2/patch_35.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm2/patch_36.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21431047_rm2/patch_37.2.01
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21501067_rm2/patch_38.2.03
     fi
 }
 
@@ -74,6 +76,11 @@ configure() {
     if [[ $arch = rm1 ]]; then
         device="reMarkable 1"
         case "$build_date" in
+            "20221003074737")
+                patch_version="38.1.03"
+                original_hash="a3ce408c8a717d48746e361336532924f5ff40f2"
+                xochitl_version="2.15.0.1067"
+                ;;
             "20220921102803")
                 patch_version="37.1.01"
                 original_hash="011742f027b70f37a0da293132daafcfc82b537d"
@@ -165,6 +172,11 @@ configure() {
     elif [[ $arch = rm2 ]]; then
         device="reMarkable 2"
         case "$build_date" in
+            "20221003075633")
+                patch_version="38.2.03"
+                original_hash="fcd3c84215c5457d455419831760304736f3b694"
+                xochitl_version="2.15.0.1067"
+                ;;
             "20220921101206")
                 patch_version="37.2.01"
                 original_hash="47c3ad26651f604be5de901881a8a44f9124a79c"

--- a/package/ddvk-hacks/package
+++ b/package/ddvk-hacks/package
@@ -6,15 +6,15 @@ archs=(rm1 rm2)
 pkgnames=(ddvk-hacks)
 pkgdesc="Enhance Xochitl with additional features"
 url=https://github.com/ddvk/remarkable-hacks
-pkgver=36.01-1
-timestamp=2022-09-07T00:05:57+0200
+pkgver=37.01-1
+timestamp=2022-09-28T20:38:22Z
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT
 flags=(nostrip)
 
-source=(https://github.com/ddvk/remarkable-hacks/archive/c3ec0b6aa480baaaaf63460c99796f952265bf19.zip)
-sha256sums=(7ce383e5be058fa7bd90ec069211a74c737c36ef61a1c767bff9a352963d94a0)
+source=(https://github.com/ddvk/remarkable-hacks/archive/9ff935ef09efe4bdb9f9371b84bef21ef1b766e2.zip)
+sha256sums=(55818b14839301aa3f8da5ba70ef9de3f92bcab8ea9f72b9c6ab20d27e6b5655)
 
 _patches_dir="/opt/share/ddvk-hacks"
 _xochitl_path="/usr/bin/xochitl"
@@ -40,6 +40,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2140861_rm1/patch_34.1.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2141866_rm1/patch_35.1.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm1/patch_36.1.01
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21431047_rm1/patch_37.1.01
     elif [[ $arch = rm2 ]]; then
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26171_rm2/patch_19.2.02
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26275_rm2/patch_20.2.03
@@ -59,6 +60,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2140861_rm2/patch_34.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2141866_rm2/patch_35.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm2/patch_36.2.01
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21431047_rm2/patch_37.2.01
     fi
 }
 
@@ -72,6 +74,11 @@ configure() {
     if [[ $arch = rm1 ]]; then
         device="reMarkable 1"
         case "$build_date" in
+            "20220921102803")
+                patch_version="37.1.01"
+                original_hash="011742f027b70f37a0da293132daafcfc82b537d"
+                xochitl_version="2.14.3.1047"
+                ;;
             "20220825122914")
                 patch_version="36.1.01"
                 original_hash="a88faec812ae20960bfbab38be0aa49aafec902a"
@@ -79,7 +86,7 @@ configure() {
                 ;;
             "20220617142418")
                 patch_version="35.1.01"
-                original_hash="d172016ac8a97ca5df3c551648e0b3314f17f72a"
+                original_hash="a052dfbe587851d17146e586e4be65819f1360e3"
                 xochitl_version="2.14.1.866"
                 ;;
             "20220615075543")
@@ -158,6 +165,11 @@ configure() {
     elif [[ $arch = rm2 ]]; then
         device="reMarkable 2"
         case "$build_date" in
+            "20220921101206")
+                patch_version="37.2.01"
+                original_hash="47c3ad26651f604be5de901881a8a44f9124a79c"
+                xochitl_version="2.14.3.1047"
+                ;;
             "20220825124750")
                 patch_version="36.2.01"
                 original_hash="470e88f8d5fb62f64939fe4ea3b89c515113f7e5"

--- a/package/ddvk-hacks/package
+++ b/package/ddvk-hacks/package
@@ -6,15 +6,15 @@ archs=(rm1 rm2)
 pkgnames=(ddvk-hacks)
 pkgdesc="Enhance Xochitl with additional features"
 url=https://github.com/ddvk/remarkable-hacks
-pkgver=38.03-1
-timestamp=2022-10-18T16:35:20Z
+pkgver=39.01-1
+timestamp=2022-11-09T18:31:51Z
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT
 flags=(nostrip)
 
-source=(https://github.com/ddvk/remarkable-hacks/archive/49a6117b2a9ae3d5116069670702e7aa28ed1584.zip)
-sha256sums=(099d65801eda0e38a7f65a40659d32d1b37239deb2a3c4a896e37a7ed0b4f0a4)
+source=(https://github.com/ddvk/remarkable-hacks/archive/90e7e3e7ffc269373de191085453be50c9f8da0c.zip)
+sha256sums=(d3b1413bb9219804581afab598e7f5308233e7467d64e8084e67aae7346beaba)
 
 _patches_dir="/opt/share/ddvk-hacks"
 _xochitl_path="/usr/bin/xochitl"
@@ -42,6 +42,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm1/patch_36.1.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21431047_rm1/patch_37.1.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21501067_rm1/patch_38.1.03
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21511189_rm1/patch_39.1.01
     elif [[ $arch = rm2 ]]; then
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26171_rm2/patch_19.2.02
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/26275_rm2/patch_20.2.03
@@ -63,6 +64,7 @@ package() {
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/2143977_rm2/patch_36.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21431047_rm2/patch_37.2.01
         install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21501067_rm2/patch_38.2.03
+        install -D -m 644 -t "$pkgdir$_patches_dir" "$srcdir"/patches/21511189_rm2/patch_39.2.01
     fi
 }
 
@@ -76,6 +78,11 @@ configure() {
     if [[ $arch = rm1 ]]; then
         device="reMarkable 1"
         case "$build_date" in
+            "20221026103859")
+                patch_version="39.1.01"
+                original_hash="1c01bae469a2e29846c68758e2cae4a2b8b5055d"
+                xochitl_version="2.15.1.1189"
+                ;;
             "20221003074737")
                 patch_version="38.1.03"
                 original_hash="a3ce408c8a717d48746e361336532924f5ff40f2"
@@ -172,6 +179,11 @@ configure() {
     elif [[ $arch = rm2 ]]; then
         device="reMarkable 2"
         case "$build_date" in
+            "20221026104022")
+                patch_version="39.2.01"
+                original_hash="64e3cb3d05aec4a40624ebfc730e480358e1b184"
+                xochitl_version="2.15.1.1189"
+                ;;
             "20221003075633")
                 patch_version="38.2.03"
                 original_hash="fcd3c84215c5457d455419831760304736f3b694"

--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-09-17T16:14:01Z
+timestamp=2022-10-28T15:36:16Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.26-1
+pkgver=1:0.0.27-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    dbed22e7e5b8e9f64d64d37301ed53e99ed8369236468bec1bdd03050f2737b2
+    f4bf553f2bc868a04452f67881d7a1053f791da7d29fecbb2c5fc4075facf282
     SKIP
     SKIP
     SKIP

--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-09-10T09:40:15Z
+timestamp=2022-09-17T16:14:01Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.23-1
+pkgver=1:0.0.26-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    f29fc4c1683a4833059291ccc1a8b472be1e4cdbdd4f1f3f39317b9e994e840c
+    dbed22e7e5b8e9f64d64d37301ed53e99ed8369236468bec1bdd03050f2737b2
     SKIP
     SKIP
     SKIP

--- a/package/kernelctl/kernelctl
+++ b/package/kernelctl/kernelctl
@@ -67,7 +67,11 @@ get_kernel_names() {
 
 # get current kernel
 get_current_kernel_name() {
-    current_kernel_name=$(find "$kernelctl_dir" -samefile "$kernelctl_dir"/current.tar.bz2 ! -name current.tar.bz2 -print0 | xargs -0 -I"{}" basename {} .tar.bz2)
+    if [[ -e "$kernelctl_dir"/current.tar.bz2 ]]; then
+        current_kernel_name=$(find "$kernelctl_dir" -samefile "$kernelctl_dir"/current.tar.bz2 ! -name current.tar.bz2 -print0 | xargs -0 -I"{}" basename {} .tar.bz2)
+    else
+        current_kernel_name=''
+    fi
 }
 
 # translate input into a kernel name
@@ -104,8 +108,12 @@ list() {
 # show the current configured kernel
 show() {
     get_current_kernel_name
-    echo -e "${gr}Current kernel:${sf}"
-    echo -e "  ${bf}${current_kernel_name}${sf}"
+    if [[ "$current_kernel_name" = "" ]]; then
+        echo -e "${bf}There is no link to the current running kernel in the staging area.${sf}"
+    else
+        echo -e "${gr}Current kernel:${sf}"
+        echo -e "  ${bf}${current_kernel_name}${sf}"
+    fi
 }
 
 # actually switch kernels

--- a/package/kernelctl/kernelctl
+++ b/package/kernelctl/kernelctl
@@ -25,6 +25,7 @@ help() {
 		${bf}    list                    ${sf}List available kernels.
 		${bf}    show                    ${sf}Show the current configured kernel.
 		${bf}    delete <kernel>         ${sf}Delete kernel from the staging dir. WARNING this is irreversible.
+		${bf}    prune                   ${sf}Delete all backups of vanilla kernels older than the one that shipped with the current software version. WARNING this is irreversible.
 		${bf}    set <kernel>            ${sf}Change booting kernel.
 
 		${bf}        <kernel>            ${sf}Kernel name or number (from 'list' command) or "default" to revert to the upstram kernel.
@@ -171,6 +172,18 @@ delete() {
     fi
 }
 
+prune() {
+    echo "Deleting backups of old vanilla kernel(s) from the staging area is irreversible."
+    echo -n "Do you want to proceed? [N/y]: "
+    read -r ans
+    if [[ "$ans" = "y" || "$ans" = "Y" ]]; then
+        mapfile -t filenames < <(find "$kernelctl_dir" -path "*vanilla-*.tar.bz2" ! -name vanilla-"$(< /etc/version)".tar.bz2)
+        for filename in "${filenames[@]}"; do
+            rm "$filename"
+        done
+    fi
+}
+
 if [[ $0 = "${BASH_SOURCE[0]}" ]]; then
     if [[ $# -eq 0 ]]; then
         help
@@ -210,6 +223,9 @@ if [[ $0 = "${BASH_SOURCE[0]}" ]]; then
                 exit 1
             fi
             delete "$1"
+            ;;
+        prune)
+            prune
             ;;
         *)
             echo -e "Error: Invalid command '$action'\n"

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,7 +5,7 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.1-3
+pkgver=0.1-4
 timestamp=2022-03-14T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"
@@ -13,17 +13,16 @@ license=MIT
 
 source=(
     kernelctl
-    force_reinstall_on_toltecctl_reenable
 )
 sha256sums=(
-    SKIP
     SKIP
 )
 
 package() {
+    touch "$srcdir"/emptyfile
     install -D -m 744 -t "$pkgdir"/opt/bin "$srcdir"/kernelctl
     install -d "$pkgdir"/opt/usr/share/kernelctl
-    install -D -m 666 -t "$pkgdir"/usr/share/kernelctl/ "$srcdir"/force_reinstall_on_toltecctl_reenable
+    install -D -m 666 -t "$pkgdir"/usr/share/toltec/reenable.d/kernelctl "$srcdir"/emptyfile
 }
 
 configure() {

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,8 +5,8 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.1-4
-timestamp=2022-03-14T00:00Z
+pkgver=0.1-5
+timestamp=2022-11-12T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"
 license=MIT
@@ -27,14 +27,7 @@ package() {
 
 configure() {
     if [[ "$(kernelctl list | tail -n +2 | awk '{print $2}' | grep "vanilla-$(< /etc/version)")" == "" ]]; then
-        read -r -d '' msg <<- EOM
-		It looks like there is no backup of the upstream kernel for the
-		installed version of codex.
-
-		Please standby while one is produced (assuming that the
-		currently running kernel is upstream).
-	EOM
-        echo -e "$msg"
+        echo "Creating a backup of the currently running kernel."
         kernelctl backup vanilla
     fi
 }

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,7 +5,7 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.1-2
+pkgver=0.1-3
 timestamp=2022-03-14T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"

--- a/package/linux-mainline/package
+++ b/package/linux-mainline/package
@@ -6,7 +6,7 @@ archs=(rm2)
 pkgnames=(linux-mainline)
 pkgdesc="reMarkable 2 kernel based on the mainline kernel"
 url=https://www.kernel.org
-pkgver=5.19.0-1
+pkgver=6.0.0-1
 timestamp=2022-05-22T21:50:09Z
 section=kernel
 maintainer="Alistair Francis <alistair@alistair23.me>"
@@ -15,8 +15,8 @@ license=GPL-2.0-only
 flags=(nostrip)
 
 image=base:v2.3
-source=("https://github.com/alistair23/linux/archive/6df274810d20448125834115e2181de288fdc8a4.tar.gz")
-sha256sums=(a7538198dbef21868d2c52e8b379576c8791726809bd5886176ab88d1f9df49f)
+source=("https://github.com/alistair23/linux/archive/4c2ef4e3bba89a8d767eccb85a242b2cd8850146.tar.gz")
+sha256sums=(1583d553380a656ecaac8dab89558051e9165983381adc9c3d52fb8ac0ce19fd)
 
 build() {
     ARCH=arm make imx_v6_v7_defconfig

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety liboxide libsentry)
-pkgver=2.4-1
+pkgver=2.4-2
 _sentryver=0.4.17
 timestamp=2022-05-22T03:18:32Z
 maintainer="Eeems <eeems@eeems.email>"
@@ -11,8 +11,14 @@ url=https://oxide.eeems.codes
 license=MIT
 flags=(patch_rm2fb)
 image=qt:v2.3
-source=("https://github.com/Eeems-Org/oxide/archive/e6c62a6860b52cd1cbd47e21377f8d1ecf72bb0a.tar.gz")
-sha256sums=(a29cf455d5f66fee4ee67722c6f1d20627930920286398932c3d5c813d58ebee)
+source=(
+    "https://github.com/Eeems-Org/oxide/archive/e6c62a6860b52cd1cbd47e21377f8d1ecf72bb0a.tar.gz"
+    toltec-override.conf
+)
+sha256sums=(
+    a29cf455d5f66fee4ee67722c6f1d20627930920286398932c3d5c813d58ebee
+    SKIP
+)
 
 build() {
     find . -name "*.pro" -type f -print0 \
@@ -84,6 +90,8 @@ tarnish() {
         install -D -m 644 -t "$pkgdir"/etc/dbus-1/system.d "$srcdir"/release/etc/dbus-1/system.d/codes.eeems.oxide.conf
         install -D -m 644 -t "$pkgdir"/lib/systemd/system "$srcdir"/release/etc/systemd/system/tarnish.service
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/tarnish
+        install -D -m 644 -t "$pkgdir"/etc/systemd/system/tarnish.service.d \
+            "$srcdir"/toltec-override.conf
     }
     configure() {
         systemctl daemon-reload

--- a/package/oxide/toltec-override.conf
+++ b/package/oxide/toltec-override.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Conflicts=xochitl.service
+Conflicts=sync.service

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -6,8 +6,8 @@ archs=(rm1 rm2)
 pkgnames=(toltec-base)
 pkgdesc="Metapackage defining the base set of packages in a Toltec install"
 url=https://toltec-dev.org/
-pkgver=1.0-1
-timestamp=2022-02-28T00:12Z
+pkgver=1.1-1
+timestamp=2022-11-07T20:19:57Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
@@ -19,5 +19,15 @@ source=()
 sha256sums=()
 
 package() {
-    true
+    touch "$srcdir"/emptyfile
+    install -D -m 666 -t "$pkgdir"/usr/share/toltec/reenable.d/toltec-base "$srcdir"/emptyfile
+}
+
+configure() {
+    if is-enabled "update-engine.service"; then
+        echo "Disabling automatic update"
+        systemctl disable --now update-engine
+    fi
+    echo "Disabling usb1 network device to avoid long boots"
+    systemctl mask sys-subsystem-net-devices-usb1.device
 }

--- a/package/xochitl/kill-xochitl
+++ b/package/xochitl/kill-xochitl
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+killall xochitl

--- a/package/xochitl/manual-sync.service
+++ b/package/xochitl/manual-sync.service
@@ -1,0 +1,21 @@
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+[Unit]
+Description=reMarkable Document Sync without the xochitl.service dependency
+After=dbus.socket
+StartLimitIntervalSec=60
+StartLimitBurst=4
+Conflicts=sync.service
+
+[Service]
+# Do NOT make this dbus, systemd will kill the service when it should be
+# running otherwise.
+Type=simple
+BusName=no.remarkable.sync
+ExecStart=/usr/bin/sync --service
+Restart=on-failure
+RestartForceExitStatus=SIGHUP SIGINT SIGTERM SIGPIPE
+
+[Install]
+WantedBy=multi-user.target

--- a/package/xochitl/package
+++ b/package/xochitl/package
@@ -5,8 +5,8 @@
 pkgnames=(xochitl)
 pkgdesc="Read documents and take notes"
 url=https://remarkable.com
-pkgver=0.0.0-13
-timestamp=2022-03-05T23:26Z
+pkgver=0.0.0-14
+timestamp=2022-11-07T20:19:57Z
 section="readers"
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=MIT
@@ -24,8 +24,10 @@ source=(
     toltec-after-launcher.conf
     toltec-wrapper.conf
     env-readme
+    manual-sync.service
 )
 sha256sums=(
+    SKIP
     SKIP
     SKIP
     SKIP
@@ -56,10 +58,21 @@ package() {
         "$srcdir"/toltec-after-launcher.conf
     install -D -m 644 -t "$pkgdir"/etc/systemd/system/remarkable-reboot.service.d \
         "$srcdir"/toltec-after-launcher.conf
+    install -D -m 644 -t "$pkgdir"/etc/systemd/system \
+        "$srcdir"/manual-sync.service
 }
 
 configure() {
     systemctl daemon-reload
+
+    # sync.service interferes with launchers
+    # we use manual-sync.service instead
+    if [[ "x$(systemctl is-enabled sync.service)" != "xmasked" ]]; then
+        systemctl mask sync.service
+    fi
+    if ! is-active manual-sync.service; then
+        systemctl enable --now manual-sync.service
+    fi
 
     if is-enabled xochitl.service && ! is-enabled launcher.service; then
         # This package changes xochitl.service to alias it to launcher.service
@@ -69,8 +82,18 @@ configure() {
     fi
 }
 
+preremove() {
+    if is-active manual-sync.service; then
+        systemctl disable --now manual-sync.service
+    fi
+}
+
 postremove() {
     systemctl daemon-reload
+
+    if [[ "x$(systemctl is-enabled sync.service)" == "xmasked" ]]; then
+        systemctl unmask sync.service 2> /dev/null
+    fi
 
     if is-enabled xochitl.service && is-enabled launcher.service; then
         # If xochitl is currently the active launcher, make sure the

--- a/package/xochitl/xochitl
+++ b/package/xochitl/xochitl
@@ -9,4 +9,13 @@ for file in /opt/etc/xochitl.env.d/*.env; do
         source "$file"
     fi
 done
+# If for some reason, sync.service is no longer masked, re-mask it
+# The package install should have handled this, but something may
+# have changed it.
+if [[ "x$(systemctl is-enabled sync.service)" != "xmasked" ]]; then
+    systemctl mask sync.service
+fi
+if ! systemctl is-active --quiet manual-sync.service; then
+    systemctl enable --now manual-sync.service
+fi
 exec /usr/bin/xochitl "$@"

--- a/package/xochitl/xochitl.oxide
+++ b/package/xochitl/xochitl.oxide
@@ -11,19 +11,24 @@
         "/home/root",
         "/opt/etc",
         "/run/dbus",
+        "/run/lock",
+        "/run/systemd",
         "/run/systemd/resolve",
         "/run/udev",
         "/tmp/runtime-root",
         "/usr/share",
         "/usr/share/remarkable/templates",
+        "/usr/local/share/ca-certificates",
         "/var/cache/fontconfig",
         "/var/lib/dbus",
+        "/var/volatile/tmp"
     ],
     "environment": {
-        "QMLSCENE_DEVICE": "epaper",
-        "QT_QPA_PLATFORM": "epaper",
-        "QT_QPA_EVDEV_TOUCHSCREEN_PARAMETERS": "rotate=180",
         "HOME": "/home/root",
+        "QMLSCENE_DEVICE": "epaper",
+        "QT_QPA_EVDEV_TOUCHSCREEN_PARAMETERS": "rotate=180",
+        "QT_QPA_PLATFORM": "epaper",
+        "SYSTEMD_IGNORE_CHROOT": "true",
         "XDG_RUNTIME_DIR": "/tmp/runtime-root"
     }
 }


### PR DESCRIPTION
This update brings official support for OS 2.15.1.1189 to toltec.

### Updated Packages

- `ddvk-hacks` - 39.01-1 (#633 #640 #645)
  - Add support for OS
    - 2.14.3.1047
    - 2.15.0.1067
    - 2.15.1.1189
  - Fix hash for rM1 2.14.1.866
- `display` and `rm2fb-client` - 0.0.27 (#634 #643 )
  - Add support for OS
     - 2.14.3.1047
     - 2.15.0.1011
     - 2.15.0.1046
     - 2.15.0.1052
     - 2.15.0.1067
     - 2.15.1.1189
- `kernelctl` - 0.1-5 (#636 #641)
  - Add prune
  - Fix bug where initial install would always fail
- `linux-mainline` - 6.0.0-1 (#637)
- `erode` `fret` `oxide` `rot` `tarnish` `decay` `corrupt` `anxiety` `liboxide` - 2.4-2 (#641)
  - Fix xochitl not being run in chroot
  - Fix systemd and dbus access in chroot
  - Fix sync for xochitl inside chroot when using rmfakecloud-proxy
- `toltec-base` - 1.1-1 (#641)
  - Speed up boot time on 2.15.1.1189 by disabling unused usb1 network interface
  - Disable auto update
- `xochitl` - 0.0.0-14 (#641)
  - Fix issue where xochitl would run even though it was disabled due to how sync.service is configured