### PR TITLE
detect architecture and give error if running on reMarkable paper pro

### DIFF
--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -23,9 +23,11 @@ fi
 arch=""
 case "$(uname -m)" in
     "armv7l")
-        arch="armv7sf-k3.2" ;;
+        arch="armv7sf-k3.2"
+        ;;
     #"aarch64)
-    #    arch="aarch64-k3.10" ;;
+    #    arch="aarch64-k3.10"
+    #    ;;
     *)
         echo "Unsupported device architecture"
         exit 1

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -21,25 +21,16 @@ if [ -z "$BASH" ] || [[ "$(ps | awk '$1=='$$' { n=split($5,a,"/"); print a[n] }'
 fi
 
 arch=""
-device=""
-unam="$(uname -m)"
-
-if [ "$unam" = "armv7l" ]; then
-    arch="armv7sf-k3.2"
-    device="rmall" #rmall is only rm1 and rm2 to keep compatibility with older toltec versions
-fi
-
-if [ "$unam" = "aarch64" ]; then
-    arch="aarch64-k3.10"
-    device="rmpp"
-    echo "The reMarkable Paper Pro is not yet supported!"
-    exit 1
-fi
-
-if [ -z "$arch" ]; then
-	echo "Device architecture not recognised."
-	exit 1
-fi
+case "$(uname -m") in
+    "armv7l")
+        arch="armv7sf-k3.2" ;;
+    #"aarch64)
+    #    arch="aarch64-k3.10" ;;
+    *)
+        echo "Unsupported device architecture"
+        exit 1
+        ;;
+esac
 
 set -eEuo pipefail
 
@@ -55,7 +46,7 @@ toltec_branch="${toltec_branch:-stable}"
 
 # Base URLs for bootstrapping from the Entware and Toltec repositories
 entware_remote="${entware_remote:-https://bin.entware.net/$arch/installer}"
-toltec_remote="${toltec_remote:-https://toltec-dev.org/$toltec_branch/$device}"
+toltec_remote="${toltec_remote:-https://toltec-dev.org/$toltec_branch/rmall}"
 
 # Remove all temporary files
 cleanup() {

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -21,7 +21,7 @@ if [ -z "$BASH" ] || [[ "$(ps | awk '$1=='$$' { n=split($5,a,"/"); print a[n] }'
 fi
 
 arch=""
-case "$(uname -m") in
+case "$(uname -m)" in
     "armv7l")
         arch="armv7sf-k3.2" ;;
     #"aarch64)

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -20,6 +20,27 @@ if [ -z "$BASH" ] || [[ "$(ps | awk '$1=='$$' { n=split($5,a,"/"); print a[n] }'
     exit 1
 fi
 
+arch=""
+device=""
+unam="$(uname -m)"
+
+if [ "$unam" = "armv7l" ]; then
+    arch="armv7sf-k3.2"
+    device="rmall" #rmall is only rm1 and rm2 to keep compatibility with older toltec versions
+fi
+
+if [ "$unam" = "aarch64" ]; then
+    arch="aarch64-k3.10"
+    device="rmpp"
+    echo "The reMarkable Paper Pro is not yet supported!"
+    exit 1
+fi
+
+if [ -z "$arch" ]; then
+	echo "Device architecture not recognised."
+	exit 1
+fi
+
 set -eEuo pipefail
 
 # Path to the temporary local wget and Opkg binaries
@@ -33,8 +54,8 @@ toltecctl_path="${toltecctl_path:-/home/root/.local/bin/toltecctl}"
 toltec_branch="${toltec_branch:-stable}"
 
 # Base URLs for bootstrapping from the Entware and Toltec repositories
-entware_remote="${entware_remote:-https://bin.entware.net/armv7sf-k3.2/installer}"
-toltec_remote="${toltec_remote:-https://toltec-dev.org/$toltec_branch/rmall}"
+entware_remote="${entware_remote:-https://bin.entware.net/$arch/installer}"
+toltec_remote="${toltec_remote:-https://toltec-dev.org/$toltec_branch/$device}"
 
 # Remove all temporary files
 cleanup() {


### PR DESCRIPTION
Added some groundwork to the installation script for supporting rmpp.
It just quits installation if run on aarch64.
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
