### PR TITLE
rmfm: Update to 1.5.0

### DIFF
--- a/package/rmfm/package
+++ b/package/rmfm/package
@@ -5,25 +5,24 @@
 pkgnames=(rmfm)
 pkgdesc="Bare-bones file manager using Node.js and sas"
 url="https://forgejo.sny.sh/sun/rmFM"
-pkgver=1.4.0-3
-timestamp=2022-08-19T11:20:10+02:00
+pkgver=1.5.0-1
+timestamp=2023-08-08T22:19:23+02:00
 section=utils
-maintainer="Sunny <roesch.eric@protonmail.com>"
-license=MIT
+maintainer="Sunny <sunny@sny.sh>"
+license=Unlicense
 installdepends=(node simple)
 
 source=(
-    https://forgejo.sny.sh/sun/rmFM/archive/1.4.0.zip
+    https://forgejo.sny.sh/sun/rmFM/archive/1.5.0.zip
     path_fix.patch
 )
 sha256sums=(
-    28ce80c67fecc370d11f3fe2069742c2789b388a9426fff49d269d7900ae3dc9
+    515cc1843bf61f628c3a0b2b2dcb3256a0182352c6b491585fd52cf96a554b26
     SKIP
 )
 
 prepare() {
-    # Assume node to be in /opt/bin and add that directory
-    # to the path of the app to allow finding simple
+    # Assume node to be in /opt/bin
     # This is a temporary fix for not working in remux
     patch -d "$srcdir" < "$srcdir"/path_fix.patch
 }

--- a/package/rmfm/path_fix.patch
+++ b/package/rmfm/path_fix.patch
@@ -1,9 +1,7 @@
 diff --git a/rmfm b/rmfm
-index 4571db9..172eedf 100755
+index 63eeb98..b28dbd0 100755
 --- a/rmfm
 +++ b/rmfm
-@@ -1,2 +1,3 @@
+@@ -1 +1 @@
 -#!/usr/bin/env node
 +#!/opt/bin/node
-+process.env.PATH += ":/opt/bin"
- 


### PR DESCRIPTION
Changelog:

- Fixed reloading in a deleted directory resulting in a crash
- Append /opt/bin to PATH if not already included[^1]
- The installation instructions, license and e-mail address were updated/changed

Commits/diff: https://forgejo.sny.sh/sun/rmFM/compare/1.4.0...1.5.0

[^1]: I also updated path_fix.patch accordingly