### PR TITLE
Add Rempack

### DIFF
--- a/package/rempack/package
+++ b/package/rempack/package
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright (c) 2020 The Toltec Contributors
+# SPDX-License-Identifier: MIT
+
+pkgnames=(rempack)
+pkgdesc="A user friendly package manager frontend for opkg"
+archs=(rm2)
+url="https://github.com/rempack-b/rempack"
+pkgver=1.0.5
+timestamp=2025-02-24T04:41:34-05:00
+section=admin
+maintainer="Brant Martin <toltec@brantmartin.com>"
+license=MIT
+image=base:v3.1
+installdepends=(display)
+source=(
+    http://gitlab.onionstorm.net/rolenthedeep/rempack/-/archive/1.0.5/rempack-1.0.5.zip
+)
+sha256sums=(
+    754c34ad4b4e5e208da4e27f3c7b9c7a33fdf6617263aa22a67e31e82a22dffe
+)
+build() {
+    cd $srcdir
+    mkdir output
+    cmake -S . -B output --preset "Release Native"
+    cmake --build output --target rempack
+}
+
+package() {
+    ## Commands to copy the build artifacts into a package structure
+    # Use the `install` command when possible
+    # (see `man install` or <https://linux.die.net/man/1/install>)
+
+    # The following variables are available:
+    # "$srcdir" - The directory where build() was run
+    # "$pkgdir" - The final folder containing the root where your files should go
+
+    # Examples:
+    # Add a single config file or non-executable resource
+    # install -D -m 644 "$srcdir"/default_config "$pkgdir"/opt/etc/your_package.conf
+    #
+    # Add a empty directory
+    # install -d "$pkgdir"/opt/etc/draft/icons
+    #
+    # Add a executable (binary/script)
+    # install -D -m 755 "$srcdir"/build/programname "$pkgdir"/opt/bin/programname    
+    install -D -m 755 "$srcdir"/output/rempack "$pkgdir"/opt/bin/rempack
+    #touch ~/rempack
+}

--- a/package/rempack/package
+++ b/package/rempack/package
@@ -6,7 +6,7 @@ pkgnames=(rempack)
 pkgdesc="A user friendly package manager frontend for opkg"
 archs=(rm2)
 url="https://github.com/rempack-b/rempack"
-pkgver=1.1.2
+pkgver=1.1.3
 timestamp=2025-03-01T04:26:09-05:00
 section=admin
 maintainer="Brant Martin <toltec@brantmartin.com>"
@@ -14,7 +14,7 @@ license=MIT
 image=base:v3.1
 installdepends=(display)
 source=(
-    http://gitlab.onionstorm.net/rolenthedeep/rempack/-/archive/1.1.2/rempack-1.1.2.zip
+    http://gitlab.onionstorm.net/rolenthedeep/rempack/-/archive/1.1.3/rempack-1.1.3.zip
     rempack.draft
     rempack.oxide
 )

--- a/package/rempack/package
+++ b/package/rempack/package
@@ -6,18 +6,22 @@ pkgnames=(rempack)
 pkgdesc="A user friendly package manager frontend for opkg"
 archs=(rm2)
 url="https://github.com/rempack-b/rempack"
-pkgver=1.0.5
-timestamp=2025-02-24T04:41:34-05:00
+pkgver=1.1.2
+timestamp=2025-03-01T04:26:09-05:00
 section=admin
 maintainer="Brant Martin <toltec@brantmartin.com>"
 license=MIT
 image=base:v3.1
 installdepends=(display)
 source=(
-    http://gitlab.onionstorm.net/rolenthedeep/rempack/-/archive/1.0.5/rempack-1.0.5.zip
+    http://gitlab.onionstorm.net/rolenthedeep/rempack/-/archive/1.1.2/rempack-1.1.2.zip
+    rempack.draft
+    rempack.oxide
 )
 sha256sums=(
-    754c34ad4b4e5e208da4e27f3c7b9c7a33fdf6617263aa22a67e31e82a22dffe
+    SKIP
+    SKIP
+    SKIP
 )
 build() {
     cd $srcdir
@@ -26,24 +30,8 @@ build() {
     cmake --build output --target rempack
 }
 
-package() {
-    ## Commands to copy the build artifacts into a package structure
-    # Use the `install` command when possible
-    # (see `man install` or <https://linux.die.net/man/1/install>)
-
-    # The following variables are available:
-    # "$srcdir" - The directory where build() was run
-    # "$pkgdir" - The final folder containing the root where your files should go
-
-    # Examples:
-    # Add a single config file or non-executable resource
-    # install -D -m 644 "$srcdir"/default_config "$pkgdir"/opt/etc/your_package.conf
-    #
-    # Add a empty directory
-    # install -d "$pkgdir"/opt/etc/draft/icons
-    #
-    # Add a executable (binary/script)
-    # install -D -m 755 "$srcdir"/build/programname "$pkgdir"/opt/bin/programname    
+package() {    
     install -D -m 755 "$srcdir"/output/rempack "$pkgdir"/opt/bin/rempack
-    #touch ~/rempack
+    install -D -m 644 "$srcdir"/rempack.draft "$pkgdir"/opt/etc/draft/rempack.draft
+    install -D -m 644 "$srcdir"/rempack.oxide "$pkgdir"/opt/usr/share/applications/rempack.oxide
 }

--- a/package/rempack/package
+++ b/package/rempack/package
@@ -30,7 +30,7 @@ build() {
     cmake --build output --target rempack
 }
 
-package() {    
+package() {
     install -D -m 755 "$srcdir"/output/rempack "$pkgdir"/opt/bin/rempack
     install -D -m 644 "$srcdir"/rempack.draft "$pkgdir"/opt/etc/draft/rempack.draft
     install -D -m 644 "$srcdir"/rempack.oxide "$pkgdir"/opt/usr/share/applications/rempack.oxide

--- a/package/rempack/package
+++ b/package/rempack/package
@@ -6,20 +6,20 @@ pkgnames=(rempack)
 pkgdesc="A user friendly package manager frontend for opkg"
 archs=(rmall)
 url="https://github.com/rexxar-tc/rempack"
-pkgver=1.1.3
-timestamp=2025-03-01T04:26:09-05:00
+pkgver=1.1.4
+timestamp=2025-03-09T21:13:27
 section=admin
 maintainer="Brant Martin <toltec@brantmartin.com>"
 license=MIT
 image=base:v3.1
 installdepends=(display)
 source=(
-    http://gitlab.onionstorm.net/rolenthedeep/rempack/-/archive/1.1.3/rempack-1.1.3.zip
+    https://github.com/rexxar-tc/rempack/archive/refs/tags/1.1.4.zip
     rempack.draft
     rempack.oxide
 )
 sha256sums=(
-    2a82d3d8f9db9d0d8a784c8560c582f5e7513e293be1c07fdd86352f3d3b3edc
+    b8d8c1f75269f9091b39e1e20afbcdc6e4c1f12d811682f36b759aa4f9955696
     SKIP
     SKIP
 )

--- a/package/rempack/package
+++ b/package/rempack/package
@@ -5,7 +5,7 @@
 pkgnames=(rempack)
 pkgdesc="A user friendly package manager frontend for opkg"
 archs=(rm2)
-url="https://github.com/rempack-b/rempack"
+url="https://github.com/rexxar-tc/rempack"
 pkgver=1.1.3
 timestamp=2025-03-01T04:26:09-05:00
 section=admin

--- a/package/rempack/package
+++ b/package/rempack/package
@@ -4,7 +4,7 @@
 
 pkgnames=(rempack)
 pkgdesc="A user friendly package manager frontend for opkg"
-archs=(rm2)
+archs=(rmall)
 url="https://github.com/rexxar-tc/rempack"
 pkgver=1.1.3
 timestamp=2025-03-01T04:26:09-05:00
@@ -19,7 +19,7 @@ source=(
     rempack.oxide
 )
 sha256sums=(
-    SKIP
+    2a82d3d8f9db9d0d8a784c8560c582f5e7513e293be1c07fdd86352f3d3b3edc
     SKIP
     SKIP
 )

--- a/package/rempack/rempack.draft
+++ b/package/rempack/rempack.draft
@@ -1,0 +1,4 @@
+name=rempack
+desc=User firendly package manager
+call=/opt/bin/rempack
+term=killall rempack

--- a/package/rempack/rempack.oxide
+++ b/package/rempack/rempack.oxide
@@ -1,0 +1,7 @@
+{
+  "displayName": "rempack",
+  "description": "A friendly package manager",
+  "bin": "/opt/bin/rempack",
+  "type": "foreground",
+  "permissions": ["permissions", "apps", "system"]
+}


### PR DESCRIPTION
Rempack is an opkg frontend for the RM2 and similar.

It was developed on and tested with an RM2, but I expect it runs fine on any device with a similar screen size.

This is the first release stable enough for public testing.