### PR TITLE
Build gocryptfs for rmall

### DIFF
--- a/package/gocryptfs/package
+++ b/package/gocryptfs/package
@@ -2,12 +2,12 @@
 # Copyright (c) 2020 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
-archs=(rmallos2)
+archs=(rmall)
 pkgnames=(gocryptfs)
 pkgdesc="An encrypted overlay filesystem written in Go."
 url="https://nuetzlich.net/gocryptfs/"
 _srcver=2.0-beta2
-pkgver="$_srcver"-3
+pkgver="$_srcver"-4
 timestamp=2021-03-22
 section=utils
 maintainer="plan5 <30434574+plan5@users.noreply.github.com>"


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->

This package used to be available for reMarkable 2 on OS 3 but seems to have been limited to OS 2.x only after the split to individual OS version repos. Upgrading currently leads to the uninstallation of this package.

This PR restores sharing of the package between OS 2.x and OS 3.x by including it in rmall instead of rmallos2. As far as I can tell, there is no technical reason for why this package shouldn't be made available this way.

I am not the author of the software or the package, I'm merely contributing a change to the package here.
