### PR TITLE
Remove packages that don't work on os3

### DIFF
--- a/package/gocryptfs/package
+++ b/package/gocryptfs/package
@@ -2,11 +2,12 @@
 # Copyright (c) 2020 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
+archs=(rmallos2)
 pkgnames=(gocryptfs)
 pkgdesc="An encrypted overlay filesystem written in Go."
 url="https://nuetzlich.net/gocryptfs/"
 _srcver=2.0-beta2
-pkgver="$_srcver"-2
+pkgver="$_srcver"-3
 timestamp=2021-03-22
 section=utils
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"

--- a/package/innernet/package
+++ b/package/innernet/package
@@ -2,10 +2,11 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
+archs=(rmallos2)
 pkgnames=(innernet-client)
 pkgdesc="A private network system that uses WireGuard under the hood."
 url="https://github.com/tonarino/innernet"
-pkgver=1.5.3-2
+pkgver=1.5.3-3
 timestamp=2022-01-31T20:08:43Z
 section="utils"
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"

--- a/package/linux-mainline/package
+++ b/package/linux-mainline/package
@@ -2,11 +2,11 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-archs=(rm2)
+archs=(rm2os2)
 pkgnames=(linux-mainline)
 pkgdesc="reMarkable 2 kernel based on the mainline kernel"
 url=https://www.kernel.org
-pkgver=6.2.0-2
+pkgver=6.2.0-3
 timestamp=2022-05-22T21:50:09Z
 section=kernel
 maintainer="Alistair Francis <alistair@alistair23.me>"

--- a/package/toltec-deletions/package
+++ b/package/toltec-deletions/package
@@ -6,7 +6,7 @@ archs=(rmallos2 rmallos3)
 pkgnames=(toltec-deletions)
 pkgdesc="Metapackage to handle package deletions between OS versions"
 url=https://toltec-dev.org/
-pkgver=0.1-1
+pkgver=0.1-2
 timestamp=2023-12-03T04:51:58Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
@@ -14,8 +14,22 @@ license=MIT
 installdepends=(toltec-bootstrap)
 conflicts_rmallos2=()
 replaces_rmallos2=()
-conflicts_rmallos3=(ddvk-hacks fuse wireguard)
-replaces_rmallos3=(ddvk-hacks fuse wireguard)
+conflicts_rmallos3=(
+    ddvk-hacks
+    fuse
+    wireguard
+    innernet-client
+    gocryptfs
+    linux-mainline
+)
+replaces_rmallos3=(
+    ddvk-hacks
+    fuse
+    wireguard
+    innernet-client
+    gocryptfs
+    linux-mainline
+)
 
 source=()
 sha256sums=()


### PR DESCRIPTION
- gocryptfs marked as os2 only
- innernet-client marked as os2 only
- linux-mainline marked as os2 only