### PR TITLE
Add package for rmstylusbutton

### DIFF
--- a/package/rmstylusbutton/package
+++ b/package/rmstylusbutton/package
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+archs=(rm2)
+pkgnames=(rmstylusbutton)
+_pkgver=3.0
+pkgver=$_pkgver-1
+pkgdesc="Use a stylus button with the reMarkable 2"
+timestamp=2024-03-04T04:30:52Z
+maintainer="Moritz <github@moritzboeh.me>"
+license=GPL-3.0
+url=https://github.com/rschroll/RMStylusButton
+section="utils"
+installdepends=(xochitl)
+conflicts=(remarkable-stylus)
+
+image=base:v3.2
+source=(
+    "$url/archive/refs/tags/v$_pkgver.tar.gz"
+    rmstylusbutton.service
+)
+sha256sums=(
+    5f468b9f78b705ca67ea3288ae923b10fb70193c236b31507a4e6148ebb4e60e
+    SKIP
+)
+
+build() {
+    export CC=arm-linux-gnueabihf-gcc
+    make
+}
+
+package() {
+    install -D -m 755 -t "$pkgdir"/opt/bin "$srcdir"/RMStylusButton/RMStylusButton
+    install -D -m 644 -t "$pkgdir"/lib/systemd/system/ "$srcdir"/rmstylusbutton.service
+}
+
+configure() {
+    systemctl daemon-reload
+    systemctl enable --now rmstylusbutton.service
+}
+
+preremove() {
+    disable-unit rmstylusbutton.service
+}
+
+postremove() {
+    systemctl daemon-reload
+}

--- a/package/rmstylusbutton/rmstylusbutton.service
+++ b/package/rmstylusbutton/rmstylusbutton.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Stylus Button Input
+After=xochitl.service
+
+[Service]
+ExecStart=/opt/bin/RMStylusButton
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
<!--

Thank you for your interest in contributing to Toltec! Before submitting your
pull request, please take a moment to read our contributing guidelines at
<https://github.com/toltec-dev/toltec/blob/stable/docs/contributing.md>

Most importantly, make sure to base your pull request on the **testing**
branch (which is not the default branch). Pull requests to the stable
branch cannot be accepted.

If you’re proposing a new package please give us some details on:

* What the package does
* Whether you're the author of it
* If the package was developed/tested for a specific reMarkable model

If you’re updating an existing package, please give information on where the
changelog can be found.

A maintainer will reply to you shortly to get the package ready for testing.
As soon as the package file looks good and it was successfully tested on both
devices, we can add it! 🎊🎉🎊

-->
I am adding the package [RMStylusButton](https://github.com/rschroll/RMStylusButton).
It's a fork of the unmaintained [RemarkableLamyEraser](https://github.com/isaacwisdom/RemarkableLamyEraser).

With the package, one can:
- switch to the eraser by holding down the button of the stylus
- double click to undo
- triple click to redo

The upstream project uses a [custom script for managing the installation](https://github.com/rschroll/RMStylusButton/blob/main/RMStylusButton/manage.sh) which I used as a basis for the package scripts.
Currently, one cannot pass flags, but I plan to add this as well. Maybe using an env file which has a variable FLAGS which is then loaded via the service file.