### PR TITLE
Add package: webinterface-upload-button v1.0.1

### DIFF
--- a/package/webinterface-upload-button/package
+++ b/package/webinterface-upload-button/package
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+_pkgname='webinterface-upload-button'
+pkgnames=("$_pkgname")
+pkgdesc="A simple upload button for the web interface"
+url="https://github.com/rM-self-serve/$_pkgname"
+pkgver=1.0.1-1
+timestamp=2023-12-06T11:43:00Z
+section="utils"
+maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
+license=MIT
+
+_pkgalias='webint-upldbtn'
+
+source=(
+    "$url"/archive/ec03bcf4de99c89fd8d99addc03e40cadba4345c.zip
+)
+sha256sums=(
+    f4697beb4a9e759f4e996cf7c4dfc30f523b469084c92698c69b23188c9c40fc
+)
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir/$_pkgname"
+    ln -s /opt/bin/"$_pkgname" "$pkgdir/opt/bin/$_pkgalias"
+}
+
+_restore() {
+    echo
+    webinterface-upload-button revert -y
+    echo
+}
+
+preremove() {
+    _restore
+}
+
+preupgrade() {
+    _restore
+}

--- a/package/webinterface-upload-button/package
+++ b/package/webinterface-upload-button/package
@@ -12,8 +12,6 @@ section="utils"
 maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
 
-_pkgalias='webint-upldbtn'
-
 source=(
     "$url"/archive/1c69d4fcaa1cb8e2cf4b022a190429dc39946498.zip
 )
@@ -23,7 +21,6 @@ sha256sums=(
 
 package() {
     install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir/$_pkgname"
-    ln -s /opt/bin/"$_pkgname" "$pkgdir/opt/bin/$_pkgalias"
 
     touch "$srcdir"/emptyfile
     install -D -m 666 -t "$pkgdir"/usr/share/toltec/reenable.d/"$_pkgname" "$srcdir"/emptyfile

--- a/package/webinterface-upload-button/package
+++ b/package/webinterface-upload-button/package
@@ -15,20 +15,33 @@ license=MIT
 _pkgalias='webint-upldbtn'
 
 source=(
-    "$url"/archive/ec03bcf4de99c89fd8d99addc03e40cadba4345c.zip
+    "$url"/archive/1c69d4fcaa1cb8e2cf4b022a190429dc39946498.zip
 )
 sha256sums=(
-    f4697beb4a9e759f4e996cf7c4dfc30f523b469084c92698c69b23188c9c40fc
+    a388d1db49a3c35782600efbd94ee449c59f46c223f14c254cb74d9509255d96
 )
 
 package() {
     install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir/$_pkgname"
     ln -s /opt/bin/"$_pkgname" "$pkgdir/opt/bin/$_pkgalias"
+
+    touch "$srcdir"/emptyfile
+    install -D -m 666 -t "$pkgdir"/usr/share/toltec/reenable.d/"$_pkgname" "$srcdir"/emptyfile
+}
+
+configure() {
+    echo
+    echo "Applying webinterface-upload-button"
+    webinterface-upload-button apply -y > /dev/null
+    echo "Success"
+    echo
 }
 
 _restore() {
     echo
-    webinterface-upload-button revert -y
+    echo "Reverting webinterface-upload-button"
+    webinterface-upload-button revert -y > /dev/null
+    echo "Success"
     echo
 }
 


### PR DESCRIPTION
[Release Notes v1.0.1](https://github.com/rM-self-serve/webinterface-upload-button/releases/tag/v1.0.1)
[Docs](https://github.com/rM-self-serve/webinterface-upload-button)

Simple program to add or remove button that will open a file explorer window on your phone or computer and allow you to upload a file, for the ReMarkable Tablet's Web Interface. Work around to drag and drop.

I am the author of this software. This should work on all devices+versions.

---

Modifies index.html and app-*.css in /usr/share/remarkable/webui/. Will ensure the modifications are possible before performing them by checking for the "guilty" strings rather than a shasum. It will attempt to revert the modifications when uninstalled, if they are applied.

![mobile_web_ui](https://github.com/rM-self-serve/webinterface-wifi/assets/122753594/981f3367-653e-40db-b389-703a046a4362)