### PR TITLE
Update plato to 0.9.34

### DIFF
--- a/package/plato/package
+++ b/package/plato/package
@@ -14,7 +14,7 @@ installdepends=(display jq)
 makedepends=(build:jq build:unzip build:wget)
 flags=(patch_rm2fb)
 
-image=rust:v2.3
+image=rust:v2.3.1
 source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-13.zip")
 sha256sums=(82ef5786704ecdb4fe11ce16e7e4ae10b518a592965c292977bb33962c891d48)
 

--- a/package/plato/package
+++ b/package/plato/package
@@ -11,7 +11,7 @@ section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 installdepends=(display jq)
-makedepends=(build:jq build:unzip build:wget, build:patchelf)
+makedepends=(build:jq build:unzip build:wget build:patchelf)
 flags=(patch_rm2fb)
 
 image=rust:v2.3.1

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,8 +5,8 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.25-2
-timestamp=2022-02-08T23:54Z
+pkgver=0.9.34-1
+timestamp=2023-03-08T17:58Z
 section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
@@ -14,14 +14,11 @@ installdepends=(display jq)
 makedepends=(build:jq build:unzip build:wget)
 flags=(patch_rm2fb)
 
-image=rust:v2.2.2
-source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-12.zip")
-sha256sums=(42e18e882e7e6853e299234a44eea9b9e3c4170076eec0577a0644dcf7005cf9)
+image=rust:v2.3
+source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-13.zip")
+sha256sums=(82ef5786704ecdb4fe11ce16e7e4ae10b518a592965c292977bb33962c891d48)
 
 build() {
-    # Fall back to system-wide config
-    rm .cargo/config
-
     # 'cargo pkgid' seems to output something different with most
     # recent nightly builds. This adjusts the filtering.
     sed -i "s/version=.*$/version=\'$(cargo pkgid | cut -d "#" -f 2 | cut -d ":" -f 2)\'/g" download.sh
@@ -30,7 +27,6 @@ build() {
     export AR=arm-linux-gnueabihf-ar
     export CC=arm-linux-gnueabihf-gcc
     export STRIP=arm-linux-gnueabihf-strip
-    sed -i '/source \/usr\/local\/oecore-x86_64/d' src/mupdf_wrapper/build-kobo.sh
 
     # Compile all to dist/
     ./clean.sh

--- a/package/plato/package
+++ b/package/plato/package
@@ -11,7 +11,7 @@ section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 installdepends=(display jq)
-makedepends=(build:jq build:unzip build:wget)
+makedepends=(build:jq build:unzip build:wget, build:patchelf)
 flags=(patch_rm2fb)
 
 image=rust:v2.3.1

--- a/package/plato/package
+++ b/package/plato/package
@@ -21,7 +21,7 @@ sha256sums=(82ef5786704ecdb4fe11ce16e7e4ae10b518a592965c292977bb33962c891d48)
 build() {
     # 'cargo pkgid' seems to output something different with most
     # recent nightly builds. This adjusts the filtering.
-    sed -i "s/version=.*$/version=\'$(cargo pkgid | cut -d "#" -f 2 | cut -d ":" -f 2)\'/g" download.sh
+    sed -i "s/version=.*$/version=\'$(cargo pkgid -p plato | cut -d "#" -f 2 | cut -d ":" -f 2)\'/g" download.sh
 
     # Use our toolchain
     export AR=arm-linux-gnueabihf-ar

--- a/package/plato/package
+++ b/package/plato/package
@@ -23,6 +23,9 @@ build() {
     # recent nightly builds. This adjusts the filtering.
     sed -i "s/version=.*$/version=\'$(cargo pkgid -p plato | cut -d "#" -f 2 | cut -d ":" -f 2)\'/g" download.sh
 
+    # Temporary fix until next release (TODO: Remove for next released version as included with commit fbfaf3d7)
+    sed -i "s/--target=arm-unknown-linux-gnueabihf/--target=armv7-unknown-linux-gnueabihf/g" build.sh
+
     # Use our toolchain
     export AR=arm-linux-gnueabihf-ar
     export CC=arm-linux-gnueabihf-gcc


### PR DESCRIPTION
Finally got to updating it.

A bunch of coding structures changed in plato but should build and run as usual.

https://github.com/LinusCDE/plato/releases/tag/0.9.34-rm-release-13