### PR TITLE
Update whiteboard-hypercard to 0.4.0

### DIFF
--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Copyright (c) 2023 The Toltec Contributors
+# Copyright (c) 2024 The Toltec Contributors
 # SPDX-License-Identifier: MIT
 
 pkgnames=(whiteboard-hypercard)
 pkgdesc="Real-time collaboration, drawing or whiteboarding"
 url=https://github.com/fenollp/reMarkable-tools
-pkgver=0.3.7-2
-timestamp=2023-10-11T12:57Z
+pkgver=0.4.0-1
+timestamp=2024-05-14T23:01:16Z
 section="drawing"
 maintainer="Pierre Fenoll <pierrefenoll@gmail.com>"
 license=CC-BY-NC-ND

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -15,11 +15,11 @@ flags=(patch_rm2fb)
 
 image=rust:v3.1
 source=(
-    https://github.com/fenollp/reMarkable-tools/archive/v0.3.7.zip
+    https://github.com/fenollp/reMarkable-tools/archive/refs/tags/v0.4.0.zip
     whiteboard-hypercard.draft
 )
 sha256sums=(
-    642fd954ec4f9a1d132b10cc7f7dfbee3467e9c08b1253cc32d1e372178d168b
+    3184125c71b4d0a628280b0c49bb368a254dd582b951f5a62ca451c3dc465e65
     SKIP
 )
 

--- a/package/whiteboard-hypercard/package
+++ b/package/whiteboard-hypercard/package
@@ -13,7 +13,7 @@ license=CC-BY-NC-ND
 installdepends=(display)
 flags=(patch_rm2fb)
 
-image=rust:v3.1
+image=rust:v3.2
 source=(
     https://github.com/fenollp/reMarkable-tools/archive/refs/tags/v0.4.0.zip
     whiteboard-hypercard.draft


### PR DESCRIPTION
[Release notes](https://github.com/fenollp/reMarkable-tools/releases/tag/v0.4.0)