### PR TITLE
Update webinterface-wifi to v2.0.0

### DIFF
--- a/package/webinterface-wifi/package
+++ b/package/webinterface-wifi/package
@@ -18,12 +18,12 @@ _configdir="/home/root/.config/$_pkgname"
 _etcdir="/opt/etc/$_pkgname"
 
 source=(
-    "$url/archive/feb573ac5f16a75d3d7ce66b3957d5c753ad5561.zip"
+    "$url/archive/4513d5cbc5e323f2959987f3bc9e300b0aaddb19.zip"
     "$_pkgname-toltec.service"
 )
 
 sha256sums=(
-    516f4c1684b8d50fc8c9c63a7f11f3183b259ba52243b719a73a56519dc45947
+    a23c05faf4ccaafea9222255399c8c3a121079dd07970c8768b4315606eb7834
     SKIP
 )
 

--- a/package/webinterface-wifi/package
+++ b/package/webinterface-wifi/package
@@ -57,6 +57,11 @@ configure() {
 
     systemctl daemon-reload
 
+    if is-active "$pkgname"; then
+        echo "Restarting $pkgname"
+        systemctl restart "$pkgname"
+    fi
+
     echo ""
     echo "Run '\$ $pkgname' for usage information and a link to"
     echo "the documentation. You can also find the documentation locally"

--- a/package/webinterface-wifi/package
+++ b/package/webinterface-wifi/package
@@ -7,7 +7,7 @@ pkgnames=("$_pkgname")
 pkgdesc="View the web interface if running, over wifi"
 url="https://github.com/rM-self-serve/$_pkgname"
 pkgver=2.0.0-1
-timestamp=2023-11-26T12:23:17Z
+timestamp=2023-11-26T00:02:11Z
 section="utils"
 maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
@@ -18,12 +18,12 @@ _configdir="/home/root/.config/$_pkgname"
 _etcdir="/opt/etc/$_pkgname"
 
 source=(
-    "$url/archive/d2d93b3bd8cf970e7a14a7517efe6c3c322ba356.zip"
+    "$url/archive/feb573ac5f16a75d3d7ce66b3957d5c753ad5561.zip"
     "$_pkgname-toltec.service"
 )
 
 sha256sums=(
-    92c8d84e51a57704bbcb9fe21df9a173b7b55533c3ced83d835023ac1858bf99
+    516f4c1684b8d50fc8c9c63a7f11f3183b259ba52243b719a73a56519dc45947
     SKIP
 )
 
@@ -58,8 +58,9 @@ configure() {
     systemctl daemon-reload
 
     echo ""
-    echo "Run the following command to use $pkgname"
-    how-to-enable "$pkgname.service"
+    echo "Run '\$ $pkgname' for usage information and a link to"
+    echo "the documentation. You can also find the documentation locally"
+    echo "at /opt/etc/webinterface-wifi/docs/"
 }
 
 preremove() {

--- a/package/webinterface-wifi/package
+++ b/package/webinterface-wifi/package
@@ -2,38 +2,59 @@
 # Copyright (c) 2020 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-pkgnames=(webinterface-wifi)
+_pkgname="webinterface-wifi"
+pkgnames=("$_pkgname")
 pkgdesc="View the web interface if running, over wifi"
-url="https://github.com/rM-self-serve/webinterface-wifi"
-pkgver=1.0.2-1
-timestamp=2023-02-06T12:23:17Z
+url="https://github.com/rM-self-serve/$_pkgname"
+pkgver=2.0.0-1
+timestamp=2023-11-26T12:23:17Z
 section="utils"
 maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
+image=rust:v3.1
 
-image=rust:v2.3
+_pkgalias="webint-wifi"
+_configdir="/home/root/.config/$_pkgname"
+_etcdir="/opt/etc/$_pkgname"
 
 source=(
-    https://github.com/rM-self-serve/webinterface-wifi/archive/2e29855303a0806ee51e71bc836bc4b16204fa14.zip
-    webinterface-wifi-toltec.service
+    "$url/archive/d2d93b3bd8cf970e7a14a7517efe6c3c322ba356.zip"
+    "$_pkgname-toltec.service"
 )
 
 sha256sums=(
-    629bab244a387086ce2a8f8118b8d1017cf993bf97b13da72573f52572ed526e
+    92c8d84e51a57704bbcb9fe21df9a173b7b55533c3ced83d835023ac1858bf99
     SKIP
 )
 
 build() {
-    RUSTFLAGS="-Zcrate-attr=feature(const_fn_trait_bound)" cargo build --release
+    WIW_DATADIR="/opt/etc" cargo build --release
 }
 
 package() {
-    install -D -m 755 -t "$pkgdir"/opt/bin \
-        "$srcdir"/target/armv7-unknown-linux-gnueabihf/release/webinterface-wifi
-    install -D -m 644 "$srcdir"/webinterface-wifi-toltec.service "$pkgdir"/lib/systemd/system/webinterface-wifi.service
+    install -D -m 755 -t "$pkgdir/opt/bin" \
+        "$srcdir/target/armv7-unknown-linux-gnueabihf/release/$_pkgname"
+    ln -s "/opt/bin/$_pkgname" "$pkgdir/opt/bin/$_pkgalias"
+
+    install -D -m 644 "$srcdir/$_pkgname-toltec.service" \
+        "$pkgdir/lib/systemd/system/$_pkgname.service"
+
+    install -D -m 644 -t "$pkgdir""$_etcdir/docs" \
+        "$srcdir/README.MD" "$srcdir"/config/*.toml
+    install -D -m 644 -t "$pkgdir""$_etcdir/docs/config_examples" \
+        "$srcdir"/config/examples/*.toml
+    install -D -m 644 -t "$pkgdir""$_etcdir"/assets \
+        "$srcdir/assets/favicon.ico"
+    install -d "$pkgdir""$_etcdir/ssl" \
+        "$pkgdir""$_etcdir/auth" \
+        "$pkgdir""$_configdir"
 }
 
 configure() {
+    [[ -f "$_configdir/config.toml" ]] \
+        || cp "$_etcdir/docs/config.default.toml" \
+            "$_configdir/config.toml"
+
     systemctl daemon-reload
 
     echo ""
@@ -53,5 +74,6 @@ preremove() {
 }
 
 postremove() {
+    rmdir "$_etcdir"/*/* "$_etcdir"/* "$_etcdir" 2> /dev/null || true
     systemctl daemon-reload
 }

--- a/package/webinterface-wifi/package
+++ b/package/webinterface-wifi/package
@@ -61,6 +61,9 @@ configure() {
     echo "Run '\$ $pkgname' for usage information and a link to"
     echo "the documentation. You can also find the documentation locally"
     echo "at /opt/etc/webinterface-wifi/docs/"
+    echo ""
+    echo "Run the following command to use $pkgname"
+    how-to-enable "$pkgname.service"
 }
 
 preremove() {

--- a/package/webinterface-wifi/webinterface-wifi-toltec.service
+++ b/package/webinterface-wifi/webinterface-wifi-toltec.service
@@ -5,9 +5,10 @@ StartLimitBurst=4
 After=home.mount
 
 [Service]
-Environment=HOME=/home/root
 Type=simple
-ExecStart=/opt/bin/webinterface-wifi --run 80
+Environment=HOME=/home/root
+Environment=WEBINT_WIFI_RUN_ENV=DAEMON
+ExecStart=/opt/bin/webinterface-wifi local-exec
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
[Release Notes v2.0.0](https://github.com/rM-self-serve/webinterface-wifi/releases/tag/v2.0.0)
[Docs](https://github.com/rM-self-serve/webinterface-wifi)

Quite a bit of new functionality. 

Should work on all devices+versions.

For anyone testing this, there are [test ssl certs in the repository](https://github.com/toltec-dev/toltec/pull/github.com/rM-self-serve/webinterface-wifi/tree/master/ssl_test_cert). It is necessary the wifi is connected and the web interface is accessible at 10.11.99.1. The following tests should suffice.

---
```
$ webint-wifi net-info
# ensure the wifi ssid is correct 
```
---
```
$ systemctl start webinterface-wifi
```
```
$ webint-wifi create-login
# enter a username/password 
```
```
$ webint-wifi edit
# change [undefined_networks].login_enforced to true
```
```
$ webint-wifi reload
```
Then navigate to the wifi ip address in a browser, enter the credentials, and download a file. 



