### PR TITLE
Update KOReader to v2022.11

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.10-1
+pkgver=2022.11-1
 timestamp=2022-07-31T13:31:10Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    29a477028079aeaaf669c9e31f5d3f5f3c492e19695642f3f49be0ea12d25bc4
+    09e65dcde9c507f597df3e7c09b59ebd9fdf62b6b5b882c59116bf79773cadbc
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
No reMarkable specific changes.
[Full changelog](https://github.com/koreader/koreader/releases/tag/v2022.11)