### PR TITLE
Add note about toltecmk to docs/building.md

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -1,7 +1,7 @@
 ## Building the Repository from Source
 
 The Toltec repository is automatically built for each commit on the `stable` and `testing` branches.
-You may want to build the repository locally when working with a new package recipe or to make sure that nobody tampered with the automated build system.
+You may want to build the repository locally when working with a new package recipe or to make sure that nobody tampered with the automated build system. [Toltecmk](https://github.com/toltec-dev/build) could also be used instead, if you just need to compile a single standalone package.
 
 To proceed, create a local clone of the Git repository.
 


### PR DESCRIPTION
Several people have found this before toltecmk and spent a bunch of time trying to get dependencies working, when toltecmk would have served their requirements better.