### PR TITLE
Split toltec-deletions rm1/rm2 for open-remarkable-shutdown

### DIFF
--- a/package/toltec-deletions/package
+++ b/package/toltec-deletions/package
@@ -2,11 +2,11 @@
 # Copyright (c) 2023 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-archs=(rmallos2 rmallos3)
+archs=(rmallos2 rm1os3 rm2os3)
 pkgnames=(toltec-deletions)
 pkgdesc="Metapackage to handle package deletions between OS versions"
 url=https://toltec-dev.org/
-pkgver=0.1-4
+pkgver=0.1-5
 timestamp=2023-12-03T04:51:58Z
 section="utils"
 maintainer="Eeems <eeems@eeems.email>"
@@ -14,7 +14,25 @@ license=MIT
 installdepends=(toltec-bootstrap)
 conflicts_rmallos2=()
 replaces_rmallos2=()
-conflicts_rmallos3=(
+conflicts_rm1os3=(
+    ddvk-hacks
+    fuse
+    wireguard
+    innernet-client
+    gocryptfs
+    linux-mainline
+    remarkable-stylus
+)
+replaces_rm1os3=(
+    ddvk-hacks
+    fuse
+    wireguard
+    innernet-client
+    gocryptfs
+    linux-mainline
+    remarkable-stylus
+)
+conflicts_rm2os3=(
     ddvk-hacks
     fuse
     wireguard
@@ -24,7 +42,7 @@ conflicts_rmallos3=(
     remarkable-stylus
     open-remarkable-shutdown
 )
-replaces_rmallos3=(
+replaces_rm2os3=(
     ddvk-hacks
     fuse
     wireguard


### PR DESCRIPTION
toltec-deletions doesn't allow open-remarkable-shutdown to be installed on a rm1