### PR TITLE
Stable merge for week 10 of 2023

### DIFF
--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2022-10-28T15:36:16Z
+timestamp=2023-01-11T07:12:52Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.27-1
+pkgver=1:0.0.29-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    f4bf553f2bc868a04452f67881d7a1053f791da7d29fecbb2c5fc4075facf282
+    c3fdf3d2baf33221be6530a40d85cd2c28e4f6e7f0cc0ecdc1833ed7a84caa37
     SKIP
     SKIP
     SKIP

--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2023-01-11T07:12:52Z
+timestamp=2023-02-20T15:49:05Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.29-1
+pkgver=1:0.0.30-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    c3fdf3d2baf33221be6530a40d85cd2c28e4f6e7f0cc0ecdc1833ed7a84caa37
+    bbd2acf8bc7d15082307c362985980e78cf1b48a69799aa602cf7dc3973339c7
     SKIP
     SKIP
     SKIP

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.11-1
+pkgver=2023.01-1
 timestamp=2022-07-31T13:31:10Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    09e65dcde9c507f597df3e7c09b59ebd9fdf62b6b5b882c59116bf79773cadbc
+    f052d01e9be9c65883e1f8c00bae87b37ba6e47d3bf7b9bbbd746f58acc640c2
     SKIP
     SKIP
     SKIP

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,7 +5,7 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2022.10-1
+pkgver=2022.11-1
 timestamp=2022-07-31T13:31:10Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    29a477028079aeaaf669c9e31f5d3f5f3c492e19695642f3f49be0ea12d25bc4
+    09e65dcde9c507f597df3e7c09b59ebd9fdf62b6b5b882c59116bf79773cadbc
     SKIP
     SKIP
     SKIP

--- a/package/neofetch/package
+++ b/package/neofetch/package
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(neofetch)
+pkgdesc="A command-line system information tool"
+url="https://github.com/rM-self-serve/neofetch-rM"
+pkgver=0.0.0-1
+timestamp=2023-02-09T11:43:00Z
+section="utils"
+maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
+license=MIT
+
+source=(
+    https://github.com/rM-self-serve/neofetch-rM/archive/c497597ba4b481042cbb48b7c2c55e45dda25543.zip
+)
+
+sha256sums=(
+    06492898eac6fb4f2cc95ca52c65f8f4f580ada57b4fe433722dabeae884b633
+)
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/neofetch
+}

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -2,21 +2,21 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety liboxide libsentry)
-pkgver=2.4-2
-_sentryver=0.4.17
-timestamp=2022-05-22T03:18:32Z
+pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety liboxide libsentry notify-send)
+pkgver=2.5-1
+_sentryver=0.5.0
+timestamp=2023-01-26T22:52:14Z
 maintainer="Eeems <eeems@eeems.email>"
 url=https://oxide.eeems.codes
 license=MIT
 flags=(patch_rm2fb)
 image=qt:v2.3
 source=(
-    "https://github.com/Eeems-Org/oxide/archive/e6c62a6860b52cd1cbd47e21377f8d1ecf72bb0a.tar.gz"
+    "https://github.com/Eeems-Org/oxide/archive/refs/tags/v2.5.zip"
     toltec-override.conf
 )
 sha256sums=(
-    a29cf455d5f66fee4ee67722c6f1d20627930920286398932c3d5c813d58ebee
+    07bfb84e5adaebdebd2ce55b22f3764a1d4887c2b18364f5ec1053f171e3ecbe
     SKIP
 )
 
@@ -159,9 +159,19 @@ libsentry() {
     section=devel
     url=https://github.com/getsentry/sentry-native
     pkgver="$_sentryver"
-    timestamp="2021-12-20T14:25:11Z"
+    timestamp="2022-08-02T14:40:22Z"
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/lib "$srcdir"/release/opt/lib/libsentry.so
+    }
+}
+
+notify-send() {
+    pkgdesc="A program to send desktop notifications for Oxide"
+    section=utils
+    installdepends=("tarnish=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver")
+
+    package() {
+        install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/notify-send
     }
 }

--- a/package/webinterface-wifi/package
+++ b/package/webinterface-wifi/package
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(webinterface-wifi)
+pkgdesc="View the web interface if running, over wifi"
+url="https://github.com/rM-self-serve/webinterface-wifi"
+pkgver=1.0.2-1
+timestamp=2023-02-06T12:23:17Z
+section="utils"
+maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
+license=MIT
+
+image=rust:v2.3
+
+source=(
+    https://github.com/rM-self-serve/webinterface-wifi/archive/2e29855303a0806ee51e71bc836bc4b16204fa14.zip
+    webinterface-wifi-toltec.service
+)
+
+sha256sums=(
+    629bab244a387086ce2a8f8118b8d1017cf993bf97b13da72573f52572ed526e
+    SKIP
+)
+
+build() {
+    RUSTFLAGS="-Zcrate-attr=feature(const_fn_trait_bound)" cargo build --release
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin \
+        "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/webinterface-wifi
+    install -D -m 644 "$srcdir"/webinterface-wifi-toltec.service "$pkgdir"/lib/systemd/system/webinterface-wifi.service
+}
+
+configure() {
+    systemctl daemon-reload
+
+    echo ""
+    echo "Run the following command to use $pkgname"
+    how-to-enable "$pkgname.service"
+}
+
+preremove() {
+    if is-active "$pkgname"; then
+        echo "Stopping $pkgname"
+        systemctl stop "$pkgname"
+    fi
+    if is-enabled "$pkgname"; then
+        echo "Disabling $pkgname"
+        systemctl disable "$pkgname"
+    fi
+}
+
+postremove() {
+    systemctl daemon-reload
+}

--- a/package/webinterface-wifi/webinterface-wifi-toltec.service
+++ b/package/webinterface-wifi/webinterface-wifi-toltec.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=View the web interface if running, over wifi
+StartLimitIntervalSec=600
+StartLimitBurst=4
+After=home.mount
+
+[Service]
+Environment=HOME=/home/root
+Type=simple
+ExecStart=/opt/bin/webinterface-wifi --run 80
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### New Packages
- `notify-send` - 2.5-1 (#662)
  - Reimplementation of [notify-send from libnotify](https://man.archlinux.org/man/notify-send.1.en) for use with Oxide
- `webinterface-wifi` - 1.0.2-1 (#664)
  - Use the USB web interface over wifi
- `neofetch` - 0.0.0-1 (#665)
  - A command-line system information tool

### Updated Packages
- `koreader` - 2023.01-1 (#659 #663)
- `erode`, `fret`, `oxide`, `rot`, `tarnish`, `decay`, `corrupt`, and `anxiety` - 2.5-1 (#662)
  - [See full release notes](https://github.com/Eeems-Org/oxide/releases/tag/v2.5)
- `libsentry` - 0.5.0 (#662)
- `display`, `rm2fb-client` - 0.0.30-1 (#656 #666)
  - Add support for the following OS versions:
    - 2.14.4.46
    - 3.0.2.1253
    - 3.0.4.1305

**Note:** This doesn't change what OS version that toltec supports, as full support still requires `ddvk-hacks` to be updated.