### PR TITLE
Add valgrind

### DIFF
--- a/package/valgrind/package
+++ b/package/valgrind/package
@@ -12,15 +12,14 @@ image=base:v2.3
 makedepends=(build:gawk build:automake)
 
 build() {
-    ./autogen.sh
-    ./configure --prefix=/opt --host=arm-linux-gnueabihf
-    sed -i -e "s#armv7#arm#g" configure
+    export CC=arm-linux-gnueabihf-gcc
+    ./autogen.sh --host armv7-linux-gnueabihf
+    ./configure --prefix=/opt --host=armv7-linux-gnueabihf --target=armv7-linux-gnueabihf
     make
+    mkdir -p out
+    make DESTDIR=$(pwd)/out install
 }
 
 package() {
-    cd "$srcdir"
-    # Work around make install not creating this directory
-    mkdir -p "$pkgdir"/opt/libexec/valgrind
-    make DESTDIR="$pkgdir" install
+    mv "$srcdir"/out/opt "$pkgdir"/
 }

--- a/package/valgrind/package
+++ b/package/valgrind/package
@@ -5,11 +5,11 @@ pkgver="3.21.0-1"
 timestamp="2023-04-28T02:49:00Z"
 maintainer="Eeems <eeems@eeems.email>"
 url=https://valgrind.org
-license=MIT
+license=GPL-2.0-only
 source=(https://sourceware.org/pub/valgrind/valgrind-3.21.0.tar.bz2)
 sha256sums=(10ce1618bb3e33fad16eb79552b0a3e1211762448a0d7fce11c8a6243b9ac971)
 image=base:v2.3
-makedepends=(build:automake)
+makedepends=(build:gawk build:automake)
 
 build() {
     ./autogen.sh
@@ -19,7 +19,7 @@ build() {
 
 package() {
     cd "$srcdir"
-    # Work around the make install not creating this directory
+    # Work around make install not creating this directory
     mkdir -p "$pkgdir"/opt/libexec/valgrind
     make DESTDIR="$pkgdir" install
 }

--- a/package/valgrind/package
+++ b/package/valgrind/package
@@ -1,0 +1,25 @@
+pkgnames=(valgrind)
+pkgdesc="Instrumentation framework for building dynamic analysis tools"
+section="devel"
+pkgver="3.21-1"
+timestamp="2023-04-28T02:49:00Z"
+maintainer="Eeems <eeems@eeems.email>"
+url=https://valgrind.org
+license=MIT
+source=(https://sourceware.org/pub/valgrind/valgrind-3.21.0.tar.bz2)
+sha256sums=(10ce1618bb3e33fad16eb79552b0a3e1211762448a0d7fce11c8a6243b9ac971)
+image=base:v2.3
+makedepends=(build:automake)
+
+build() {
+    ./autogen.sh
+    ./configure --prefix=/opt
+    make
+}
+
+package() {
+    cd "$srcdir"
+    # Work around the make install not creating this directory
+    mkdir -p "$pkgdir"/opt/libexec/valgrind
+    make DESTDIR="$pkgdir" install
+}

--- a/package/valgrind/package
+++ b/package/valgrind/package
@@ -14,6 +14,7 @@ makedepends=(build:gawk build:automake)
 build() {
     ./autogen.sh
     ./configure --prefix=/opt --host=arm-linux-gnueabihf
+    sed -i -e "s#armv7#arm#g" configure
     make
 }
 

--- a/package/valgrind/package
+++ b/package/valgrind/package
@@ -1,7 +1,7 @@
 pkgnames=(valgrind)
 pkgdesc="Instrumentation framework for building dynamic analysis tools"
 section="devel"
-pkgver="3.21-1"
+pkgver="3.21.0-1"
 timestamp="2023-04-28T02:49:00Z"
 maintainer="Eeems <eeems@eeems.email>"
 url=https://valgrind.org

--- a/package/valgrind/package
+++ b/package/valgrind/package
@@ -13,7 +13,7 @@ makedepends=(build:gawk build:automake)
 
 build() {
     ./autogen.sh
-    ./configure --prefix=/opt
+    ./configure --prefix=/opt --host=arm-linux-gnueabihf
     make
 }
 


### PR DESCRIPTION
Entware already contains valgrind, but it's not really useful for things built targeting the reMarkable instead of generic entware. It also appears to be missing some tools.

This does mean that we have a name conflict with the packages. I'm tempted to rename it to `toltec-valgrind` or `remarkable-valgrind` and mark it as conflicting with valgrind. Thoughts?