### PR TITLE
Add package: signature-rm v1.0.2

### DIFF
--- a/package/signature-rm/package
+++ b/package/signature-rm/package
@@ -12,6 +12,7 @@ section="utils"
 maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
 image=rust:v3.1
+conflicts=(ddvk-hacks)
 
 source=(
     "$url"/archive/b5561af4eb6a0f5aa6e98e1a1279066f0c4bd9b7.zip

--- a/package/signature-rm/package
+++ b/package/signature-rm/package
@@ -12,7 +12,7 @@ section="utils"
 maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
 image=rust:v3.1
-conflicts=(ddvk-hacks)
+conflicts=(ddvk-hacks webinterface-onboot)
 
 source=(
     "$url"/archive/b5561af4eb6a0f5aa6e98e1a1279066f0c4bd9b7.zip

--- a/package/signature-rm/package
+++ b/package/signature-rm/package
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+_pkgname='signature-rm'
+pkgnames=("$_pkgname")
+pkgdesc="Remove the signature from the bottom of emails"
+url="https://github.com/rM-self-serve/signature-rM"
+pkgver=1.0.2-1
+timestamp=2023-12-06T11:43:00Z
+section="utils"
+maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
+license=MIT
+image=rust:v3.1
+
+source=(
+    "$url"/archive/77eef2b421654d14d968f46c055392581e180b8e.zip
+)
+sha256sums=(
+    60ac53d2f621dd8baabf0032b0c67fd46ad567fe5e512129396b39f4c697bc2e
+)
+
+build() {
+    cargo build --release
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin \
+        "$srcdir/target/armv7-unknown-linux-gnueabihf/release/$_pkgname"
+}
+
+_restore() {
+    if signature-rm is-applied > /dev/null 2>&1; then
+        echo "Reverting /usr/bin/xochitl"
+        if ! signature-rm revert --backup -y > /dev/null 2>&1; then
+            if ! signature-rm revert --reverse -y > /dev/null 2>&1; then
+                echo "Could not revert /usr/bin/xochitl"
+            fi
+        fi
+        echo "Success"
+    fi
+}
+
+preremove() {
+    _restore
+}
+
+preupgrade() {
+    _restore
+}

--- a/package/signature-rm/package
+++ b/package/signature-rm/package
@@ -46,7 +46,7 @@ _restore() {
     if signature-rm has-backup > /dev/null; then
         signature-rm revert --backup -y > /dev/null
     else
-        signature-rm revert --reverse -y > /dev/null 2>&1
+        signature-rm revert --reverse -y > /dev/null
     fi
     echo "Success"
     echo

--- a/package/signature-rm/package
+++ b/package/signature-rm/package
@@ -14,10 +14,10 @@ license=MIT
 image=rust:v3.1
 
 source=(
-    "$url"/archive/77eef2b421654d14d968f46c055392581e180b8e.zip
+    "$url"/archive/b5561af4eb6a0f5aa6e98e1a1279066f0c4bd9b7.zip
 )
 sha256sums=(
-    60ac53d2f621dd8baabf0032b0c67fd46ad567fe5e512129396b39f4c697bc2e
+    1a7cc8bf7a3f5a7cc9a10ca968bbb5a0082a065760f4cb7038fdb6b9aed4bb00
 )
 
 build() {
@@ -27,18 +27,28 @@ build() {
 package() {
     install -D -m 755 -t "$pkgdir"/opt/bin \
         "$srcdir/target/armv7-unknown-linux-gnueabihf/release/$_pkgname"
+
+    touch "$srcdir"/emptyfile
+    install -D -m 666 -t "$pkgdir"/usr/share/toltec/reenable.d/"$_pkgname" "$srcdir"/emptyfile
+}
+
+configure() {
+    echo
+    echo "Applying signature-rM"
+    signature-rm apply -y > /dev/null
+    echo "Success"
+    echo
 }
 
 _restore() {
-    if signature-rm is-applied > /dev/null 2>&1; then
-        echo "Reverting /usr/bin/xochitl"
-        if ! signature-rm revert --backup -y > /dev/null 2>&1; then
-            if ! signature-rm revert --reverse -y > /dev/null 2>&1; then
-                echo "Could not revert /usr/bin/xochitl"
-            fi
-        fi
-        echo "Success"
+    echo "Reverting /usr/bin/xochitl"
+    if signature-rm has-backup > /dev/null; then
+        signature-rm revert --backup -y > /dev/null
+    else
+        signature-rm revert --reverse -y > /dev/null 2>&1
     fi
+    echo "Success"
+    echo
 }
 
 preremove() {

--- a/package/webinterface-onboot/package
+++ b/package/webinterface-onboot/package
@@ -11,7 +11,7 @@ timestamp=2023-12-03T11:43:00Z
 section="utils"
 maintainer="rM-self-serve <122753594+rM-self-serve@users.noreply.github.com>"
 license=MIT
-conflicts=(ddvk-hacks)
+conflicts=(ddvk-hacks signature-rm)
 
 source=(
     "$url"/archive/cdfe457435974f7ca309b1ac50f1b2ef67000813.zip


### PR DESCRIPTION
[Release Notes v1.0.2](https://github.com/rM-self-serve/signature-rM/releases/tag/v1.0.2)
[Docs](https://github.com/rM-self-serve/signature-rM)

Remove the signature from the bottom of emails sent from the device. It will also take a backup before the modification, and allow reverting the modification from the backup or by performing the modification in reverse.

I am the author of this software. This should work on all devices+versions.

It will ensure the modification is possible before performing it by checking for the "guilty" string rather than a shasum. It will attempt to revert the modification when uninstalled, if it is applied.

---

How it works:
In xochitl: 
- change 'Sent from my reMarkable' to '\0ent from my reMarkable' 
