### PR TITLE
KOReader wrapper script: fix LD_PRELOAD error

### DIFF
--- a/package/koreader/koreader
+++ b/package/koreader/koreader
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
-# Copyright (c) 2021 The Toltec Contributors
+# Copyright (c) 2023 The Toltec Contributors
 # SPDX-License-Identifier: MIT
-LD_PRELOAD=/opt/lib/librm2fb_client.so.1 KO_DONT_GRAB_INPUT=1 exec -a /opt/bin/koreader bash /opt/koreader/koreader.sh
+
+read -r device_version < "/sys/devices/soc0/machine"
+
+if [ "${device_version}" = "reMarkable 1.0" ]; then
+    exec -a /opt/bin/koreader bash /opt/koreader/koreader.sh
+elif [ "${device_version}" = "reMarkable 2.0" ]; then
+    LD_PRELOAD=/opt/lib/librm2fb_client.so.1 KO_DONT_GRAB_INPUT=1 exec -a /opt/bin/koreader bash /opt/koreader/koreader.sh
+fi


### PR DESCRIPTION
Current wrapper script was probably intended only for rM2. In rM1 it triggers this error indefinitely every 2 seconds:
```
ERROR: ld.so: object '/opt/lib/librm2fb_client.so.1' from LD_PRELOAD cannot be preloaded (internal error): ignored.
```

Fix: Check the device version and execute a different command accordingly
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
