### PR TITLE
Stable merge for week 19 of 2023

### DIFF
--- a/package/display/package
+++ b/package/display/package
@@ -4,11 +4,11 @@
 
 archs=(rm1 rm2)
 pkgnames=(display rm2fb-client)
-timestamp=2023-02-20T15:49:05Z
+timestamp=2023-04-16T20:53:38Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.30-1
+pkgver=1:0.0.31-1
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -23,7 +23,7 @@ source=(
     rm2fb-preload.env
 )
 sha256sums=(
-    bbd2acf8bc7d15082307c362985980e78cf1b48a69799aa602cf7dc3973339c7
+    c27081be9b4fa000e41489b42d53fb8254bd8bf348a34756799488827dbc0f0b
     SKIP
     SKIP
     SKIP

--- a/package/display/package
+++ b/package/display/package
@@ -8,7 +8,7 @@ timestamp=2023-04-16T20:53:38Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 url="https://github.com/ddvk/remarkable2-framebuffer"
-pkgver=1:0.0.31-1
+pkgver=1:0.0.31-2
 _release="${pkgver%-*}"
 _release="v${_release#*:}"
 _libver=1.0.1
@@ -64,12 +64,19 @@ display() {
     configure() {
         if [[ $arch = rm2 ]]; then
             systemctl daemon-reload
-            systemctl enable rm2fb --now
-            # Restart xochitl if it's running
-            if systemctl --quiet is-active xochitl; then
-                # Reset the crash count so we don't trigger remarkable-fail
-                echo "0" > /tmp/crashnum
-                systemctl restart xochitl
+            if systemctl enable rm2fb --now; then
+                # Restart xochitl if it's running
+                if systemctl --quiet is-active xochitl; then
+                    # Reset the crash count so we don't trigger remarkable-fail
+                    echo "0" > /tmp/crashnum
+                    systemctl restart xochitl
+                fi
+            else
+                systemctl disable rm2fb --now
+                echo "Failed to start rm2fb. Keeping it disabled for now."
+                echo "Please check the logs and open an issue:"
+                echo "  https://github.com/toltec-dev/toltec/issues/new"
+                exit 1
             fi
         fi
     }

--- a/package/fbink/package
+++ b/package/fbink/package
@@ -4,8 +4,8 @@
 
 pkgnames=(fbink fbdepth fbink-doom)
 url=https://github.com/NiLuJe/FBInk
-pkgver=1.24.0-1
-timestamp=2021-03-25T23:41:13Z
+pkgver=1.25.0-1
+timestamp=2022-12-05T02:50:38Z
 maintainer="Mattéo Delabre <spam@delab.re>"
 license=GPL-3.0
 installdepends=(display)

--- a/package/kernelctl/package
+++ b/package/kernelctl/package
@@ -5,7 +5,7 @@
 pkgnames=(kernelctl)
 pkgdesc="Manage aftermarket kernels"
 url=https://toltec-dev.org/
-pkgver=0.1-5
+pkgver=0.1-6
 timestamp=2022-11-12T00:00Z
 section="utils"
 maintainer="Salvatore Stella <etn45p4m@gmail.com>"
@@ -29,5 +29,20 @@ configure() {
     if [[ "$(kernelctl list | tail -n +2 | awk '{print $2}' | grep "vanilla-$(< /etc/version)")" == "" ]]; then
         echo "Creating a backup of the currently running kernel."
         kernelctl backup vanilla
+    fi
+}
+
+preremove() {
+    if [[ "$(kernelctl show | tail -n 1 | grep "vanilla-$(< /etc/version)")" == "" ]]; then
+        if [[ "$(kernelctl list | tail -n +2 | awk '{print $2}' | grep "vanilla-$(< /etc/version)")" == "" ]]; then
+            echo "Unable to restore default kernel."
+            echo "To force removal, you can run the following:"
+            echo "  opkg remove --force-remove kernelctl"
+            echo "Warning: This will not leave you in a stock state"
+            exit 1
+        else
+            echo "Restoring default kernel"
+            kernelctl set default
+        fi
     fi
 }

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2023.01-1
-timestamp=2022-07-31T13:31:10Z
+pkgver=2023.03-1
+timestamp=2023-03-20T11:38:17Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    f052d01e9be9c65883e1f8c00bae87b37ba6e47d3bf7b9bbbd746f58acc640c2
+    7f667e7ba72d9e7d832a95d55316f5010f0eca19461d7a591a5e8e10b7aadc45
     SKIP
     SKIP
     SKIP

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2023.03-1
-timestamp=2023-03-20T11:38:17Z
+pkgver=2023.04-1
+timestamp=2023-04-27T20:53:54Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    7f667e7ba72d9e7d832a95d55316f5010f0eca19461d7a591a5e8e10b7aadc45
+    7149beb95ee561c488491d723acbb2c641c99733abc1036de7064241a5f32813
     SKIP
     SKIP
     SKIP
@@ -44,6 +44,11 @@ package() {
 }
 
 configure() {
+    # This file can cause issues with startup when moving from 2022.08 to another version
+    if [ -f /opt/koreader/cache/fontlist/fontinfo.dat ]; then
+        rm /opt/koreader/cache/fontlist/fontinfo.dat
+    fi
+
     systemctl daemon-reload
 
     if ! is-enabled "$pkgname.service"; then

--- a/package/restream/package
+++ b/package/restream/package
@@ -5,20 +5,17 @@
 pkgnames=(restream)
 pkgdesc="Binary framebuffer capture tool for the reStream script"
 url=https://github.com/rien/reStream
-pkgver=1.1-2
-timestamp=2021-01-28T23:25:40Z
+pkgver=1.2.0-1
+timestamp=2021-11-04T19:09:14Z
 section="screensharing"
 maintainer="Dan Shick <dan.shick@gmail.com>"
 license=MIT
 
 image=rust:v2.1
-source=("https://github.com/rien/reStream/archive/${pkgver%-*}.tar.gz")
-sha256sums=(89fa4c8adfcdfb5266e11d1f8ed4c5d8dac12a68a7ee5622cf21f833bca1704f)
+source=("https://github.com/rien/reStream/archive/refs/tags/${pkgver%-*}.tar.gz")
+sha256sums=(4166142b15e1e7363dac302aa92aad5b44e0514cab233abecb51414952c1d5a1)
 
 build() {
-    # Fall back to system-wide config
-    rm .cargo/config
-
     cargo build --release --bin restream
 }
 

--- a/package/rmkit/changelog
+++ b/package/rmkit/changelog
@@ -1,3 +1,32 @@
+2023-03-12 raisjn <of.raisjn@arkose>
+
+	harmony
+
+	* fix exporting individual layers
+
+	rmkit
+
+	* swap M and N on keyboard
+	* fix image thumbnail code
+
+	simple:
+
+	* add "range" input widget
+	* add "canvas" widget
+	* less debug output
+	* make images clickable
+	* move 'timeout' to its own thread instead of jamming task queue
+	* ignore empty lines
+
+	remux
+
+	* add "suspend" to remux FIFO api
+
+	rpncalc
+
+	* make it more hp48 like (@cesss)
+
+
 2022-05-06 raisjn <of.raisjn@arkose>
 	remux
 

--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(bufshot dumbskull genie harmony iago lamp mines nao remux rpncalc simple wordlet)
-timestamp=2022-06-23T20:03:10Z
+timestamp=2023-03-12T20:03:10Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 installdepends=(display)
@@ -11,12 +11,12 @@ flags=(patch_rm2fb)
 
 image=python:v2.1
 source=(
-    https://github.com/rmkit-dev/rmkit/archive/070d5df29a71e55050a5e993f047f1590d69ec1c.zip
+    https://github.com/rmkit-dev/rmkit/archive/2bf3488010eccf0d9e7f6c64e681517739420c58.zip
     remux.service
     genie.service
 )
 sha256sums=(
-    e7f0379d5ad9de61c32a296ab831780cfea73352fbccfe2472422165943457ef
+    a0d1a8b16adeca688d7df6a18e4c7404d9d4a405b33615dfb4e374f24ff3dded
     SKIP
     SKIP
 )
@@ -80,7 +80,7 @@ genie() {
 harmony() {
     pkgdesc="Procedural sketching app"
     url="https://rmkit.dev/apps/harmony"
-    pkgver=0.2.1-1
+    pkgver=0.2.2-1
     section="drawing"
 
     package() {
@@ -147,7 +147,7 @@ nao() {
 remux() {
     pkgdesc="Launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.2.3-1
+    pkgver=0.2.4-1
     section="launchers"
 
     package() {
@@ -179,7 +179,7 @@ remux() {
 rpncalc() {
     pkgdesc="RPN Calculator"
     url="https://rmkit.dev/apps/rpncalc"
-    pkgver=0.0.2-2
+    pkgver=0.0.3-2
     section="math"
 
     package() {
@@ -193,7 +193,7 @@ rpncalc() {
 simple() {
     pkgdesc="Simple app script for writing scripted applications"
     url="https://rmkit.dev/apps/sas"
-    pkgver=0.1.5-2
+    pkgver=0.2.0-2
     section="devel"
 
     package() {
@@ -204,7 +204,7 @@ simple() {
 wordlet() {
     pkgdesc="Wordle clone"
     url="https://rmkit.dev/apps/wordlet"
-    pkgver=0.0.1-2
+    pkgver=0.0.2-2
     section="games"
 
     package() {

--- a/package/templatectl/package
+++ b/package/templatectl/package
@@ -5,7 +5,7 @@
 pkgnames=(templatectl)
 pkgdesc="Tool to add/remove templates for xochitl"
 url=https://github.com/PeterGrace/templatectl
-pkgver=0.1.3-3
+pkgver=0.1.3-4
 timestamp=2021-01-15T01:23Z
 section="templates"
 maintainer="Peter Grace <pete.grace@gmail.com>"
@@ -41,7 +41,15 @@ configure() {
 }
 
 postremove() {
-    remove-bind-mount /usr/share/remarkable/templates
+    local bind_path
+    local unit_name
+    local unit_path
+    bind_path=/usr/share/remarkable/templates
+    unit_name="$(systemd-escape --path "$bind_path").mount"
+    unit_path="/lib/systemd/system/$unit_name"
+    if [[ -e $unit_path ]]; then
+        remove-bind-mount "$bind_path"
+    fi
 
     echo "To fully remove templatectl you'll need to run the following command:"
     echo "  rm -rf /home/root/.entware/share/remarkable/templates"

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -6,8 +6,8 @@ archs=(rm1 rm2)
 pkgnames=(toltec-base)
 pkgdesc="Metapackage defining the base set of packages in a Toltec install"
 url=https://toltec-dev.org/
-pkgver=1.1-1
-timestamp=2022-11-07T20:19:57Z
+pkgver=1.2-1
+timestamp=2023-05-08T19:31Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
@@ -28,6 +28,20 @@ configure() {
         echo "Disabling automatic update"
         systemctl disable --now update-engine
     fi
-    echo "Disabling usb1 network device to avoid long boots"
-    systemctl mask sys-subsystem-net-devices-usb1.device
+    if [[ "$arch" == "rm1" ]] && ! is-masked sys-subsystem-net-devices-usb1.device; then
+        echo "Disabling usb1 network device to avoid long boots"
+        systemctl mask sys-subsystem-net-devices-usb1.device
+    elif [[ "$arch" == "rm2" ]] && is-masked sys-subsystem-net-devices-usb1.device; then
+        echo "Enabling usb1 network device to ensure usb SSH works"
+        systemctl unmask sys-subsystem-net-devices-usb1.device
+    fi
+}
+
+postremove() {
+    if is-masked sys-subsystem-net-devices-usb1.device; then
+        systemctl unmask sys-subsystem-net-devices-usb1.device
+    fi
+    if ! is-enabled "update-engine.service"; then
+        systemctl enable update-engine
+    fi
 }

--- a/scripts/install-lib
+++ b/scripts/install-lib
@@ -23,6 +23,19 @@ is-enabled() {
     systemctl --quiet is-enabled "$1" 2> /dev/null
 }
 
+# Check whether a systemd unit exists and is masked
+#
+# Arguments:
+#
+# $1 - Name of the systemd unit, e.g. "xochitl.service" or "xochitl"
+#
+# Exit code:
+#
+# 0 if the unit exists and is masked, 1 otherwise
+is-masked() {
+    [[ "$(systemctl is-enabled "$1" 2> /dev/null)" == "masked" ]]
+}
+
 # Check whether a systemd unit is in an active state
 # ("running")
 #


### PR DESCRIPTION
### Updated Packages
- `koreader` - 2023.04-1 (#672 #681)
- `display`, `rm2fb-client` - 0.0.31-1 (#680 #686)
  - If rm2fb fails to start on install, disable it to avoid soft-bricking the device
  - Add support for the following OS versions:
    - 3.2.2.1581
    - 3.2.3.1595
- `wordlet` - 0.0.2-2 (#670)
  - Swap M and N on keyboard
  - Fix image thumbnail code
- `harmony` - 0.2.2-1 (#670)
  - Fix exporting individual layers
- `simple` - 0.2.0-2 (#670)
  - Add "range" input widget
  - Add "canvas" widget
  - Less debug output
  - Make images clickable
  - Move 'timeout' to its own thread instead of jamming task queue
  - Ignore empty lines
- `remux` - 0.2.4-1 (#670)
  - Add "suspend" to remux FIFO api
- `rpncalc` - 0.0.3-2 (#670)
  - Make it more like the hp48
- `toltec-base` - 1.2-1 (#685)
  -  Only disable sys-subsystem-net-devices-usb1.device if on a reMarkable 1. On a reMarkable 2, this makes SSH over usb no longer available.
  - Make toltec-base properly clean itself up on uninstall
- `kernelctl` - 0.1-6 (#691)
  - Reset to the default kernel on uninstall so that `toltecctl uninstall` will return the device to a stock state
- `restream` - 1.2-1 (#688)
- `fbink`, `fbdepth`, and `fbink-doom` - 1.25.0-1 (#687)

**Note:** This doesn't change what OS version that toltec supports, as full support still requires `ddvk-hacks` to be updated, and for proper testing of various other packages.