### PR TITLE
Remove remarkable-stylus from os3 for now

### DIFF
--- a/package/remarkable-stylus/package
+++ b/package/remarkable-stylus/package
@@ -2,6 +2,7 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
+archs=(rmallos2)
 pkgnames=(remarkable-stylus)
 pkgver=0.0.3-2
 pkgdesc="Generate a key press upon pressing the button of a Lamy AL-star EMR pen"

--- a/package/remarkable-stylus/package
+++ b/package/remarkable-stylus/package
@@ -4,7 +4,7 @@
 
 archs=(rmallos2)
 pkgnames=(remarkable-stylus)
-pkgver=0.0.3-2
+pkgver=0.0.3-3
 pkgdesc="Generate a key press upon pressing the button of a Lamy AL-star EMR pen"
 timestamp=2020-11-19T20:07:29Z
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/toltec-deletions/package
+++ b/package/toltec-deletions/package
@@ -6,7 +6,7 @@ archs=(rmallos2 rmallos3)
 pkgnames=(toltec-deletions)
 pkgdesc="Metapackage to handle package deletions between OS versions"
 url=https://toltec-dev.org/
-pkgver=0.1-2
+pkgver=0.1-3
 timestamp=2023-12-03T04:51:58Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
@@ -21,6 +21,7 @@ conflicts_rmallos3=(
     innernet-client
     gocryptfs
     linux-mainline
+    remarkable-stylus
 )
 replaces_rmallos3=(
     ddvk-hacks
@@ -29,6 +30,7 @@ replaces_rmallos3=(
     innernet-client
     gocryptfs
     linux-mainline
+    remarkable-stylus
 )
 
 source=()


### PR DESCRIPTION
remarkable-stylus depends on ddvk-hacks to work, will be removed until rm-hacks is added