### PR TITLE
Bugfix: adding sysfs_preload as dependency of Oxide

### DIFF
--- a/package/oxide/package
+++ b/package/oxide/package
@@ -35,7 +35,7 @@ build() {
 oxide() {
     pkgdesc="Launcher application"
     section="launchers"
-    installdepends=("oxide-utils=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver" reboot-guard jq display launcherctl)
+    installdepends=("oxide-utils=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver" reboot-guard jq display launcherctl sysfs_preload)
     replaces=(erode tarnish decay corrupt)
     conflicts=(erode tarnish decay corrupt)
 


### PR DESCRIPTION
This update adds sysfs_preload as a formal package dependency of Oxide.