### PR TITLE
Update toltecctl to fix uninstalling error

### DIFF
--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,8 +5,8 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Manage your Toltec install"
 url=https://toltec-dev.org/
-pkgver=0.2.2-1
-timestamp=2022-02-28T00:12Z
+pkgver=0.2.1-1
+timestamp=2023-09-17T17:35Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,7 +5,7 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Manage your Toltec install"
 url=https://toltec-dev.org/
-pkgver=0.2.1-1
+pkgver=0.2.3-1
 timestamp=2023-09-17T17:35Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/toltec-bootstrap/toltecctl
+++ b/package/toltec-bootstrap/toltecctl
@@ -153,7 +153,7 @@ reinstall-root() {
     while read -r pkgname; do
         if [[ -v "on_root_packages[$pkgname]" ]]; then
             reinstall_packages[$pkgname]=1
-        fi
+        fipython -m nuitka hello.py --include-module=encodings --standalone
     done < <(gunzip -c /opt/var/opkg-lists/* | grep "^Package:" | awk '{print $2}')
 
     # Workaround: Checking the size of an empty array when the nounset option
@@ -161,7 +161,7 @@ reinstall-root() {
     # temporarily
     set +u
     if [[ ${#reinstall_packages[@]} -ne 0 ]]; then
-        opkg install --force-reinstall --force-remove "${!reinstall_packages[@]}"
+        opkg install --force-reinstall --force-removal-of-essential-packages --force-remove "${!reinstall_packages[@]}"
     else
         echo "No package needs to be reinstalled"
     fi

--- a/package/toltec-bootstrap/toltecctl
+++ b/package/toltec-bootstrap/toltecctl
@@ -161,7 +161,7 @@ reinstall-root() {
     # temporarily
     set +u
     if [[ ${#reinstall_packages[@]} -ne 0 ]]; then
-        opkg install --force-reinstall --force-removal-of-essential-packages --force-remove "${!reinstall_packages[@]}"
+        opkg install --force-reinstall --force-remove "${!reinstall_packages[@]}"
     else
         echo "No package needs to be reinstalled"
     fi
@@ -338,7 +338,7 @@ uninstall() {
 
     # Remove installed packages in reverse dependency order
     list-installed-ordered | while read -r pkgname; do
-        "$opkg_path" remove --force-depends --force-remove "$pkgname"
+        "$opkg_path" remove --force-removal-of-essential-packages --force-depends --force-remove "$pkgname"
     done
 
     systemctl daemon-reload

--- a/package/toltec-bootstrap/toltecctl
+++ b/package/toltec-bootstrap/toltecctl
@@ -153,7 +153,7 @@ reinstall-root() {
     while read -r pkgname; do
         if [[ -v "on_root_packages[$pkgname]" ]]; then
             reinstall_packages[$pkgname]=1
-        fipython -m nuitka hello.py --include-module=encodings --standalone
+        fi
     done < <(gunzip -c /opt/var/opkg-lists/* | grep "^Package:" | awk '{print $2}')
 
     # Workaround: Checking the size of an empty array when the nounset option


### PR DESCRIPTION
This fixes
```
reMarkable: ~/ toltecctl uninstall
This will wipe out all files in '/opt'. Continue? [y/N] y
2023-09-13 18:53:42 URL:https://bin.entware.net/armv7sf-k3.2/installer/opkg [752476/752476] -> "/home/root/.local/bin/opkg" [1]
Removing package autoconf from root...
Refusing to remove essential package busybox.
    Removing an essential package may lead to an unusable system, but if
    you enjoy that kind of pain, you can force opkg to proceed against
    its will with the option: --force-removal-of-essential-packages
```