### PR TITLE
Remove open-remarkable-shutdown from os3 due to it not working

### DIFF
--- a/package/open-remarkable-shutdown/package
+++ b/package/open-remarkable-shutdown/package
@@ -2,10 +2,11 @@
 # Copyright (c) 2021 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
+archs=(rmallos2)
 pkgnames=(open-remarkable-shutdown)
 pkgdesc="Use remarkable-splash to display shutdown and reboot images"
 url=https://github.com/ddvk/remarkable-splash
-pkgver=1.0-1
+pkgver=1.0-2
 timestamp=2022-02-28T00:12Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/toltec-deletions/package
+++ b/package/toltec-deletions/package
@@ -6,7 +6,7 @@ archs=(rmallos2 rmallos3)
 pkgnames=(toltec-deletions)
 pkgdesc="Metapackage to handle package deletions between OS versions"
 url=https://toltec-dev.org/
-pkgver=0.1-3
+pkgver=0.1-4
 timestamp=2023-12-03T04:51:58Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
@@ -22,6 +22,7 @@ conflicts_rmallos3=(
     gocryptfs
     linux-mainline
     remarkable-stylus
+    open-remarkable-shutdown
 )
 replaces_rmallos3=(
     ddvk-hacks
@@ -31,6 +32,7 @@ replaces_rmallos3=(
     gocryptfs
     linux-mainline
     remarkable-stylus
+    open-remarkable-shutdown
 )
 
 source=()


### PR DESCRIPTION
Testing with #854 indicates that open-remarkable-shutdown doesn't work on OS 3.x, so for now we will remove it from the os3 repositories.