### PR TITLE
Update oxide to v2.5

### DIFF
--- a/package/oxide/package
+++ b/package/oxide/package
@@ -2,21 +2,21 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety liboxide libsentry)
-pkgver=2.4-2
-_sentryver=0.4.17
-timestamp=2022-05-22T03:18:32Z
+pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety liboxide libsentry notify-send)
+pkgver=2.5-1
+_sentryver=0.5.0
+timestamp=2023-01-26T22:52:14Z
 maintainer="Eeems <eeems@eeems.email>"
 url=https://oxide.eeems.codes
 license=MIT
 flags=(patch_rm2fb)
 image=qt:v2.3
 source=(
-    "https://github.com/Eeems-Org/oxide/archive/e6c62a6860b52cd1cbd47e21377f8d1ecf72bb0a.tar.gz"
+    "https://github.com/Eeems-Org/oxide/archive/refs/tags/v2.5.zip"
     toltec-override.conf
 )
 sha256sums=(
-    a29cf455d5f66fee4ee67722c6f1d20627930920286398932c3d5c813d58ebee
+    07bfb84e5adaebdebd2ce55b22f3764a1d4887c2b18364f5ec1053f171e3ecbe
     SKIP
 )
 
@@ -159,9 +159,19 @@ libsentry() {
     section=devel
     url=https://github.com/getsentry/sentry-native
     pkgver="$_sentryver"
-    timestamp="2021-12-20T14:25:11Z"
+    timestamp="2022-08-02T14:40:22Z"
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/lib "$srcdir"/release/opt/lib/libsentry.so
+    }
+}
+
+notify-send() {
+    pkgdesc="A program to send desktop notifications for Oxide"
+    section=utils
+    installdepends=("tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
+
+    package() {
+        install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/notify-send
     }
 }


### PR DESCRIPTION
Update the following applications to 2.5:
- erode
- fret
- oxide
- rot
- tarnish
- decay
- corrupt
- anxiety
- lliboxide

Update libsentry to 0.5.0

Add new notify-send package

[Full release notes](https://github.com/Eeems-Org/oxide/releases/tag/v2.5)