### PR TITLE
Add package webinterface-onboot v1.2.2

### DIFF
--- a/package/webinterface-onboot/package
+++ b/package/webinterface-onboot/package
@@ -13,8 +13,6 @@ maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
 conflicts=(ddvk-hacks)
 
-_pkgalias="webint-onboot"
-
 source=(
     "$url"/archive/cdfe457435974f7ca309b1ac50f1b2ef67000813.zip
     "$_pkgname-toltec.service"
@@ -28,6 +26,9 @@ package() {
     install -D -m 755 -t "$pkgdir/opt/bin" "$srcdir/$_pkgname"
     install -D -m 644 "$srcdir/$_pkgname-toltec.service" \
         "$pkgdir/lib/systemd/system/$_pkgname.service"
+
+    touch "$srcdir"/emptyfile
+    install -D -m 666 -t "$pkgdir"/usr/share/toltec/reenable.d/"$_pkgname" "$srcdir"/emptyfile
 }
 
 configure() {
@@ -37,7 +38,7 @@ configure() {
     echo "Applying usb0 ip persistence"
     webinterface-onboot apply-prstip -y > /dev/null
     echo "Success"
-    if webinterface-onboot is-hack-vers > /dev/null; then
+    if webinterface-onboot is-hack-version > /dev/null; then
         echo
         echo "Applying binary modification"
         webinterface-onboot apply-hack -y > /dev/null

--- a/package/webinterface-onboot/package
+++ b/package/webinterface-onboot/package
@@ -4,53 +4,89 @@
 
 _pkgname='webinterface-onboot'
 pkgnames=("$_pkgname")
-pkgdesc="Start the web interface without the cable"
+pkgdesc="Start the web interface without the cable, on boot."
 url="https://github.com/rM-self-serve/$_pkgname"
 pkgver=1.2.2-1
 timestamp=2023-12-03T11:43:00Z
 section="utils"
 maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
+conflicts=(ddvk-hacks)
 
 _pkgalias="webint-onboot"
 
 source=(
-    "$url"/archive/cbb2b936f0d27898701695f4d166dcf01b0174e2.zip
+    "$url"/archive/cdfe457435974f7ca309b1ac50f1b2ef67000813.zip
     "$_pkgname-toltec.service"
 )
 sha256sums=(
-    053de1cb3c889df844f6c3e9ce1947803663a13b5efd3bd376a1937c0d1c3787
+    bad965b923fa0979e7c8b97f6a90a400300ef8461292276e6fa2107a89624c8b
     SKIP
 )
 
 package() {
     install -D -m 755 -t "$pkgdir/opt/bin" "$srcdir/$_pkgname"
-    ln -s "/opt/bin/$_pkgname" "$pkgdir/opt/bin/$_pkgalias"
+    install -D -m 644 "$srcdir/$_pkgname-toltec.service" \
+        "$pkgdir/lib/systemd/system/$_pkgname.service"
+}
+
+configure() {
+    systemctl daemon-reload
+
+    echo
+    echo "Applying usb0 ip persistence"
+    webinterface-onboot apply-prstip -y > /dev/null
+    echo "Success"
+    if webinterface-onboot is-hack-vers > /dev/null; then
+        echo
+        echo "Applying binary modification"
+        webinterface-onboot apply-hack -y > /dev/null
+        echo "Success"
+    fi
+
+    echo
+    echo "Run the following command to use $pkgname"
+    how-to-enable "$pkgname.service"
+    echo
+    echo "Then restart xochitl or the device"
 }
 
 _restore() {
-    if webinterface-onboot is-hack-applied > /dev/null 2>&1; then
-        echo "Reverting /usr/bin/xochitl"
-        if ! webinterface-onboot revert-hack --backup -y > /dev/null 2>&1; then
-            if ! webinterface-onboot revert-hack --reverse -y > /dev/null 2>&1; then
-                echo "Could not revert /usr/bin/xochitl"
-            fi
-        fi
+    if webinterface-onboot is-prstip-applied > /dev/null; then
+        echo
+        echo "Reverting usb0 ip persistence"
+        webinterface-onboot revert-prstip -y > /dev/null
         echo "Success"
     fi
-    if webinterface-onboot is-prstip-applied > /dev/null 2>&1; then
-        echo "Reverting /etc/ifplugd/ifplugd.action"
-        if ! webinterface-onboot revert-prstip -y > /dev/null 2>&1; then
-            echo "Could not revert /etc/ifplugd/ifplugd.action"
+
+    if webinterface-onboot is-hack-applied > /dev/null; then
+        echo
+        echo "Reverting binary modification"
+        if webinterface-onboot has-backup > /dev/null; then
+            webinterface-onboot revert-hack --backup -y > /dev/null
+        else
+            webinterface-onboot revert-hack --reverse -y > /dev/null
         fi
         echo "Success"
     fi
 }
 
 preremove() {
+    if is-active "$pkgname"; then
+        echo "Stopping $pkgname"
+        systemctl stop "$pkgname"
+    fi
+    if is-enabled "$pkgname"; then
+        echo "Disabling $pkgname"
+        systemctl disable "$pkgname"
+    fi
     _restore
 }
 
 preupgrade() {
     _restore
+}
+
+postremove() {
+    systemctl daemon-reload
 }

--- a/package/webinterface-onboot/package
+++ b/package/webinterface-onboot/package
@@ -29,18 +29,18 @@ package() {
 }
 
 _restore() {
-    if webinterface-onboot is-hack-applied >/dev/null 2>&1; then
+    if webinterface-onboot is-hack-applied > /dev/null 2>&1; then
         echo "Reverting /usr/bin/xochitl"
-        if ! webinterface-onboot revert-hack --backup -y >/dev/null 2>&1; then
-            if ! webinterface-onboot revert-hack --reverse -y >/dev/null 2>&1; then
+        if ! webinterface-onboot revert-hack --backup -y > /dev/null 2>&1; then
+            if ! webinterface-onboot revert-hack --reverse -y > /dev/null 2>&1; then
                 echo "Could not revert /usr/bin/xochitl"
             fi
         fi
         echo "Success"
     fi
-    if webinterface-onboot is-prstip-applied >/dev/null 2>&1; then
+    if webinterface-onboot is-prstip-applied > /dev/null 2>&1; then
         echo "Reverting /etc/ifplugd/ifplugd.action"
-        if ! webinterface-onboot revert-prstip -y >/dev/null 2>&1; then
+        if ! webinterface-onboot revert-prstip -y > /dev/null 2>&1; then
             echo "Could not revert /etc/ifplugd/ifplugd.action"
         fi
         echo "Success"

--- a/package/webinterface-onboot/package
+++ b/package/webinterface-onboot/package
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+_pkgname='webinterface-onboot'
+pkgnames=("$_pkgname")
+pkgdesc="Start the web interface without the cable"
+url="https://github.com/rM-self-serve/$_pkgname"
+pkgver=1.2.2-1
+timestamp=2023-12-03T11:43:00Z
+section="utils"
+maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
+license=MIT
+
+_pkgalias="webint-onboot"
+
+source=(
+    "$url"/archive/cbb2b936f0d27898701695f4d166dcf01b0174e2.zip
+    "$_pkgname-toltec.service"
+)
+sha256sums=(
+    053de1cb3c889df844f6c3e9ce1947803663a13b5efd3bd376a1937c0d1c3787
+    SKIP
+)
+
+package() {
+    install -D -m 755 -t "$pkgdir/opt/bin" "$srcdir/$_pkgname"
+    ln -s "/opt/bin/$_pkgname" "$pkgdir/opt/bin/$_pkgalias"
+}
+
+_restore() {
+    if webinterface-onboot is-hack-applied >/dev/null 2>&1; then
+        echo "Reverting /usr/bin/xochitl"
+        if ! webinterface-onboot revert-hack --backup -y >/dev/null 2>&1; then
+            if ! webinterface-onboot revert-hack --reverse -y >/dev/null 2>&1; then
+                echo "Could not revert /usr/bin/xochitl"
+            fi
+        fi
+        echo "Success"
+    fi
+    if webinterface-onboot is-prstip-applied >/dev/null 2>&1; then
+        echo "Reverting /etc/ifplugd/ifplugd.action"
+        if ! webinterface-onboot revert-prstip -y >/dev/null 2>&1; then
+            echo "Could not revert /etc/ifplugd/ifplugd.action"
+        fi
+        echo "Success"
+    fi
+}
+
+preremove() {
+    _restore
+}
+
+preupgrade() {
+    _restore
+}

--- a/package/webinterface-onboot/webinterface-onboot-toltec.service
+++ b/package/webinterface-onboot/webinterface-onboot-toltec.service
@@ -7,7 +7,7 @@ After=home.mount
 [Service]
 Environment=HOME=/home/root
 Type=oneshot
-ExecStart=/home/root/.local/bin/webinterface-onboot local-exec
+ExecStart=/opt/bin/webinterface-onboot local-exec
 
 [Install]
 WantedBy=multi-user.target

--- a/package/webinterface-onboot/webinterface-onboot-toltec.service
+++ b/package/webinterface-onboot/webinterface-onboot-toltec.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Enable the web interface on boot
+StartLimitIntervalSec=600
+StartLimitBurst=4
+After=home.mount
+
+[Service]
+Environment=HOME=/home/root
+Type=oneshot
+ExecStart=/home/root/.local/bin/webinterface-onboot local-exec
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
[Release Notes v1.2.2](https://github.com/rM-self-serve/webinterface-onboot/releases/tag/v1.2.2)
[Docs](https://github.com/rM-self-serve/webinterface-onboot/)

This program will start the web interface without the usb cable being plugged in. It can also keep the web interface accessible after unplugging the usb cable.

I am the author of this software. This should work on all devices+versions.

Has been verified on both devices up until v3.3 and the rM1 until v3.8, though the relevant part of both xochitl binaries seem the same. 

If applying other binary modifications such as [rM-hacks](https://github.com/mb1986/rm-hacks) or [ddvk's hacks](https://github.com/ddvk/remarkable-hacks), they will fail if webint-onboot has been applied. Thus, it is necessary to apply webint-onboot after applying the other modifications. If reverting other binary modifications after webint-onboot has been applied, it is necessary to revert webint-onboot before reverting these modifications.

webint-onboot will ensure the modifications are possible before performing them by checking for the "guilty" strings rather than a shasum. It will attempt to revert the modifications when uninstalled, if they are applied.

---

How it works:

Before xochitl starts:
- set WebInterfaceEnabled=true in /home/root/.config/remarkable/xochitl.conf
- give the usb0 network interface the ip address 10.11.99.1/32

For versions >= 2.15:
Requires simple binary hack.

In xochitl:
- change the string 'usb0' to 'usbF'
- change the string 'usb1' to 'usb0'

---

It also has built in functionality to keep the web interface accessible after unplugging the usb cord. 
Add the following line to /etc/ifplugd/ifplugd.action in order to run after dhcpd is stopped: 
- ip addr change 10.11.99.1/32 dev usb0


