### PR TITLE
Update KOReader to v2023.04

### DIFF
--- a/package/koreader/package
+++ b/package/koreader/package
@@ -44,6 +44,11 @@ package() {
 }
 
 configure() {
+    # This file can cause issues with startup when moving from 2022.08 to another version
+    if [ -f /opt/koreader/cache/fontlist/fontinfo.dat ]; then
+        rm /opt/koreader/cache/fontlist/fontinfo.dat
+    }
+
     systemctl daemon-reload
 
     if ! is-enabled "$pkgname.service"; then

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2023.03-1
-timestamp=2023-03-20T11:38:17Z
+pkgver=2023.04-1
+timestamp=2023-04-27T20:53:54Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    7f667e7ba72d9e7d832a95d55316f5010f0eca19461d7a591a5e8e10b7aadc45
+    7149beb95ee561c488491d723acbb2c641c99733abc1036de7064241a5f32813
     SKIP
     SKIP
     SKIP

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -47,7 +47,7 @@ configure() {
     # This file can cause issues with startup when moving from 2022.08 to another version
     if [ -f /opt/koreader/cache/fontlist/fontinfo.dat ]; then
         rm /opt/koreader/cache/fontlist/fontinfo.dat
-    }
+    fi
 
     systemctl daemon-reload
 


### PR DESCRIPTION
There are no reMarkable specific changes.

See the [release notes](https://github.com/koreader/koreader/releases/tag/v2023.04) for more information.