### PR TITLE
Temporarily fix remux

### DIFF
--- a/package/rmkit/package
+++ b/package/rmkit/package
@@ -7,7 +7,7 @@ timestamp=2024-01-11T20:03:10Z
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=MIT
 installdepends=(display)
-flags=(patch_rm2fb)
+flags=(patch_rm2fb notstrip)
 
 image=python:v2.1
 source=(
@@ -147,7 +147,7 @@ nao() {
 remux() {
     pkgdesc="Launcher that supports multi-tasking applications"
     url="https://rmkit.dev/apps/remux"
-    pkgver=0.3.0-5
+    pkgver=0.3.0-6
     section="launchers"
 
     installdepends=(procps-ng-ps)


### PR DESCRIPTION
Binaries in this package that are being stripped are failing with the following error: `remux: remux: no version information available (required by remux)`

When they aren't stripped there is no error, and when manually stripping a non-stripped binary, the following warning is raised: `warning: allocated section `.dynstr' not in segmen`. The binary will then segfault if you run it on device.