### PR TITLE
Update KOReader to v2023.01

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.11-1
+pkgver=2023.01-1
 timestamp=2022-07-31T13:31:10Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    09e65dcde9c507f597df3e7c09b59ebd9fdf62b6b5b882c59116bf79773cadbc
+    f052d01e9be9c65883e1f8c00bae87b37ba6e47d3bf7b9bbbd746f58acc640c2
     SKIP
     SKIP
     SKIP


### PR DESCRIPTION
No reMarkable specific changes.
[Release notes](https://github.com/koreader/koreader/releases/tag/v2023.01)