### PR TITLE
Update restream to 1.2

### DIFF
--- a/package/restream/package
+++ b/package/restream/package
@@ -5,15 +5,15 @@
 pkgnames=(restream)
 pkgdesc="Binary framebuffer capture tool for the reStream script"
 url=https://github.com/rien/reStream
-pkgver=1.1-2
-timestamp=2021-01-28T23:25:40Z
+pkgver=1.2-1
+timestamp=2021-11-04T19:09:14Z
 section="screensharing"
 maintainer="Dan Shick <dan.shick@gmail.com>"
 license=MIT
 
 image=rust:v2.1
 source=("https://github.com/rien/reStream/archive/${pkgver%-*}.tar.gz")
-sha256sums=(89fa4c8adfcdfb5266e11d1f8ed4c5d8dac12a68a7ee5622cf21f833bca1704f)
+sha256sums=(4166142b15e1e7363dac302aa92aad5b44e0514cab233abecb51414952c1d5a1)
 
 build() {
     # Fall back to system-wide config

--- a/package/restream/package
+++ b/package/restream/package
@@ -5,14 +5,14 @@
 pkgnames=(restream)
 pkgdesc="Binary framebuffer capture tool for the reStream script"
 url=https://github.com/rien/reStream
-pkgver=1.2-1
+pkgver=1.2.0-1
 timestamp=2021-11-04T19:09:14Z
 section="screensharing"
 maintainer="Dan Shick <dan.shick@gmail.com>"
 license=MIT
 
 image=rust:v2.1
-source=("https://github.com/rien/reStream/archive/${pkgver%-*}.tar.gz")
+source=("https://github.com/rien/reStream/archive/refs/tags/${pkgver%-*}.tar.gz")
 sha256sums=(4166142b15e1e7363dac302aa92aad5b44e0514cab233abecb51414952c1d5a1)
 
 build() {

--- a/package/restream/package
+++ b/package/restream/package
@@ -16,9 +16,6 @@ source=("https://github.com/rien/reStream/archive/refs/tags/${pkgver%-*}.tar.gz"
 sha256sums=(4166142b15e1e7363dac302aa92aad5b44e0514cab233abecb51414952c1d5a1)
 
 build() {
-    # Fall back to system-wide config
-    rm .cargo/config
-
     cargo build --release --bin restream
 }
 


### PR DESCRIPTION
[Release notes](https://github.com/rien/reStream/releases/tag/1.2.0)