### PR TITLE
Stable merge for week 5 of 2025

### DIFF
--- a/package/debian-chroot/debian-chroot.conf
+++ b/package/debian-chroot/debian-chroot.conf
@@ -1,0 +1,1 @@
+chroot_path="/home/root/.local/share/debian"

--- a/package/debian-chroot/package
+++ b/package/debian-chroot/package
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(debian-chroot debootstrap)
+section="utils"
+# Each package has it's own timestamp override below
+timestamp=2023-12-22T19:37Z
+maintainer="Eeems <eeems@eeems.email>"
+installdepends=(display)
+flags=(nostrip)
+
+source=(
+    https://github.com/Eeems-org/remarkable-debian-chroot/archive/ea12a1bf851f412e8df4b59fe072bce26bb72571.zip
+    https://salsa.debian.org/installer-team/debootstrap/-/archive/1.0.133/debootstrap-1.0.133.tar.gz
+    debian-chroot.conf
+)
+sha256sums=(
+    3fcd571ba1aa1a5c55a32767c34e6939e0c0e8ad9213425c6d66d25300fe24b8
+    734af3492eea99de940853e2c00e1a9ebd65c463362155f613aa24b9cc3336a0
+    SKIP
+)
+
+debian-chroot() {
+    pkgdesc="A minimal Debian chroot for the reMarkable tablet"
+    url=https://github.com/Eeems-Org/remarkable-debian-chroot
+    pkgver=0.0.0-1
+    timestamp=2023-12-22T19:37Z
+    license=MIT
+    installdepends=(debootstrap lsof)
+    package() {
+        install -D -m 755 \
+            "$srcdir"/bin/debian-chroot \
+            "$pkgdir"/opt/bin/debian-chroot
+        install -D -m 655 \
+            "$srcdir"/debian-chroot.conf \
+            "$pkgdir"/home/root/.config/debian-chroot.conf
+        mkdir -p "$pkgdir"/opt/etc/
+        ln -s /home/root/.config/debian-chroot.conf \
+            "$pkgdir"/opt/etc/debian-chroot.conf
+        source "$srcdir"/debian-chroot.conf
+        mkdir -p "$pkgdir"/opt/lib/
+        ln -s "$chroot_path" "$pkgdir"/opt/lib/debian-chroot
+    }
+    configure() {
+        # Force debian chroot to install iteself
+        debian-chroot true
+    }
+    preremove() {
+        source /home/root/.config/debian-chroot.conf
+        if lsof "$chroot_path" 2> /dev/null | grep "$chroot_path"; then
+            echo "Error: debian-chroot has running processes"
+            exit 1
+        fi
+        if grep -q "$chroot_path " /proc/mounts; then
+            /bin/umount -R "$chroot_path"
+        fi
+        cp /home/root/.config/debian-chroot.conf /tmp/_debian-chroot.conf
+    }
+    postremove() {
+        source /tmp/_debian-chroot.conf
+        rm -rf "$chroot_path"
+        rm /tmp/_debian-chroot.conf
+    }
+}
+
+debootstrap() {
+    pkgdesc="debootstrap is a tool which will install a Debian base system into a subdirectory of another, already installed system."
+    installdepends=(perl ar)
+    url=https://wiki.debian.org/Debootstrap
+    pkgver=1.0.133-1
+    timestamp=2023-10-21T11:38Z
+    license=MIT
+    package() {
+        cd "$srcdir"
+        sed -i 's|/usr/sbin|/sbin|' Makefile
+        make DESTDIR="$pkgdir"/opt install
+        sed -i 's|DEBOOTSTRAP_DIR=/usr/share/debootstrap|DEBOOTSTRAP_DIR=/opt/usr/share/debootstrap|' "$pkgdir"/opt/sbin/debootstrap
+    }
+}

--- a/package/keyd/default.conf
+++ b/package/keyd/default.conf
@@ -1,0 +1,4 @@
+[ids]
+# 2edd:0001 # type folio
+
+[main]

--- a/package/keyd/package
+++ b/package/keyd/package
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+archs=(rmallos3)
+pkgnames=(keyd)
+pkgdesc="A key remapping daemon for linux"
+url="https://github.com/rvaiya/keyd"
+pkgver=2.4.3-1
+timestamp=2023-05-16T10:11Z
+section=utils
+maintainer="Kai <z@kwi.li>"
+license=MIT
+
+image=base:v3.1
+source=(
+    https://github.com/rvaiya/keyd/archive/refs/tags/v2.4.3.zip
+    default.conf
+)
+sha256sums=(
+    cdfcc2cf0518b9a2d292ebac17b18f78548b92803e2a9deeb9f18c9641bf80e5
+    SKIP
+)
+
+build() {
+    make PREFIX=/opt CONFIG_DIR=/opt/etc/keyd "CC=${CROSS_COMPILE}cc"
+    sed -i 's|ExecStart=/usr/bin/keyd|ExecStart=/opt/bin/keyd|' keyd.service
+}
+
+package() {
+    cd "$srcdir"
+    make PREFIX=/opt CONFIG_DIR=/opt/etc/keyd DESTDIR="$pkgdir" install
+    rmdir "$pkgdir"/etc/keyd
+    install -D -m 644 -t "$pkgdir"/etc/systemd/system "$srcdir"/keyd.service
+    install -D -m 644 -t "$pkgdir"/opt/etc/keyd "$srcdir"/default.conf
+}
+
+configure() {
+    addgroup keyd
+    systemctl daemon-reload
+    if is-active keyd; then
+        systemctl restart keyd
+    elif ! is-enabled "$pkgname.service"; then
+        echo ""
+        echo "Run the following command(s) to enable the keyd service"
+        how-to-enable "$pkgname.service"
+        echo ""
+        echo "You will need to modify /opt/etc/keyd/default.conf before starting the service"
+    fi
+}
+
+preremove() {
+    disable-unit keyd
+    delgroup keyd
+}
+
+postremove() {
+    systemctl daemon-reload
+}

--- a/package/koreader/package
+++ b/package/koreader/package
@@ -5,8 +5,8 @@
 pkgnames=(koreader)
 pkgdesc="Ebook reader supporting PDF, DjVu, EPUB, FB2 and many more formats"
 url=https://github.com/koreader/koreader
-pkgver=2024.07-1
-timestamp=2024-07-15T16:21:26Z
+pkgver=2024.11-1
+timestamp=2024-11-20T19:52:06Z
 section="readers"
 maintainer="raisjn <of.raisjn@gmail.com>"
 license=AGPL-3.0-or-later
@@ -22,7 +22,7 @@ source=(
     launcherctl-koreader
 )
 sha256sums=(
-    1040894434421b52076473f7947f139e2c98fcc04b1acadfe29b3362f262f9b7
+    2b97146e38bdfeec483773e01738cd6109fadc06312b41a16328e33ad3eceae5
     SKIP
     SKIP
     SKIP

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -5,7 +5,7 @@
 archs=(rm1 rm2)
 pkgnames=(oxide oxide-extra oxide-utils inject_evdev liboxide liboxide-dev libsentry)
 _oxidever=2.8.4
-pkgver=$_oxidever-2
+pkgver=$_oxidever-3
 _sentryver=0.7.6
 timestamp=2024-06-26T22:31:46Z
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -35,7 +35,7 @@ build() {
 oxide() {
     pkgdesc="Launcher application"
     section="launchers"
-    installdepends=("oxide-utils=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver" reboot-guard jq display launcherctl)
+    installdepends=("oxide-utils=$pkgver" "liboxide=$pkgver" "libsentry=$_sentryver" reboot-guard jq display launcherctl sysfs_preload)
     replaces=(erode tarnish decay corrupt)
     conflicts=(erode tarnish decay corrupt)
 

--- a/package/sysfs_preload/package
+++ b/package/sysfs_preload/package
@@ -5,15 +5,15 @@
 pkgnames=(sysfs_preload)
 pkgdesc="A simple preload that forces any calls to /sys/power/state to use systemd instead."
 url="https://github.com/Eeems-Org/sysfs_preload"
-pkgver=1.0.1-2
-timestamp=2024-06-22T05:19Z
+pkgver=1.0.3-1
+timestamp=2024-10-11T04:33:10Z
 section=utils
 maintainer="Eeems <eeems@eeems.email>"
 license=MIT
 
 image=qt:v3.1
-source=(https://github.com/Eeems-Org/sysfs_preload/archive/refs/tags/1.0.1.tar.gz)
-sha256sums=(73627b68e3b2454efcc2d83e6ebdc2eb473f9cc2616ed1b9dd2acae159c54b3d)
+source=(https://github.com/Eeems-Org/sysfs_preload/archive/refs/tags/1.0.3.tar.gz)
+sha256sums=(06a4c356e583614880c24afc2205caa3db445e3e6bd4414091545540d841a095)
 
 build() {
     find . -name "*.pro" -type f -print0 \

--- a/package/zerotier-one/package
+++ b/package/zerotier-one/package
@@ -4,16 +4,16 @@
 
 pkgnames=(zerotier zerotier-one zerotier-one-doc zerotier-selftest)
 url=https://github.com/zerotier/ZeroTierOne
-_upver=1.14.1
+_upver=1.14.2
 pkgver=${_upver}-1
-timestamp=2023-03-23T17:39:31Z
+timestamp=2024-10-29T16:17:48Z
 maintainer="Eeems <eeems@eeems.email>"
 license=BUSL-1.1
 section="utils"
 image=base:v3.0
 
 source=("https://github.com/zerotier/ZeroTierOne/archive/refs/tags/${_upver}.zip")
-sha256sums=(fcf30ce797dbca757f3e882e004a3f953ebe12ae13f03d804b3fb184ee3c9714)
+sha256sums=(529dd6d246f51ca7cb0b14794ba68560c0134409f94fcc61a3ee7f5c173c301f)
 
 build() {
     sed -i \

--- a/scripts/bootstrap/bootstrap
+++ b/scripts/bootstrap/bootstrap
@@ -20,6 +20,20 @@ if [ -z "$BASH" ] || [[ "$(ps | awk '$1=='$$' { n=split($5,a,"/"); print a[n] }'
     exit 1
 fi
 
+arch=""
+case "$(uname -m)" in
+    "armv7l")
+        arch="armv7sf-k3.2"
+        ;;
+    #"aarch64)
+    #    arch="aarch64-k3.10"
+    #    ;;
+    *)
+        echo "Unsupported device architecture"
+        exit 1
+        ;;
+esac
+
 set -eEuo pipefail
 
 # Path to the temporary local wget and Opkg binaries
@@ -33,7 +47,7 @@ toltecctl_path="${toltecctl_path:-/home/root/.local/bin/toltecctl}"
 toltec_branch="${toltec_branch:-stable}"
 
 # Base URLs for bootstrapping from the Entware and Toltec repositories
-entware_remote="${entware_remote:-https://bin.entware.net/armv7sf-k3.2/installer}"
+entware_remote="${entware_remote:-https://bin.entware.net/$arch/installer}"
 toltec_remote="${toltec_remote:-https://toltec-dev.org/$toltec_branch/rmall}"
 
 # Remove all temporary files


### PR DESCRIPTION
### New Packages
- `debian-chroot` - 0.0.0-1 (#799)
- `debootstrap` - 1.0.133-1 (#799)
- `keyd` - 2.4.3-1 (#744)

### Updated Packages
- `koreader` - 2024.11-1 (#930)
- `sysfs_preload` 1.0.3-1 (#936)
- `zerotier` - 1:1.14.2 (#928)
- `zerotier-one`, `zerotier-one-doc`, and `zerotier-selftest` - 1.14.2 (#928)
- `oxide`, `oxide-extra`, `oxide-utils`, `inject_evdev`, `liboxide`, and `liboxide-dev` - 2.8.4-2 (#938)

### Tooling
- Bootstrap now properly detects and errors if run on an unsupported architecture (#933)