### PR TITLE
Stable merge for week 30 of 2023

### DIFF
--- a/package/7zip/package
+++ b/package/7zip/package
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+pkgnames=(7zip)
+pkgdesc="A file archiver with a high compression ratio."
+url="https://www.7-zip.org/"
+section="util"
+pkgver=22.01-1
+timestamp=2022-07-15T00:00:00Z
+maintainer="Eeems <eeems@eeems.email>"
+license=LGPL-2.1-or-later
+source=(
+    https://www.7-zip.org/a/7z2201-linux-arm.tar.xz
+)
+sha256sums=(
+    428c11efd91fe1809c4750e8cd5d6eddfbed2826d8a5399ffcacb849f0d21cf8
+)
+
+package() {
+    install -dm 755 "$pkgdir"/opt/usr/share/licenses/7zip
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/7zz
+    cp -dr --no-preserve='ownership' "$srcdir"/License.txt "$pkgdir"/opt/usr/share/licenses/7zip
+}

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2023.04-1
-timestamp=2023-04-27T20:53:54Z
+pkgver=2023.05.1-1
+timestamp=2023-06-02T13:05:01Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    7149beb95ee561c488491d723acbb2c641c99733abc1036de7064241a5f32813
+    1eadd87717ff1ee9fe91a2986198d64b871bf2e9b2412ae0add1d5ca66dd81f1
     SKIP
     SKIP
     SKIP

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2023.05.1-1
-timestamp=2023-06-02T13:05:01Z
+pkgver=2023.06.1-1
+timestamp=2023-07-09T08:17:26Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -21,7 +21,7 @@ source=(
     koreader
 )
 sha256sums=(
-    1eadd87717ff1ee9fe91a2986198d64b871bf2e9b2412ae0add1d5ca66dd81f1
+    a24f334983060b5cfee7b87484529b77fe4adffd646e8fd55447750e73309ef0
     SKIP
     SKIP
     SKIP

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 pkgnames=(erode fret oxide rot tarnish decay corrupt anxiety liboxide libsentry notify-send)
-pkgver=2.5-1
+pkgver=2.5-2
 _sentryver=0.5.0
 timestamp=2023-01-26T22:52:14Z
 maintainer="Eeems <eeems@eeems.email>"
@@ -13,7 +13,7 @@ flags=(patch_rm2fb)
 image=qt:v2.3
 source=(
     "https://github.com/Eeems-Org/oxide/archive/refs/tags/v2.5.zip"
-    toltec-override.conf
+    toltec-rm2-override.conf
 )
 sha256sums=(
     07bfb84e5adaebdebd2ce55b22f3764a1d4887c2b18364f5ec1053f171e3ecbe
@@ -90,8 +90,10 @@ tarnish() {
         install -D -m 644 -t "$pkgdir"/etc/dbus-1/system.d "$srcdir"/release/etc/dbus-1/system.d/codes.eeems.oxide.conf
         install -D -m 644 -t "$pkgdir"/lib/systemd/system "$srcdir"/release/etc/systemd/system/tarnish.service
         install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/release/opt/bin/tarnish
-        install -D -m 644 -t "$pkgdir"/etc/systemd/system/tarnish.service.d \
-            "$srcdir"/toltec-override.conf
+        if [[ $arch = rm2 ]]; then
+            install -D -m 644 -t "$pkgdir"/etc/systemd/system/tarnish.service.d \
+                "$srcdir"/toltec-rm2-override.conf
+        fi
     }
     configure() {
         systemctl daemon-reload

--- a/package/oxide/toltec-override.conf
+++ b/package/oxide/toltec-override.conf
@@ -1,6 +1,0 @@
-# Copyright (c) 2021 The Toltec Contributors
-# SPDX-License-Identifier: MIT
-
-[Unit]
-Conflicts=xochitl.service
-Conflicts=sync.service

--- a/package/oxide/toltec-rm2-override.conf
+++ b/package/oxide/toltec-rm2-override.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+[Unit]
+After=rm2fb.service
+Requires=rm2fb.service
+OnFailure=xochitl.service

--- a/package/plato/package
+++ b/package/plato/package
@@ -5,32 +5,31 @@
 pkgnames=(plato)
 pkgdesc="Document reader"
 url=https://github.com/LinusCDE/plato
-pkgver=0.9.25-2
-timestamp=2022-02-08T23:54Z
+pkgver=0.9.34-1
+timestamp=2023-03-08T17:58Z
 section="readers"
 maintainer="Linus K. <linus@cosmos-ink.net>"
 license=AGPL-3.0-or-later
 installdepends=(display jq)
-makedepends=(build:jq build:unzip build:wget)
+makedepends=(build:jq build:unzip build:wget build:patchelf)
 flags=(patch_rm2fb)
 
-image=rust:v2.2.2
-source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-12.zip")
-sha256sums=(42e18e882e7e6853e299234a44eea9b9e3c4170076eec0577a0644dcf7005cf9)
+image=rust:v2.3.1
+source=("https://github.com/LinusCDE/plato/archive/${pkgver%-*}-rm-release-13.zip")
+sha256sums=(82ef5786704ecdb4fe11ce16e7e4ae10b518a592965c292977bb33962c891d48)
 
 build() {
-    # Fall back to system-wide config
-    rm .cargo/config
-
     # 'cargo pkgid' seems to output something different with most
     # recent nightly builds. This adjusts the filtering.
-    sed -i "s/version=.*$/version=\'$(cargo pkgid | cut -d "#" -f 2 | cut -d ":" -f 2)\'/g" download.sh
+    sed -i "s/version=.*$/version=\'$(cargo pkgid -p plato | cut -d "#" -f 2 | cut -d ":" -f 2)\'/g" download.sh
+
+    # Temporary fix until next release (TODO: Remove for next released version as included with commit fbfaf3d7)
+    sed -i "s/--target=arm-unknown-linux-gnueabihf/--target=armv7-unknown-linux-gnueabihf/g" build.sh
 
     # Use our toolchain
     export AR=arm-linux-gnueabihf-ar
     export CC=arm-linux-gnueabihf-gcc
     export STRIP=arm-linux-gnueabihf-strip
-    sed -i '/source \/usr\/local\/oecore-x86_64/d' src/mupdf_wrapper/build-kobo.sh
 
     # Compile all to dist/
     ./clean.sh

--- a/package/rmfm/package
+++ b/package/rmfm/package
@@ -4,8 +4,8 @@
 
 pkgnames=(rmfm)
 pkgdesc="Bare-bones file manager using Node.js and sas"
-url="https://codeberg.org/sun/rmFM"
-pkgver=1.4.0-2
+url="https://forgejo.sny.sh/sun/rmFM"
+pkgver=1.4.0-3
 timestamp=2022-08-19T11:20:10+02:00
 section=utils
 maintainer="Sunny <roesch.eric@protonmail.com>"
@@ -13,7 +13,7 @@ license=MIT
 installdepends=(node simple)
 
 source=(
-    https://codeberg.org/sun/rmFM/archive/1.4.0.zip
+    https://forgejo.sny.sh/sun/rmFM/archive/1.4.0.zip
     path_fix.patch
 )
 sha256sums=(

--- a/package/tailscale-systemd/package
+++ b/package/tailscale-systemd/package
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(tailscale-systemd)
+pkgdesc="SystemD configuration for tailscale"
+url=https://tailscale.com
+pkgver=0.0.0-1
+section="utils"
+timestamp=2023-07-12T00:00Z
+maintainer="Kai <z@kwi.li>"
+license="BSD 3-Clause"
+installdepends=(tailscale)
+
+source=(
+    tailscaled.service
+)
+sha256sums=(
+    SKIP
+)
+
+package() {
+    install -D -m 644 -t "$pkgdir"/etc/systemd/system "$srcdir"/tailscaled.service
+}
+
+configure() {
+    systemctl daemon-reload
+    systemctl enable tailscaled
+    systemctl start tailscaled
+}
+
+preremove() {
+    if is-active tailscaled; then
+        echo "Stopping tailscaled"
+        systemctl stop tailscaled
+    fi
+
+    if is-enabled tailscaled; then
+        echo "Disabling tailscaled"
+        systemctl disable tailscaled
+    fi
+}
+
+postremove() {
+    systemctl daemon-reload
+}

--- a/package/tailscale-systemd/tailscaled.service
+++ b/package/tailscale-systemd/tailscaled.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Tailscale node agent
+Documentation=https://tailscale.com/kb/
+Wants=network-pre.target
+After=network-pre.target
+
+[Service]
+Environment="HOME=/home/root"
+ExecStartPre=/opt/bin/tailscaled --cleanup
+ExecStart=/opt/bin/tailscaled --state=/opt/var/lib/tailscale/tailscaled.state --socket=/opt/var/run/tailscale/tailscaled.sock --tun=userspace-networking --socks5-server=localhost:1055 --outbound-http-proxy-listen=localhost:1055
+ExecStopPost=/opt/bin/tailscaled --cleanup
+
+Restart=on-failure
+
+RuntimeDirectory=tailscale
+RuntimeDirectoryMode=0755
+StateDirectory=tailscale
+StateDirectoryMode=0700
+CacheDirectory=tailscale
+CacheDirectoryMode=0750
+Type=notify
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
### New Packages
- `tailscale-systemd` - 0.0.0-1 (#706)
  - Necessary configuration for tailscale to work on the reMarkable
- `7zip` - 22.01-1 (#699)

### Updated Packages
- `koreader` - 2023.06-1 (#696 #705)
- `plato` - 0.9.34-1 (#669)
- `erode` `fret` `oxide` `rot` `tarnish` `decay` `corrupt` `anxiety` `liboxide` `notify-send` - 2.5-2 (#697)
  - Remove rm2fb runtime dependency for reMarkable 1 devices