### PR TITLE
toltec-base: Disable busybox-ifplugd@usb1.service

### DIFF
--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -33,21 +33,21 @@ configure() {
     disable-unit update-engine.service
     if [[ "$arch" == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"
-        ! is-masked sys-subsystem-net-devices-usb1.device && systemctl mask sys-subsystem-net-devices-usb1.device
-        ! is-masked busybox-ifplugd@usb1.service && systemctl mask busybox-ifplugd@usb1.service
+        ! systemctl is-masked sys-subsystem-net-devices-usb1.device && systemctl mask sys-subsystem-net-devices-usb1.device
+        ! systemctl is-masked busybox-ifplugd@usb1.service && systemctl mask busybox-ifplugd@usb1.service
     elif [[ "$arch" == "rm2" ]]; then
         echo "Enabling usb1 network device to ensure usb SSH works"
-        is-masked sys-subsystem-net-devices-usb1.device && systemctl unmask sys-subsystem-net-devices-usb1.device
-        is-masked busybox-ifplugd@usb1.service && systemctl unmask busybox-ifplugd@usb1.service
+        systemctl is-masked sys-subsystem-net-devices-usb1.device && systemctl unmask sys-subsystem-net-devices-usb1.device
+        systemctl is-masked busybox-ifplugd@usb1.service && systemctl unmask busybox-ifplugd@usb1.service
     fi
 }
 
 postremove() {
-    if is-masked sys-subsystem-net-devices-usb1.device; then
+    if systemctl is-masked sys-subsystem-net-devices-usb1.device; then
         systemctl unmask sys-subsystem-net-devices-usb1.device
         systemctl unmask busybox-ifplugd@usb1.service
     fi
-    if ! is-enabled "update-engine.service"; then
+    if ! systemctl is-enabled update-engine.service; then
         systemctl enable update-engine
     fi
 }

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -33,18 +33,28 @@ configure() {
     disable-unit update-engine.service
     if [[ "$arch" == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"
-        ! is-masked sys-subsystem-net-devices-usb1.device && systemctl mask sys-subsystem-net-devices-usb1.device
-        ! is-masked busybox-ifplugd@usb1.service && systemctl mask busybox-ifplugd@usb1.service
+        if ! is-masked sys-subsystem-net-devices-usb1.device; then
+            systemctl mask sys-subsystem-net-devices-usb1.device
+        fi
+        if ! is-masked busybox-ifplugd@usb1.service; then
+            systemctl mask busybox-ifplugd@usb1.service
+        fi
     elif [[ "$arch" == "rm2" ]]; then
         echo "Enabling usb1 network device to ensure usb SSH works"
-        is-masked sys-subsystem-net-devices-usb1.device && systemctl unmask sys-subsystem-net-devices-usb1.device
-        is-masked busybox-ifplugd@usb1.service && systemctl unmask busybox-ifplugd@usb1.service
+        if is-masked sys-subsystem-net-devices-usb1.device; then
+            systemctl unmask sys-subsystem-net-devices-usb1.device
+        fi
+        if  is-masked busybox-ifplugd@usb1.service; then
+            systemctl unmask busybox-ifplugd@usb1.service
+        fi
     fi
 }
 
 postremove() {
     if is-masked sys-subsystem-net-devices-usb1.device; then
         systemctl unmask sys-subsystem-net-devices-usb1.device
+    fi
+    if is-masked systemctl unmask busybox-ifplugd@usb1.service; then
         systemctl unmask busybox-ifplugd@usb1.service
     fi
     if ! is-enabled "update-engine.service"; then

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Copyright (c) 2021 The Toltec Contributors
+# Copyright (c) 2023 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
 archs=(rm1 rm2)
 pkgnames=(toltec-base)
 pkgdesc="Metapackage defining the base set of packages in a Toltec install"
 url=https://toltec-dev.org/
-pkgver=1.2-3
-timestamp=2023-05-08T19:31Z
+pkgver=1.3-1
+timestamp=2023-12-27T08:30Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -33,21 +33,21 @@ configure() {
     disable-unit update-engine.service
     if [[ "$arch" == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"
-        ! systemctl is-masked sys-subsystem-net-devices-usb1.device && systemctl mask sys-subsystem-net-devices-usb1.device
-        ! systemctl is-masked busybox-ifplugd@usb1.service && systemctl mask busybox-ifplugd@usb1.service
+        ! is-masked sys-subsystem-net-devices-usb1.device && systemctl mask sys-subsystem-net-devices-usb1.device
+        ! is-masked busybox-ifplugd@usb1.service && systemctl mask busybox-ifplugd@usb1.service
     elif [[ "$arch" == "rm2" ]]; then
         echo "Enabling usb1 network device to ensure usb SSH works"
-        systemctl is-masked sys-subsystem-net-devices-usb1.device && systemctl unmask sys-subsystem-net-devices-usb1.device
-        systemctl is-masked busybox-ifplugd@usb1.service && systemctl unmask busybox-ifplugd@usb1.service
+        is-masked sys-subsystem-net-devices-usb1.device && systemctl unmask sys-subsystem-net-devices-usb1.device
+        is-masked busybox-ifplugd@usb1.service && systemctl unmask busybox-ifplugd@usb1.service
     fi
 }
 
 postremove() {
-    if systemctl is-masked sys-subsystem-net-devices-usb1.device; then
+    if is-masked sys-subsystem-net-devices-usb1.device; then
         systemctl unmask sys-subsystem-net-devices-usb1.device
         systemctl unmask busybox-ifplugd@usb1.service
     fi
-    if ! systemctl is-enabled update-engine.service; then
+    if ! is-enabled "update-engine.service"; then
         systemctl enable update-engine
     fi
 }

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -31,18 +31,21 @@ configure() {
         /opt/etc/profile
     echo "Disabling automatic update"
     disable-unit update-engine.service
-    if [[ "$arch" == "rm1" ]] && ! is-masked sys-subsystem-net-devices-usb1.device; then
+    if [[ "$arch" == "rm1" ]]; then
         echo "Disabling usb1 network device to avoid long boots"
-        systemctl mask sys-subsystem-net-devices-usb1.device
-    elif [[ "$arch" == "rm2" ]] && is-masked sys-subsystem-net-devices-usb1.device; then
+        ! is-masked sys-subsystem-net-devices-usb1.device && systemctl mask sys-subsystem-net-devices-usb1.device
+        ! is-masked busybox-ifplugd@usb1.service && systemctl mask busybox-ifplugd@usb1.service
+    elif [[ "$arch" == "rm2" ]]; then
         echo "Enabling usb1 network device to ensure usb SSH works"
-        systemctl unmask sys-subsystem-net-devices-usb1.device
+        is-masked sys-subsystem-net-devices-usb1.device && systemctl unmask sys-subsystem-net-devices-usb1.device
+        is-masked busybox-ifplugd@usb1.service && systemctl unmask busybox-ifplugd@usb1.service
     fi
 }
 
 postremove() {
     if is-masked sys-subsystem-net-devices-usb1.device; then
         systemctl unmask sys-subsystem-net-devices-usb1.device
+        systemctl unmask busybox-ifplugd@usb1.service
     fi
     if ! is-enabled "update-engine.service"; then
         systemctl enable update-engine

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -54,10 +54,10 @@ postremove() {
     if is-masked sys-subsystem-net-devices-usb1.device; then
         systemctl unmask sys-subsystem-net-devices-usb1.device
     fi
-    if is-masked systemctl unmask busybox-ifplugd@usb1.service; then
+    if is-masked busybox-ifplugd@usb1.service; then
         systemctl unmask busybox-ifplugd@usb1.service
     fi
-    if ! is-enabled "update-engine.service"; then
+    if ! is-enabled update-engine.service; then
         systemctl enable update-engine
     fi
 }

--- a/package/toltec-base/package
+++ b/package/toltec-base/package
@@ -44,7 +44,7 @@ configure() {
         if is-masked sys-subsystem-net-devices-usb1.device; then
             systemctl unmask sys-subsystem-net-devices-usb1.device
         fi
-        if  is-masked busybox-ifplugd@usb1.service; then
+        if is-masked busybox-ifplugd@usb1.service; then
             systemctl unmask busybox-ifplugd@usb1.service
         fi
     fi


### PR DESCRIPTION
Disable `busybox-ifplugd@usb1.service` in rM1 to avoid the following errors on boot:

```
systemd[1]: busybox-ifplugd@usb1.service: Bound to unit sys-subsystem-net-devices-usb1.device, but unit isn't active.
systemd[1]: Dependency failed for ifplugd on usb1.
systemd[1]: busybox-ifplugd@usb1.service: Job busybox-ifplugd@usb1.service/start failed with result 'dependency'.
```

Discussed in https://github.com/toltec-dev/toltec/issues/803#issuecomment-1869778997
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
