### PR TITLE
Update zerotier to 1.14.2

### DIFF
--- a/package/zerotier-one/package
+++ b/package/zerotier-one/package
@@ -4,16 +4,16 @@
 
 pkgnames=(zerotier zerotier-one zerotier-one-doc zerotier-selftest)
 url=https://github.com/zerotier/ZeroTierOne
-_upver=1.14.1
+_upver=1.14.2
 pkgver=${_upver}-1
-timestamp=2023-03-23T17:39:31Z
+timestamp=2024-10-29T16:17:48Z
 maintainer="Eeems <eeems@eeems.email>"
 license=BUSL-1.1
 section="utils"
 image=base:v3.0
 
 source=("https://github.com/zerotier/ZeroTierOne/archive/refs/tags/${_upver}.zip")
-sha256sums=(fcf30ce797dbca757f3e882e004a3f953ebe12ae13f03d804b3fb184ee3c9714)
+sha256sums=(529dd6d246f51ca7cb0b14794ba68560c0134409f94fcc61a3ee7f5c173c301f)
 
 build() {
     sed -i \


### PR DESCRIPTION
[Release notes](https://github.com/zerotier/ZeroTierOne/blob/dev/RELEASE-NOTES.md#2024-10-23----version-1142)