### PR TITLE
Fix upper case LOG in toltecctl

### DIFF
--- a/package/toltec-bootstrap/package
+++ b/package/toltec-bootstrap/package
@@ -5,8 +5,8 @@
 pkgnames=(toltec-bootstrap)
 pkgdesc="Manage your Toltec install"
 url=https://toltec-dev.org/
-pkgver=0.4.2-1
-timestamp=2024-05-30T19:50Z
+pkgver=0.4.3-1
+timestamp=2024-05-30T20:02Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT

--- a/package/toltec-bootstrap/toltecctl
+++ b/package/toltec-bootstrap/toltecctl
@@ -156,8 +156,8 @@ check-version() {
     cd "$cwd"
 
     if ! grep -q "${current_model}=${current_version}" "${toltec_share}/Compatibility"; then
-        LOG ERROR "You’re running an unsupported OS version: $current_version"
-        LOG ERROR "Please monitor Toltec releases for upcoming support"
+        log ERROR "You’re running an unsupported OS version: $current_version"
+        log ERROR "Please monitor Toltec releases for upcoming support"
         return 1
     fi
 


### PR DESCRIPTION
The function should be `log()`, not `LOG`.
