### PR TITLE
Update libsentry timestamp and depend on launcherctl

### DIFF
--- a/package/oxide/package
+++ b/package/oxide/package
@@ -5,7 +5,7 @@
 archs=(rm1 rm2)
 pkgnames=(oxide oxide-extra oxide-utils inject_evdev liboxide liboxide-dev libsentry)
 _oxidever=2.8.4
-pkgver=$_oxidever-1
+pkgver=$_oxidever-2
 _sentryver=0.7.6
 timestamp=2024-06-26T22:31:46Z
 maintainer="Eeems <eeems@eeems.email>"
@@ -35,7 +35,7 @@ build() {
 oxide() {
     pkgdesc="Launcher application"
     section="launchers"
-    installdepends=("oxide-utils=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver" reboot-guard jq display)
+    installdepends=("oxide-utils=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver" reboot-guard jq display launcherctl)
     replaces=(erode tarnish decay corrupt)
     conflicts=(erode tarnish decay corrupt)
 
@@ -168,7 +168,7 @@ libsentry() {
     section="devel"
     url=https://github.com/getsentry/sentry-native
     pkgver="$_sentryver"
-    timestamp="2021-12-20T14:25:11Z"
+    timestamp="2024-06-12T08:04:15Z"
 
     package() {
         install -D -m 755 -t "$pkgdir"/opt/lib "$srcdir"/release/opt/lib/libsentry.so


### PR DESCRIPTION
This should resolve any potential issues with oxide being removed at the same time as launcherctl, as `opkg` should now remove oxide first.