### PR TITLE
Update display and rm2fb-client to v0.0.29

### DIFF
--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-11-17T21:40:46Z
+timestamp=2023-01-11T07:12:52Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.28-1
+pkgver=1:0.0.29-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    20b198ab261ed4acd4afbb6ef16efb02966b12b5b00f3f4e93b69efd520265e6
+    c3fdf3d2baf33221be6530a40d85cd2c28e4f6e7f0cc0ecdc1833ed7a84caa37
     SKIP
     SKIP
     SKIP

--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-10-28T15:36:16Z
+timestamp=2022-11-17T21:40:46Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.27-1
+pkgver=1:0.0.28-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    f4bf553f2bc868a04452f67881d7a1053f791da7d29fecbb2c5fc4075facf282
+    20b198ab261ed4acd4afbb6ef16efb02966b12b5b00f3f4e93b69efd520265e6
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
Update display and rm2fb-client to v0.0.29
https://github.com/ddvk/remarkable2-framebuffer/releases/tag/v0.0.29

Fixes bug with Remarkable desktop app screen share freezing: https://github.com/ddvk/remarkable2-framebuffer/issues/71

Adds support for the following OS versions:

- 2.14.4.46
- 3.0.2.1253
- 3.0.4.1305
- ~3.1.0.1346~

