### PR TITLE
Update fbink, fbdepth, and fbink-doom to 1.25.0

### DIFF
--- a/package/fbink/package
+++ b/package/fbink/package
@@ -4,8 +4,8 @@
 
 pkgnames=(fbink fbdepth fbink-doom)
 url=https://github.com/NiLuJe/FBInk
-pkgver=1.24.0-1
-timestamp=2021-03-25T23:41:13Z
+pkgver=1.25.0-1
+timestamp=2022-12-05T02:50:38Z
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 installdepends=(display)


### PR DESCRIPTION
[Release notes](https://github.com/NiLuJe/FBInk/releases/tag/v1.25.0)