### PR TITLE
Pin specific versions of Folly's clang deps

### DIFF
--- a/package/folly/package
+++ b/package/folly/package
@@ -11,7 +11,7 @@ section=games
 maintainer="Ben Kirwin <ben@kirw.in>"
 license=MIT
 installdepends=(display)
-makedepends=(build:librust-clang-sys-dev build:libclang-dev build:libc6 build:libc6-dev build:clang)
+makedepends=(build:libclang-14-dev build:clang-14 build:llvm-14-dev)
 
 image=rust:v2.3
 

--- a/package/folly/package
+++ b/package/folly/package
@@ -5,7 +5,7 @@
 pkgnames=(folly)
 pkgdesc="Z-machine interpreter for interactive fiction"
 url="https://github.com/bkirwi/folly"
-pkgver=0.0.1-3
+pkgver=0.0.1-4
 timestamp=2022-04-18T17:50:16Z
 section=games
 maintainer="Ben Kirwin <ben@kirw.in>"


### PR DESCRIPTION
While poking at https://github.com/bkirwi/folly/issues/2, I noticed that ~Ubuntu~ Debian ships multiple versioned packages of `clang`, so it's actually relatively straightforward to switch back to a compatible version.

I'll still work to get a version of the ML runtime that's compatible with the cutting edge, so things don't bitrot forever and to justify the fairly large amount of time I've already spent, but this should unbreak things in the meantime.