### PR TITLE
Add toltec-python package

### DIFF
--- a/package/python/package
+++ b/package/python/package
@@ -12,6 +12,7 @@ timestamp=2023-12-08T00:00Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=PSF-2.0
+flags="nostrip"
 
 image=python:v3.1
 source=(
@@ -27,13 +28,14 @@ makedepends=("build:python${_python_ver%.*}")
 
 build() {
     tar -xf "libffi-${_libffi_ver}.tar.gz"
-    cd libffi-${_libffi_ver}
+    cd "libffi-${_libffi_ver}"
     ./configure \
         --prefix=/usr \
         --host="$CHOST"
     make --jobs="$(nproc)"
     make DESTDIR="$SYSROOT" install
     cd "$srcdir"
+    rm -rf "libffi-${_libffi_ver}"
     ./configure \
         --enable-optimizations \
         --with-lto \

--- a/package/python/package
+++ b/package/python/package
@@ -49,6 +49,7 @@ build() {
         ac_cv_file__dev_ptc=no
     make --jobs="$(nproc)"
     make DESTDIR=dist altinstall
+
 }
 
 package() {
@@ -57,5 +58,13 @@ package() {
 }
 
 configure() {
-    /opt/bin/python3.12 -m ensurepip --upgrade --altinstall
+    "/opt/bin/python${_python_ver%.*}" -m ensurepip --upgrade --altinstall
+}
+
+postremove() {
+    if [ -d "/opt/lib/python${_python_ver%.*}/site-packages" ]; then
+        echo "WARNING: /opt/lib/python${_python_ver%.*}/site-packages is not empty."
+        echo "         You will need to remove the directory to fully uninstall any"
+        echo "         python modules installed with pip."
+    fi
 }

--- a/package/python/package
+++ b/package/python/package
@@ -11,7 +11,6 @@ timestamp=2023-12-08T00:00Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=PSF-2.0
-provides=(python3)
 
 image=python:v3.1
 source=(

--- a/package/python/package
+++ b/package/python/package
@@ -12,7 +12,7 @@ timestamp=2023-12-08T00:00Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=PSF-2.0
-flags="nostrip"
+flags=(nostrip)
 
 image=python:v3.1
 source=(

--- a/package/python/package
+++ b/package/python/package
@@ -33,7 +33,7 @@ build() {
         --host="$CHOST"
     make --jobs="$(nproc)"
     make DESTDIR="$SYSROOT" install
-    cd ..
+    cd "$srcdir"
     ./configure \
         --enable-optimizations \
         --with-lto \

--- a/package/python/package
+++ b/package/python/package
@@ -5,8 +5,9 @@
 pkgnames=(toltec-python)
 pkgdesc="Python is a programming language that lets you work quickly and integrate systems more effectively."
 url="https://python.org"
-_ver=3.12.1
-pkgver=${_ver}-1
+_python_ver=3.12.1
+_libffi_ver=3.3
+pkgver=${_python_ver}-1
 timestamp=2023-12-08T00:00Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
@@ -14,21 +15,32 @@ license=PSF-2.0
 
 image=python:v3.1
 source=(
-    "https://www.python.org/ftp/python/${_ver}/Python-${_ver}.tar.xz"
+    "https://www.python.org/ftp/python/${_python_ver}/Python-${_python_ver}.tar.xz"
+    "https://github.com/libffi/libffi/releases/download/v${_libffi_ver}/libffi-${_libffi_ver}.tar.gz"
 )
 sha256sums=(
     8dfb8f426fcd226657f9e2bd5f1e96e53264965176fa17d32658e873591aeb21
+    72fba7922703ddfa7a028d513ac15a85c8d54c8d67f55fa5a4802885dc652056
 )
-makedepends=("build:python${_ver%.*}")
+noextract=("libffi-${_libffi_ver}.tar.gz")
+makedepends=("build:python${_python_ver%.*}")
 
 build() {
+    tar -xf "libffi-${_libffi_ver}.tar.gz"
+    cd libffi-${_libffi_ver}
+    ./configure \
+        --prefix=/usr \
+        --host="$CHOST"
+    make --jobs="$(nproc)"
+    make DESTDIR="$SYSROOT" install
+    cd ..
     ./configure \
         --enable-optimizations \
         --with-lto \
         --prefix=/opt \
         --build="$(./config.guess)" \
         --host="$CHOST" \
-        --with-build-python="$(which "python${_ver%.*}")" \
+        --with-build-python="$(which "python${_python_ver%.*}")" \
         --with-ensurepip=no \
         ac_cv_buggy_getaddrinfo=no \
         ac_cv_file__dev_ptmx=yes \

--- a/package/python/package
+++ b/package/python/package
@@ -20,21 +20,21 @@ source=(
 sha256sums=(
     8dfb8f426fcd226657f9e2bd5f1e96e53264965176fa17d32658e873591aeb21
 )
-makedepends=(build:python${_ver%.*})
+makedepends=("build:python${_ver%.*}")
 
 build() {
     ./configure \
         --enable-optimizations \
         --with-lto \
         --prefix=/opt \
-        --build=$(./config.guess) \
-        --host=$CHOST \
-        --with-build-python=$(which python${_ver%.*}) \
+        --build="$(./config.guess)" \
+        --host="$CHOST" \
+        --with-build-python="$(which "python${_ver%.*}")" \
         --with-ensurepip=no \
         ac_cv_buggy_getaddrinfo=no \
         ac_cv_file__dev_ptmx=yes \
         ac_cv_file__dev_ptc=no
-    make --jobs=$(nproc)
+    make --jobs="$(nproc)"
     make DESTDIR=dist altinstall
 }
 

--- a/package/python/package
+++ b/package/python/package
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(toltec-python)
+pkgdesc="Python is a programming language that lets you work quickly and integrate systems more effectively."
+url="https://python.org"
+_ver=3.12.1
+pkgver=${_ver}-1
+timestamp=2023-12-08T00:00Z
+section=utils
+maintainer="Eeems <eeems@eeems.email>"
+license=PSF-2.0
+provides=(python3)
+
+image=python:v3.1
+source=(
+    "https://www.python.org/ftp/python/${_ver}/Python-${_ver}.tar.xz"
+)
+sha256sums=(
+    8dfb8f426fcd226657f9e2bd5f1e96e53264965176fa17d32658e873591aeb21
+)
+makedepends=(build:python${_ver%.*})
+
+build() {
+    ./configure \
+        --enable-optimizations \
+        --with-lto \
+        --prefix=/opt \
+        --build=$(./config.guess) \
+        --host=$CHOST \
+        --with-build-python=$(which python${_ver%.*}) \
+        --with-ensurepip=no \
+        ac_cv_buggy_getaddrinfo=no \
+        ac_cv_file__dev_ptmx=yes \
+        ac_cv_file__dev_ptc=no
+    make --jobs=$(nproc)
+    make DESTDIR=dist altinstall
+}
+
+package() {
+    cd "$srcdir"
+    cp -ar dist/. "$pkgdir"
+}
+
+configure() {
+    /opt/bin/python3.12 -m ensurepip --upgrade --altinstall
+}


### PR DESCRIPTION
Due to https://github.com/Nuitka/Nuitka/issues/2440 it may be worth adding a normal build of python to the device. I'll be using this to test using nuitka to build binaries for the device to see if it works as expected. We may not even want to merge this PR and instead create an arm toolchain image that has python that can just use nuitka to build things that will run natively.