### PR TITLE
Update toltec-base to 1.2-1

### DIFF
--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -28,9 +28,7 @@ configure() {
         echo "Disabling automatic update"
         systemctl disable --now update-engine
     fi
-    # shellcheck source=../toltec-bootstrap/toltecctl
-    source /home/root/.local/bin/toltecctl
-    if [[ $(identify-model) == "rm1" ]]; then
+    if [[ "$arch" == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"
         systemctl mask sys-subsystem-net-devices-usb1.device
     fi

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -28,8 +28,11 @@ configure() {
         echo "Disabling automatic update"
         systemctl disable --now update-engine
     fi
-    if [[ "$arch" == "rm1" ]]; then
+    if [[ "$arch" == "rm1" ]] && ! is-masked sys-subsystem-net-devices-usb1.device; then
         echo "Disabling usb1 network device to avoid long boots"
         systemctl mask sys-subsystem-net-devices-usb1.device
+    elif [[ "$arch" == "rm2" ]] && is-masked sys-subsystem-net-devices-usb1.device; then
+        echo "Enabling usb1 network device to ensure usb SSH works"
+        systemctl unmask sys-subsystem-net-devices-usb1.device
     fi
 }

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -29,7 +29,7 @@ configure() {
         systemctl disable --now update-engine
     fi
     source /home/root/.local/bin/toltecctl
-    if [[ $(identify-model) == "rm1" ]];then
+    if [[ $(identify-model) == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"
         systemctl mask sys-subsystem-net-devices-usb1.device
     fi

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -6,8 +6,8 @@ archs=(rm1 rm2)
 pkgnames=(toltec-base)
 pkgdesc="Metapackage defining the base set of packages in a Toltec install"
 url=https://toltec-dev.org/
-pkgver=1.1-1
-timestamp=2022-11-07T20:19:57Z
+pkgver=1.2-1
+timestamp=2023-05-08T19:31Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
@@ -28,6 +28,9 @@ configure() {
         echo "Disabling automatic update"
         systemctl disable --now update-engine
     fi
-    echo "Disabling usb1 network device to avoid long boots"
-    systemctl mask sys-subsystem-net-devices-usb1.device
+    source /home/root/.local/bin/toltecctl
+    if [[ $(identify-model) == "rm1" ]];then
+        echo "Disabling usb1 network device to avoid long boots"
+        systemctl mask sys-subsystem-net-devices-usb1.device
+    fi
 }

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -36,3 +36,12 @@ configure() {
         systemctl unmask sys-subsystem-net-devices-usb1.device
     fi
 }
+
+postremove() {
+    if is-masked sys-subsystem-net-devices-usb1.device; then
+        systemctl unmask sys-subsystem-net-devices-usb1.device
+    fi
+    if ! is-enabled "update-engine.service"; then
+        systemctl enable update-engine
+    fi
+}

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -28,6 +28,7 @@ configure() {
         echo "Disabling automatic update"
         systemctl disable --now update-engine
     fi
+    # shellcheck source=toltecctl
     source /home/root/.local/bin/toltecctl
     if [[ $(identify-model) == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -28,7 +28,7 @@ configure() {
         echo "Disabling automatic update"
         systemctl disable --now update-engine
     fi
-    # shellcheck source=toltecctl
+    # shellcheck source=../toltec-bootstrap/toltecctl
     source /home/root/.local/bin/toltecctl
     if [[ $(identify-model) == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -31,7 +31,7 @@ is-enabled() {
 #
 # Exit code:
 #
-# 0 if the unit exists and is enabled, 1 otherwise
+# 0 if the unit exists and is masked, 1 otherwise
 is-masked() {
     [[ "$(systemctl is-enabled "$1" 2> /dev/null)" == "masked" ]]
 }

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -23,6 +23,19 @@ is-enabled() {
     systemctl --quiet is-enabled "$1" 2> /dev/null
 }
 
+# Check whether a systemd unit exists and is masked
+#
+# Arguments:
+#
+# $1 - Name of the systemd unit, e.g. "xochitl.service" or "xochitl"
+#
+# Exit code:
+#
+# 0 if the unit exists and is enabled, 1 otherwise
+is-masked() {
+    [[ "$(systemctl is-enabled "$1" 2> /dev/null)" == "masked" ]]
+}
+
 # Check whether a systemd unit is in an active state
 # ("running")
 #


### PR DESCRIPTION
- Only disable sys-subsystem-net-devices-usb1.device if on a reMarkable 1. On a reMarkable 2, this makes SSH over usb no longer available.
- Make toltec-base properly clean itself up on uninstall
- Add is-masked function to install-lib