### PR TITLE
Change Oxide sentry endpoint

### DIFF
--- a/package/oxide/package
+++ b/package/oxide/package
@@ -12,7 +12,7 @@ maintainer="Eeems <eeems@eeems.email>"
 url=https://oxide.eeems.codes
 license=MIT
 flags=(patch_rm2fb)
-image=qt:v3.1
+image=qt:v3.2
 source=(
     "https://github.com/Eeems-Org/oxide/archive/refs/tags/v$_oxidever.zip"
     toltec-rm2-override.conf

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -12,7 +12,7 @@ maintainer="Eeems <eeems@eeems.email>"
 url=https://oxide.eeems.codes
 license=MIT
 flags=(patch_rm2fb)
-image=qt:v3.2
+image=qt:v3.3
 source=(
     "https://github.com/Eeems-Org/oxide/archive/refs/tags/v$_oxidever.zip"
     toltec-rm2-override.conf

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -5,7 +5,7 @@
 archs=(rm1 rm2)
 pkgnames=(oxide oxide-extra oxide-utils inject_evdev liboxide liboxide-dev libsentry)
 _oxidever=2.8.4
-pkgver=$_oxidever-3
+pkgver=$_oxidever-4
 _sentryver=0.7.6
 timestamp=2024-06-26T22:31:46Z
 maintainer="Eeems <eeems@eeems.email>"

--- a/package/oxide/package
+++ b/package/oxide/package
@@ -29,6 +29,8 @@ build() {
         | xargs -r -0 sed -i 's/linux-oe-g++/linux-arm-remarkable-g++/g'
     find . -name "*.pri" -type f -print0 \
         | xargs -r -0 sed -i 's/linux-oe-g++/linux-arm-remarkable-g++/g'
+    sed -i 's|https://a0136a12d63048c5a353c4a1c2d38914@sentry.eeems.codes/2|https://001cfae777374b0a8ffaf8a1e66c85b3@glitchtip.eeems.codes/1|g' \
+        shared/liboxide/oxide_sentry.cpp
     CMAKE_TOOLCHAIN_FILE="/usr/share/cmake/$CHOST.cmake" make FEATURES=sentry release
 }
 


### PR DESCRIPTION
Update Sentry URL in oxide_sentry.cpp for GlitchTip.

I'm migrating away from sentry due to how resource hungry it is to self-host.