### PR TITLE
Add package: neofetch

### DIFF
--- a/package/neofetch/package
+++ b/package/neofetch/package
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(neofetch)
+pkgdesc="A command-line system information tool"
+url="https://github.com/rM-self-serve/neofetch-rM"
+pkgver=0.0.0-1
+timestamp=2023-02-09T11:43:00Z
+section="utils"
+maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
+license=MIT
+
+source=(
+    https://github.com/rM-self-serve/neofetch-rM/archive/c497597ba4b481042cbb48b7c2c55e45dda25543.zip
+)
+
+sha256sums=(
+    06492898eac6fb4f2cc95ca52c65f8f4f580ada57b4fe433722dabeae884b633
+)
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/neofetch
+}


### PR DESCRIPTION
This should be tested on the rM2,  I have tested it on the rM1 versions 2.10, 2.15, and 3.1. The OS information and battery read out are the primary concerns.