### PR TITLE
lf: Fix missing dependency error

### DIFF
--- a/package/lf/package
+++ b/package/lf/package
@@ -5,11 +5,12 @@
 pkgnames=(lf)
 pkgdesc="Terminal file manager"
 url=https://github.com/gokcehan/lf
-pkgver=r31-1
+pkgver=r31-2
 timestamp=2023-09-17T12:55Z
 section="utils"
 maintainer="gbyl <gbyl@users.noreply.github.com>"
 license=MIT
+installdepends=(libncurses-dev)
 
 image=golang:v3.1
 source=("https://github.com/gokcehan/lf/archive/refs/tags/${pkgver%-*}.zip")


### PR DESCRIPTION
Add `libncurses-dev` as an explicit dependency of `lf`. Otherwise, when launched from yaft (`TERM=yaft-256color`), it fails with the following error:

```
creating screen: exec: "infocmp": executable file not found in $PATH
```

<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
